### PR TITLE
docs: establish repo charter (README, architecture, non-goals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,115 +1,119 @@
 # xai-dissect
 
-Standalone Rust CLI for inspecting raw JAX / Pickle shards of the Grok-1 open
-weights. Uses `memmap2` for zero-copy file reads and a targeted byte scanner
-over the Pickle Protocol 4 grammar - no real unpickler, no ML framework, no
-allocation of tensor bodies.
+Static structural analysis of the Grok family of open-weight checkpoints.
 
-## What it reports
+`xai-dissect` parses raw xAI weight shards (Pickle Protocol 4 / JAX dumps),
+builds a tensor inventory, and emits architecture, expert, and routing
+reports. It is a read-only structural tool: it never loads tensor bodies,
+never runs the model, and never produces inference output.
 
-For every ndarray located inside a `tensor*` shard the tool prints:
+Current target:
 
-| Column | Meaning |
-| ------ | ------- |
-| `Idx` | Per-file index (0-based, in byte order) |
-| `Role` | `tensor`, `quant.weight`, or `quant.scales` |
-| `Dtype` | `f32` or `int8` |
-| `Shape` | Numpy-style shape tuple |
-| `Offset` | Absolute byte offset of the raw payload within the shard |
-| `Nbytes` | Payload length in bytes (verified against dtype * prod(shape)) |
+- **Grok-1** (xAI official release, Apache-2.0 weights). First-class, actively
+  developed.
+- **Grok-2** (if/when public weights are released under a compatible license).
+  Not supported yet. Scoped as a deliberate follow-on, not a promise.
 
-`QuantizedWeight8bit` dataclasses (int8 weight + f32 scales) are detected and
-their two inner ndarrays are labeled `quant.weight` / `quant.scales`.
+Only open/public weights are in scope. This repo is for lawful analysis of
+weights you already have legitimate access to. No weights are redistributed
+here.
 
-## Usage
+## What this repo owns
+
+- Parsing xAI Pickle/JAX shard files without a Python unpickler.
+- A normalized tensor schema (dtype, shape, role, offsets, shard provenance).
+- A full tensor inventory across a checkpoint directory.
+- Architecture reports: layer count, embedding shapes, attention/MoE shape
+  families, norm placement, head/vocab geometry.
+- Expert analysis: per-layer expert count, expert-projection shapes
+  (up / gate / down), quantization layout (`int8` weight + `f32` scales).
+- Routing analysis: router/gate tensor identification, shape consistency
+  across layers, top-k inference from shape alone where possible.
+- Summary statistics: parameter counts (raw / effective / per-expert),
+  quantized vs. unquantized byte budgets, shard-size histograms.
+- Exportable findings: stable, machine-readable artifacts (JSON / CSV /
+  Markdown tables) suitable for downstream consumers.
+
+## What this repo does NOT own
+
+- A full inference runtime. No forward pass, no sampler, no decode loop.
+- Projector logic (neuromorphic or otherwise).
+- SAAQ latent calibration, SAAQ scoring, or any latent-space experiments.
+- GPU kernels, CUDA/Metal/ROCm code, or perf tuning of matmul paths.
+- Symbolic regression over weights or activations.
+- Plot-heavy / dashboard-heavy interactive analysis.
+- Orchestration, hybrid runtime glue, or multi-repo scheduling.
+- Dequantization, format conversion, or emission of runnable checkpoints.
+- Redistribution of model weights.
+
+Anything in that list belongs in a sibling repo (see below) or is explicitly
+out of scope.
+
+## Relationship to sibling repos
+
+### corinth-canal
+`corinth-canal` owns orchestration and hybrid-runtime glue: it wires models,
+projectors, and downstream consumers together. `xai-dissect` is strictly
+upstream of that: it produces structural descriptions of a frozen
+checkpoint. If `corinth-canal` needs "what is the shape of expert 3's
+down-projection in layer 17", it consumes an `xai-dissect` export. It does
+not call into this repo at runtime.
+
+### snn-projector
+`snn-projector` owns projector logic, including any spiking / neuromorphic
+projection of activations. `xai-dissect` does not implement, test, or depend
+on projector math. It may describe the *shape* of tensors that a projector
+would later consume (e.g. embedding width, expert output dimension), but it
+never projects anything itself.
+
+### SAAQ-latent
+`SAAQ-latent` owns SAAQ latent calibration and latent-space analysis.
+`xai-dissect` does not compute SAAQ scores, does not calibrate latents, and
+does not load tensor values into memory. The boundary is sharp: `xai-dissect`
+stops at "this tensor lives at this offset with this shape and dtype"; any
+interpretation of its numerical contents belongs in `SAAQ-latent`.
+
+### Surrogate_Viz.jl
+`Surrogate_Viz.jl` owns visualization and dashboarding. `xai-dissect` emits
+structured, exportable findings (JSON / CSV / Markdown). It does not render
+plots, does not ship a UI, and does not embed a plotting stack.
+`Surrogate_Viz.jl` is a downstream consumer of `xai-dissect` exports.
+
+## Usage (current)
 
 ```bash
 cargo build --release
 
-# Sweep an entire checkpoint directory.
+# Inventory an entire checkpoint directory.
 ./target/release/xai-dissect /path/to/grok-1/ckpt-0
 
-# Peek at just the first shard while iterating on the parser.
+# Peek at a single shard.
 ./target/release/xai-dissect /path/to/grok-1/ckpt-0 --limit 1
 
-# Non-default filename prefix.
+# Non-default shard filename prefix.
 ./target/release/xai-dissect /path/to/dump --prefix shard_
 ```
 
-## Parsing strategy (summary)
+The CLI memory-maps each shard, validates the PROTO 4 header, scans the
+pickle byte grammar for ndarray anchors, and prints one row per tensor:
+`Idx | Role | Dtype | Shape | Offset | Nbytes`. `QuantizedWeight8bit`
+dataclasses are split into `quant.weight` (`int8`) and `quant.scales`
+(`f32`) rows. No tensor bodies are read.
 
-1. Memory-map each shard file; never copy payload bytes.
-2. Validate the leading `\x80\x04` PROTO 4 magic.
-3. Locate every `\x8c\x02f4` / `\x8c\x02i1` short_binunicode whose forward
-   post-amble matches numpy's `dtype(str, False, True)` reduce shape:
-   `[\x94?] \x89 \x88 \x87`. This anchors one ndarray per hit and works even
-   when CPython's pickler elides individual `\x94` MEMOIZE opcodes.
-4. Walk backward through the variable-length "dtype class push" (full
-   `STACK_GLOBAL` form or a `BINGET` / `LONG_BINGET` memo re-fetch) to find the
-   shape tuple terminator (`\x85` / `\x86` / `\x87` / `)` / `t`) and decode the
-   shape ints.
-5. Walk forward looking for `[\x88|\x89]` (fortran-order bool) immediately
-   followed by a bytes-payload opcode (`C`, `B`, or `\x8e`); read the payload
-   length and record the absolute offset.
-6. Mark any `__main__.QuantizedWeight8bit` class reference sites and label the
-   adjacent int8/f32 pair as `quant.weight` / `quant.scales`.
+See `docs/architecture.md` for the intended layer breakdown and
+`docs/non_goals.md` for the full non-goals list.
 
-## Observed: Grok-1 `ckpt-0` (xAI official release)
+## Legal / ethical scope
 
-Before running the tool, a simple `find -printf '%s\n' | sort | uniq -c` over
-`ckpt-0/` gives a clean histogram of the 770 shards (~297 GiB total). Because
-every ndarray payload inside a shard is stored verbatim (pickle adds only
-~150-400 bytes of framing), the file size alone already tells you roughly
-what's inside.
-
-| Count | Size (bytes)   | Size (human) | Likely contents |
-| ----: | -------------: | ------------ | --------------- |
-|     1 |  3,221,225,637 | 3.0 GiB      | `tensor00000_000` - token embedding `(131072, 6144) f32`. Payload = 131072 x 6144 x 4 = 3,221,225,472 B; the extra ~165 B is pickle framing. |
-|   128 |  1,611,137,347 | 1.5 GiB      | MoE / attention `QuantizedWeight8bit` shards, variant A. Int8 body is 8 x 6144 x 32768 = 1,610,612,736 B; remaining ~524 KB holds the f32 scales + pickle framing. |
-|    64 |  1,611,399,491 | 1.5 GiB      | Same class as variant A but exactly 262,144 B (= 65,536 f32) larger - consistent with a differently-shaped `scales` array on one of the three expert projections (up / gate / down). |
-|    64 |     37,847,359 | 36 MiB       | f32 tensor sized ~9.46M elements; compatible with a `(vocab_size, ?)` router / head slice or an attention-projection f32 companion, 1 per layer. |
-|    64 |     37,761,334 | 36 MiB       | Sibling shape to the row above, 1 per layer. |
-|   128 |      6,293,814 | 6.0 MiB      | f32 scales for the large quantized expert shards, 2 per layer. |
-|    64 |        196,770 | 192 KiB      | Small f32 tensor, 1 per layer - likely attention norm / bias. |
-|   257 |         24,727 | 24 KiB       | f32 vector of 6144 elements (6144 x 4 = 24,576 B + pickle framing) - per-layer RMSNorms / residual norms. |
-
-Totals cross-check: 1 + 128 + 64 + 64 + 64 + 128 + 64 + 257 = 770 shards.
-
-Interpretation at a glance:
-
-- Grok-1 is a 64-layer MoE with 8 experts; the counts align: most buckets are
-  multiples of 64 (per-layer) and the two 1.5 GiB buckets together sum to
-  3 x 64 = 192 shards, matching 3 MoE projections (up / gate / down) per layer.
-- The 257 x 24 KiB count = 64 x 4 + 1 extra; the "+1" is the final pre-head
-  norm and 4x per-layer matches attention-q-norm, attention-k-norm, pre-mlp
-  norm, and post-mlp norm.
-- Every 1.5 GiB shard is a `QuantizedWeight8bit` dataclass (int8 weight +
-  f32 scales), so the tool will emit two rows per shard (`quant.weight`
-  and `quant.scales`). The plain f32 shards emit a single `tensor` row.
-
-### Dissecting a single shard
-
-To see exact shapes and byte offsets without pulling weights into RAM:
-
-```bash
-./target/release/xai-dissect /path/to/grok-1-official/ckpt-0 --limit 1
-```
-
-This opens only `tensor00000_000`, memory-maps it, and prints the token
-embedding's dtype, shape, payload offset, and `Nbytes`. Drop `--limit` to
-sweep all 770 shards; the tool does not allocate tensor bodies, so the whole
-scan is I/O-bound (a few seconds on NVMe even at 297 GiB).
-
-## Non-goals
-
-- Full Pickle deserialization.
-- Decoding tensor values, dequantization, or file conversion.
-- Dtypes beyond `float32` and `int8` (the only ones present in raw Grok-1).
+- Analyze only weights you have lawful access to under their original
+  license (Grok-1: Apache-2.0, distributed by xAI).
+- This repository does not contain, mirror, or redistribute model weights.
+- This repository does not ship circumvention tooling; it reads files the
+  operator already possesses.
 
 ## License
 
 GPL-3.0-only. See [LICENSE](LICENSE).
 
-The Grok-1 model weights themselves are distributed by xAI under
-Apache-2.0 and are NOT included in or redistributed by this repository;
-this tool only reads them out-of-band.
+Grok model weights are the property of their respective rights holders and
+are not covered by this repository's license.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,149 @@
+# Architecture
+
+`xai-dissect` is organized as a pipeline of thin, composable layers. Each
+layer has one job, consumes only the layer below it, and is individually
+testable against a single shard or a full checkpoint directory.
+
+```
+  raw shard bytes
+        |
+        v
+  [ parser ]        -> pickle-grammar byte scan, no unpickler
+        |
+        v
+  [ schema ]        -> normalized tensor records
+        |
+        v
+  [ inventory ]     -> per-checkpoint tensor table
+        |
+        +--> [ expert analysis ]   -> MoE expert geometry
+        +--> [ routing analysis ]  -> router / gate geometry
+        +--> [ stats ]             -> parameter & byte accounting
+        |
+        v
+  [ reports / exports ]  -> JSON, CSV, Markdown
+```
+
+## Layers
+
+### 1. parser
+Memory-maps each shard, validates the `\x80\x04` PROTO 4 magic, and walks
+the pickle byte grammar to locate every `numpy.ndarray` reduce site. Emits
+raw `TensorAnchor` records: shard path, byte offset, payload length, dtype
+token, shape tuple, and any enclosing `QuantizedWeight8bit` marker. Never
+decodes tensor bodies. Never depends on a Python interpreter.
+
+### 2. schema
+Normalizes `TensorAnchor` records into a stable `TensorRecord`:
+
+- `shard_path`, `shard_index`
+- `role` (`tensor` | `quant.weight` | `quant.scales`)
+- `dtype` (`f32` | `int8`, extensible)
+- `shape` (`Vec<u64>`)
+- `offset`, `nbytes`
+- optional `group_id` linking paired quant weight + scales
+
+This is the canonical on-disk / on-wire record format for every other layer
+and every export.
+
+### 3. inventory
+Aggregates `TensorRecord`s across a checkpoint directory into a single
+queryable table. Responsibilities:
+
+- dedup and order shards deterministically
+- verify `nbytes == dtype_size * prod(shape)`
+- build indices by shard, by role, and by shape family
+- detect missing/extra shards vs. an expected count
+
+The inventory is the single source of truth consumed by every downstream
+analyzer.
+
+### 4. expert analysis
+Identifies Mixture-of-Experts structure from inventory records alone:
+
+- per-layer expert count (inferred from leading shape dimension of expert
+  projections, e.g. `(8, 6144, 32768)` -> 8 experts)
+- up / gate / down projection families and their quantization layout
+- expert-local parameter counts (raw, quantized, effective)
+- consistency checks across layers (same expert count, same inner dims)
+
+Shape-only. No activation, no routing decision, no runtime execution.
+
+### 5. routing analysis
+Identifies router / gate tensors and per-layer routing geometry:
+
+- locate router weight tensors by shape signature `(d_model, n_experts)`
+  or equivalent
+- cross-check against expert count from (4)
+- report top-k structure where it can be inferred from shapes
+- flag layers whose router shape disagrees with sibling layers
+
+Explicitly does not execute routing, does not rank experts, and does not
+touch activation data.
+
+### 6. stats
+Summary accounting over the inventory:
+
+- total parameters (raw, effective after dequant accounting)
+- bytes on disk, bytes after notional dequant
+- shard-size histogram (the "6 MiB / 36 MiB / 1.5 GiB / 3 GiB" story for
+  Grok-1)
+- per-layer and per-role breakdowns
+
+Pure arithmetic over inventory records; no I/O beyond what inventory
+already did.
+
+### 7. reports / exports
+Emits stable, machine-readable artifacts:
+
+- `inventory.json` - full `TensorRecord` array
+- `architecture.md` - human-readable summary (layer count, d_model,
+  n_experts, head geometry, norm placement)
+- `experts.json` / `routing.json` - structured findings from (4) and (5)
+- `stats.csv` - parameter and byte accounting
+
+Exports are the only supported integration surface for downstream repos
+(`corinth-canal`, `SAAQ-latent`, `Surrogate_Viz.jl`). No in-process API is
+guaranteed across versions; the export schema is.
+
+## Minimal initial file tree (proposed)
+
+```
+xai-dissect/
+  Cargo.toml
+  README.md
+  LICENSE
+  src/
+    main.rs                  # CLI entry (today's binary, preserved)
+    lib.rs                   # re-exports for the layers below
+    parser/
+      mod.rs
+      pickle_scan.rs         # PROTO 4 byte-grammar scanner
+      quantized.rs           # QuantizedWeight8bit anchor pairing
+    schema/
+      mod.rs                 # TensorRecord, Role, Dtype
+    inventory/
+      mod.rs                 # checkpoint walk, dedup, verification
+    analysis/
+      mod.rs
+      experts.rs             # MoE geometry from shapes
+      routing.rs             # router/gate identification
+      stats.rs               # parameter / byte accounting
+    report/
+      mod.rs
+      json.rs                # inventory.json, experts.json, routing.json
+      csv.rs                 # stats.csv
+      markdown.rs            # architecture.md renderer
+  docs/
+    architecture.md          # this file
+    non_goals.md
+  tests/
+    fixtures/                # tiny synthetic shards (no real weights)
+    parser_smoke.rs
+    inventory_smoke.rs
+```
+
+The tree is aspirational; today's `src/` contains a single-file CLI. The
+migration is additive: `main.rs` stays, `lib.rs` + submodules grow under
+it, and the CLI is rewritten to call into the library once the schema is
+stable.

--- a/docs/non_goals.md
+++ b/docs/non_goals.md
@@ -1,0 +1,72 @@
+# Non-goals
+
+`xai-dissect` is deliberately narrow. If a request falls into any of the
+categories below, it belongs in a different repo or is out of scope
+entirely. Pull requests expanding into these areas will be rejected.
+
+## Out of scope
+
+### Inference runtime
+- No forward pass, no decode loop, no sampler, no KV cache.
+- No tensor body loads into host or device memory.
+- No model execution of any kind, even for "just a sanity check".
+
+### Projector logic
+- No spiking / neuromorphic projection of activations or weights.
+- No dimensionality reduction intended to feed a projector.
+- Projector work lives in `snn-projector`.
+
+### SAAQ latent calibration
+- No SAAQ scoring, calibration, or latent-space analysis.
+- No numerical interpretation of tensor contents.
+- Latent work lives in `SAAQ-latent`.
+
+### GPU kernels
+- No CUDA / Metal / ROCm / SYCL code.
+- No hand-tuned matmul, attention, or MoE kernels.
+- No perf work beyond what is needed to scan shards on CPU.
+
+### Symbolic regression
+- No symbolic fitting over weights or activations.
+- No program synthesis from tensor statistics.
+
+### Plotting and dashboards
+- No interactive UI, no web dashboard, no notebook-first workflows.
+- No embedded plotting stack.
+- Visualization lives in `Surrogate_Viz.jl`, which consumes our exports.
+
+### Orchestration / hybrid runtime
+- No multi-process scheduling, no job graph, no runtime glue across repos.
+- No "run dissect then run projector then run SAAQ" wrappers.
+- Orchestration lives in `corinth-canal`.
+
+### Weight transformation
+- No dequantization.
+- No format conversion (Pickle -> safetensors, GGUF, etc.).
+- No checkpoint rewriting or re-sharding.
+- No production of runnable artifacts.
+
+### Weight distribution
+- This repo does not contain, mirror, vendor, or link-through any model
+  weights.
+- Users must obtain weights directly from the rights holder under the
+  original license.
+
+## Scope-adjacent items deferred, not rejected
+
+These are not non-goals; they are "not yet":
+
+- **Grok-2** support. Depends on a public release under a compatible
+  license. No work starts until that exists.
+- Additional dtypes beyond `f32` and `int8`. Added only when a supported
+  checkpoint actually requires them.
+- A stable Rust library API. The export schema is the stable surface
+  first; an in-process API hardens later.
+
+## Legal posture
+
+`xai-dissect` is a tool for lawful analysis of weights the operator already
+has legitimate access to. It is not a circumvention tool, not a scraper,
+and not a redistribution channel. Contributions that assume or enable
+unauthorized access to proprietary weights are out of scope and will be
+rejected.


### PR DESCRIPTION
## **User description**
Scopes `xai-dissect` as a focused Grok-family weight dissection and structural analysis repo.

## What changes

- **`README.md`**: rewritten to state what this repo owns (parser, schema, inventory, expert/routing analysis, stats, exports) and what it does not own (inference runtime, projectors, SAAQ calibration, GPU kernels, symbolic regression, dashboards, orchestration, weight transformation/distribution). Adds explicit relationship sections for `corinth-canal`, `snn-projector`, `SAAQ-latent`, and `Surrogate_Viz.jl`. Grok-1 is first-class; Grok-2 is deferred, not promised. Lawful-analysis posture stated up front.
- **`docs/architecture.md`**: describes the intended pipeline layers — parser, schema, inventory, expert analysis, routing analysis, stats, reports/exports — and proposes a minimal initial file tree. Migration is additive: today's single-file CLI stays while library modules grow under it.
- **`docs/non_goals.md`**: explicit non-goals list, plus a small "deferred, not rejected" section (Grok-2, extra dtypes, stable Rust API) and a legal posture note.

## Not in this PR

- No code changes. `src/` is untouched.
- No Grok-2 work. No export implementation. No module split. Those are follow-ons once the charter is agreed.

## Verification

- `git diff --stat` shows only `README.md`, `docs/architecture.md`, `docs/non_goals.md`.
- `cargo check` behavior is unchanged (no source files touched).


___

## **CodeAnt-AI Description**
**Define the repo’s scope, architecture, and out-of-scope boundaries for Grok checkpoint analysis**

### What Changed
- Clarifies that `xai-dissect` is a read-only tool for inspecting Grok weight shards, building tensor inventories, and producing architecture, expert, routing, and stats reports.
- Adds a clear non-goals document covering what this repo will not do, including model execution, projector logic, SAAQ analysis, GPU kernels, plotting dashboards, orchestration, weight conversion, and weight redistribution.
- Describes the intended analysis pipeline and export formats, plus a proposed file layout that keeps the current CLI while adding layered library modules over time.
- Updates the README to spell out the repo’s responsibilities, its relationship to sibling repos, and the lawful-analysis posture.

### Impact
`✅ Clearer project scope`
`✅ Fewer off-topic feature requests`
`✅ Easier handoff to downstream tools`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=WYkf_SMO2GRESYaAaTjCArjjLdbhr9awzM5FvV-Tgug&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
