### PR TITLE
feat(inventory): first tensor cartography layer (schema, parser, inventory, report)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +305,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,4 +440,12 @@ dependencies = [
  "comfy-table",
  "memchr",
  "memmap2",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,22 @@ description = "Zero-copy dissector for Grok-1 raw JAX/Pickle tensor shards"
 license = "GPL-3.0-only"
 repository = "https://github.com/rmems/xai-dissect"
 
+[lib]
+name = "xai_dissect"
+path = "src/lib.rs"
+
+[[bin]]
+name = "xai-dissect"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 comfy-table = "7.1"
 memchr = "2.7"
 memmap2 = "0.9"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [profile.release]
 lto = "thin"

--- a/docs/observed-grok1-ckpt0.md
+++ b/docs/observed-grok1-ckpt0.md
@@ -1,0 +1,125 @@
+# Observed: Grok-1 `ckpt-0`
+
+Empirical shard survey of the official xAI Grok-1 release, pinned to the
+known public architecture. Every number below comes from looking at the
+shard files on disk; no shard bodies are read.
+
+## Shard size distribution in `ckpt-0/`
+
+Before running `xai-dissect`, a simple
+
+```bash
+find ckpt-0 -type f -printf '%s\n' | sort | uniq -c
+```
+
+gives a clean histogram of the 770 shards (~297 GiB total). Every ndarray
+payload inside a shard is stored verbatim; pickle adds only ~150-400 B of
+framing, so file size alone already tells you roughly what is inside.
+
+| Count | Size (bytes)   | Size (human) | Interpretation |
+| ----: | -------------: | ------------ | -------------- |
+|     1 |  3,221,225,637 | 3.0 GiB      | `tensor00000_000` - token embedding `(131072, 6144) f32`. Payload = 131072 x 6144 x 4 = 3,221,225,472 B + ~165 B pickle framing. |
+|   128 |  1,611,137,347 | 1.5 GiB      | MoE / attention `QuantizedWeight8bit` shards, variant A. Int8 body is 8 x 6144 x 32768 = 1,610,612,736 B; remaining ~524 KB is f32 scales + pickle framing. 2 per layer. |
+|    64 |  1,611,399,491 | 1.5 GiB      | Same class as variant A but exactly 262,144 B (= 65,536 f32) larger - consistent with a differently-shaped `scales` block on one of the three expert projections. 1 per layer. |
+|    64 |     37,847,359 | 36 MiB       | f32 tensor sized ~9.46M elements; f32-attention projection companion, 1 per layer. |
+|    64 |     37,761,334 | 36 MiB       | Sibling shape to the row above, 1 per layer. |
+|   128 |      6,293,814 | 6.0 MiB      | f32 scales for the large quantized expert shards, 2 per layer. |
+|    64 |        196,770 | 192 KiB      | Small f32 tensor, 1 per layer. Size matches `(6144, 8) f32 = 196,608 B + ~162 B framing` - the per-layer router / gate matrix. |
+|   257 |         24,727 | 24 KiB       | f32 vector of 6144 elements (6144 x 4 = 24,576 B + framing) - per-layer RMSNorms + the final pre-head norm. |
+
+Totals reconcile exactly:
+
+```
+1 + 128 + 64 + 64 + 64 + 128 + 64 + 257 = 770
+```
+
+The two buckets at the 1.5 GiB tier (`1,611,137,347` vs `1,611,399,491`,
+delta = 262,144 = 64 KiB in f32) are consistent with the same base
+ndarray shape carrying a different-sized `scales` block inside the
+`QuantizedWeight8bit` dataclass - exactly what the parser already
+targets.
+
+## Per-bucket architectural mapping
+
+Grok-1 is a 64-layer MoE with 8 experts (2 active per token), hidden size
+6144, FFN inner size 32768, vocab 131072. Pinning each bucket to that
+architecture:
+
+- **1 x 3.0 GiB**: the token embedding, `(131072, 6144) f32`.
+- **128 + 64 = 192 x ~1.5 GiB**: the three MoE expert feed-forward
+  projections (up / gate / down) stacked across 8 experts per layer, for
+  64 layers. `3 x 64 = 192`.
+- **64 + 64 = 128 x 36 MiB**: two f32 attention-projection companions per
+  layer for 64 layers. `2 x 64 = 128`.
+- **128 x 6 MiB**: f32 scales for the large quantized expert shards, 2
+  per layer for 64 layers. `2 x 64 = 128`.
+- **64 x 192 KiB**: one router / gate tensor per layer, `(d_model,
+  n_experts) = (6144, 8) f32`, 64 layers. `1 x 64 = 64`.
+- **257 x 24 KiB**: per-layer RMSNorms of width `d_model = 6144`. The
+  count decomposes as `4 x 64 + 1 = 257` - four norms per block
+  (attention-Q, attention-K, pre-MLP, post-MLP) plus one final pre-head
+  norm.
+
+Every 1.5 GiB shard is a `QuantizedWeight8bit` dataclass (int8 weight +
+f32 scales), so `xai-dissect` emits two rows per shard (`quant.weight`
+and `quant.scales`). The plain f32 shards emit a single `tensor` row.
+
+## Grok-1 shape sanity
+
+Known public architecture:
+
+- `d_model` = 6144
+- `vocab_size` = 131072
+- `num_layers` = 64
+- `num_experts` = 8 (top-2 active per token)
+- `d_ff` = 32768 (per expert)
+
+Shard accounting:
+
+```
+770 shards = 1 embedding
+           + 64 layers * 12 shards/layer
+           + 1 final norm
+         = 1 + 768 + 1 = 770
+```
+
+The 12 shards per layer decompose as:
+
+```
+3 quantized MoE expert projections (up / gate / down, 8 experts stacked)
++ 2 f32 attention projection companions
++ 2 f32 scales blocks for the large quantized experts
++ 1 router / gate
++ 4 RMSNorms
+= 12
+```
+
+Close enough without a full `run.py` trace; the remaining ambiguity is
+which quantized projection is `up` vs `gate` (they share the
+`(8, 6144, 32768)` signature on disk). That is a downstream disambiguation
+problem for a later analysis pass, not a cartography problem.
+
+## Dissecting a single shard
+
+To see exact shapes and byte offsets for the embedding alone without
+pulling weights into RAM:
+
+```bash
+./target/release/xai-dissect dissect /path/to/grok-1-official/ckpt-0 --limit 1
+```
+
+This opens only `tensor00000_000`, memory-maps it, and prints the token
+embedding's dtype, shape, payload offset, and `Nbytes`. Drop `--limit` to
+sweep all 770 shards; the tool does not allocate tensor bodies, so the
+whole scan is I/O-bound (a few seconds on NVMe even at 297 GiB).
+
+For the full classified view across the checkpoint, use the `inventory`
+subcommand instead:
+
+```bash
+./target/release/xai-dissect inventory /path/to/grok-1-official/ckpt-0 \
+    --json out/inventory.json --md out/summary.md
+```
+
+See `docs/tensor-schema.md` for the classification rules applied to the
+shapes observed above.

--- a/docs/tensor-schema.md
+++ b/docs/tensor-schema.md
@@ -1,0 +1,183 @@
+# Tensor schema and naming heuristics
+
+This document defines the exported data model of `xai-dissect` and the
+rules the inventory layer uses to classify Grok-1 tensors by shape. The
+JSON export is produced by `report::write_json` and matches the
+`ModelInventory` struct in `src/schema/mod.rs` byte-for-byte via serde.
+
+Schema version: **1** (`ModelInventory.schema_version`).
+
+## Core types
+
+### `TensorDType`
+
+Narrow, additive enum.
+
+- `f32` - IEEE 754 binary32.
+- `i8` - signed 8-bit integer.
+
+No other dtypes are emitted. A checkpoint that contains an unsupported
+dtype is a parser error, not a schema extension.
+
+### `TensorShape`
+
+A row-major shape tuple serialized as a JSON array of non-negative
+integers. A rank-0 tensor serializes as `[]`.
+
+### `TensorRole`
+
+Parser-level tag describing how a tensor appeared on disk. Orthogonal to
+semantic classification.
+
+- `tensor` - a bare `numpy.ndarray`.
+- `quant.weight` - the int8 half of a `QuantizedWeight8bit` dataclass.
+- `quant.scales` - the f32 scales half of a `QuantizedWeight8bit` dataclass.
+
+### `TensorKind`
+
+Semantic classification. Inferred from `(rank, dtype, dims, role)` plus a
+small set of hyperparameters inferred from the inventory itself
+(`vocab_size`, `d_model`, `n_experts`). Emitted as a tagged JSON object
+`{ "kind": "...", "detail": ... }`.
+
+Variants:
+
+- `token_embedding`
+- `final_norm`
+- `block_norm`
+- `router`
+- `moe_expert_projection` with `detail = { "projection": "up" | "gate" | "down" | "unresolved" }`
+- `moe_scales`
+- `attn_proj_f32`
+- `unknown` with `detail = { "reason": "..." }`
+
+### `TensorInfo`
+
+One record per tensor found on disk. One shard may produce one or two
+records (two for `QuantizedWeight8bit`).
+
+Fields:
+
+- `shard_path` - absolute path of the shard file.
+- `shard_ordinal` - 0-based index of the shard in the sorted shard list.
+- `in_shard_index` - 0-based index of the tensor inside the shard.
+- `role` - `TensorRole`.
+- `dtype` - `TensorDType`.
+- `shape` - `TensorShape`.
+- `offset` - byte offset of the raw payload within the shard file.
+- `nbytes` - payload length in bytes.
+- `kind` - `TensorKind`.
+- `block_index` - optional transformer-block index.
+- `block_slot` - optional position within the block.
+
+### `BlockSummary`
+
+Aggregate view of one transformer block or one non-block singleton (the
+embedding and the final norm get their own rows). Contains: label,
+`block_index`, `shard_range`, tensor/byte counts, the set of dtypes seen,
+and per-kind counts.
+
+### `ModelInventory`
+
+Top-level document. Carries `model_family`, `checkpoint_path`,
+`shard_count`, `inferred` hyperparameters, the full `tensors` array, the
+`blocks` summary list, `totals`, and `schema_version`.
+
+## Hyperparameter inference
+
+Two-pass, conservative, no hardcoded Grok-1 constants:
+
+1. **Embedding**: the largest 2-D f32 `tensor` (not quant) wins. Its
+   shape fixes `vocab_size = dims[0]` and `d_model = dims[1]`.
+2. **Experts**: the first 3-D int8 `quant.weight` tensor encountered fixes
+   `n_experts = dims[0]`. If one of the inner dims equals `d_model`, the
+   other is recorded as `d_ff`.
+3. **Blocks**: after tensors are assembled, the shard layout is checked
+   against the Grok-1 pattern below to derive `n_blocks`.
+
+If a step cannot be resolved, the corresponding field is `null` and
+classification falls back to `Unknown { reason }` for the affected
+tensors.
+
+## Classification rules (Grok-1)
+
+Applied in order; the first matching rule wins.
+
+1. `(role = quant.weight, dtype = i8, rank = 3)`:
+   - If `dims[0] == n_experts`:
+     - If `dims[1] == d_model` -> `MoeExpertProjection { projection: unresolved }`
+       (the `(E, d_model, d_ff)` signature covers both up and gate; they
+       cannot be told apart by shape alone on Grok-1).
+     - Else if `dims[2] == d_model` -> `MoeExpertProjection { projection: down }`
+       (the `(E, d_ff, d_model)` signature).
+     - Else -> `MoeExpertProjection { projection: unresolved }`.
+   - Else -> `Unknown`.
+2. `(role = quant.scales, dtype = f32)` -> `MoeScales`.
+3. `(role = tensor, dtype = f32, rank = 2)`:
+   - If `dims == (vocab_size, d_model)` -> `TokenEmbedding`.
+   - Else if `dims == (d_model, n_experts)` -> `Router`.
+   - Else -> `AttnProjF32`.
+4. `(role = tensor, dtype = f32, rank = 1)`:
+   - If `dims[0] == d_model` -> `BlockNorm` (may be promoted to
+     `FinalNorm` by the block-assignment pass).
+   - Else -> `Unknown`.
+5. `(role = tensor, dtype = f32, rank >= 3)` -> `AttnProjF32`.
+6. Anything else -> `Unknown`.
+
+## Block assignment
+
+Grok-1 emits one shard per top-level JAX leaf. The observed layout for
+`ckpt-0` is:
+
+```
+  shard   0             : token embedding          (1 shard)
+  shards  1 .. 1+64*K-1 : 64 transformer blocks    (K = 12 shards / block)
+  shard   1 + 64*K      : final norm               (1 shard)
+                          total = 770
+```
+
+The inventory layer computes:
+
+```
+  interior = shard_count - 2
+  if interior % 12 == 0 and shard_count >= 3:
+      k_per_block = 12
+      n_blocks    = interior / 12
+      block_index = (shard_ordinal - 1) / k_per_block
+      block_slot  = (shard_ordinal - 1) % k_per_block
+```
+
+If the divisor check fails the assignment is skipped; `block_index` and
+`block_slot` remain `null` and downstream consumers should fall back to
+`shard_ordinal` and `kind`.
+
+The last shard's `BlockNorm` record is promoted to `FinalNorm` once block
+assignment succeeds.
+
+## What is *not* inferred here
+
+- The ordering of `up` vs. `gate` within a block. Both share the
+  `(E, d_model, d_ff)` shape; disambiguation requires a later pass over
+  the block's shard order and is explicitly out of scope for the
+  cartography layer.
+- Attention head count, head dimension, KV-head grouping. The f32
+  attention projections are reported as `AttnProjF32` without further
+  split.
+- Any numerical property of the weights. `xai-dissect` never reads tensor
+  bodies.
+- Per-layer routing top-k, dropout layout, or anything that depends on
+  training-time hyperparameters.
+
+## Forward compatibility
+
+Grok-2 is not yet supported. When it lands, the expected extensions are:
+
+- A new `model_family` tag (`"grok-2"`).
+- Additional `TensorKind` variants where Grok-2 introduces new tensor
+  roles (e.g. a separate value projection) or new dtypes.
+- A new block-layout entry alongside the Grok-1 `K = 12` rule.
+
+The schema is designed to absorb these without breaking existing
+consumers: the JSON `kind` enum is tagged, unknown variants round-trip as
+`Unknown { reason }`, and `schema_version` bumps on any incompatible
+change.

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Inventory layer: walks a checkpoint directory, drives the parser, applies
+// shape-based semantic classification, and groups tensors into blocks.
+//
+// This layer is intentionally conservative. It identifies what can be
+// identified from `(rank, dtype, dims)` alone plus an inferred `(d_model,
+// vocab_size, n_experts)` triple. Anything ambiguous is reported as
+// `Unknown { reason }` or `MoeProjection::Unresolved` and deferred to a
+// later analysis pass.
+//
+// Deeper semantic analysis (routing math, expert-level statistics,
+// dequantized parameter accounting) is explicitly *not* done here.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::parser::{self, RawTensor};
+use crate::schema::{
+    BlockSummary, InferredHyperparams, InventoryTotals, KindCount, ModelInventory, MoeProjection,
+    ShardRange, TensorDType, TensorInfo, TensorKind, TensorRole,
+};
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Configuration for enumerating and classifying a checkpoint.
+#[derive(Clone, Debug)]
+pub struct InventoryConfig {
+    /// Filename prefix used to select shard files inside the checkpoint
+    /// directory. Grok-1 uses `tensor`.
+    pub prefix: String,
+    /// Hard cap on the number of shards scanned (sorted by filename).
+    /// `None` means scan everything.
+    pub limit: Option<usize>,
+    /// Target model family label written into the export header.
+    pub model_family: String,
+}
+
+impl Default for InventoryConfig {
+    fn default() -> Self {
+        Self {
+            prefix: "tensor".to_string(),
+            limit: None,
+            model_family: "grok-1".to_string(),
+        }
+    }
+}
+
+/// Build a full `ModelInventory` for the checkpoint directory at `path`.
+pub fn build_inventory(path: &Path, cfg: &InventoryConfig) -> Result<ModelInventory> {
+    let md = std::fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?;
+    if !md.is_dir() {
+        bail!("{} is not a directory", path.display());
+    }
+
+    let shards = collect_shards(path, &cfg.prefix, cfg.limit)?;
+    if shards.is_empty() {
+        bail!(
+            "no shards found under {} with prefix '{}'",
+            path.display(),
+            cfg.prefix
+        );
+    }
+
+    // Pass 1: parse every shard into RawTensor records.
+    let mut raws_per_shard: Vec<Vec<RawTensor>> = Vec::with_capacity(shards.len());
+    for shard in &shards {
+        match parser::dissect_shard(shard) {
+            Ok(ts) => raws_per_shard.push(ts),
+            Err(e) => {
+                eprintln!("warn: {}: {:#}", shard.display(), e);
+                raws_per_shard.push(Vec::new());
+            }
+        }
+    }
+
+    // Pass 2: infer model hyperparameters from the raw set.
+    let hp = infer_hyperparams(&raws_per_shard);
+
+    // Pass 3: classify each raw tensor into a TensorKind.
+    let mut tensors: Vec<TensorInfo> = Vec::new();
+    for (shard_ordinal, (shard_path, raws)) in
+        shards.iter().zip(raws_per_shard.iter()).enumerate()
+    {
+        for (in_shard_index, raw) in raws.iter().enumerate() {
+            let kind = classify_tensor(raw, &hp);
+            tensors.push(TensorInfo {
+                shard_path: shard_path.clone(),
+                shard_ordinal: shard_ordinal as u32,
+                in_shard_index: in_shard_index as u32,
+                role: raw.role,
+                dtype: raw.dtype,
+                shape: raw.shape.clone(),
+                offset: raw.offset,
+                nbytes: raw.nbytes,
+                kind,
+                block_index: None,
+                block_slot: None,
+            });
+        }
+    }
+
+    // Pass 4: assign block_index / block_slot from shard ordinals, using a
+    // Grok-1-shaped layout model when the shard count fits.
+    let n_blocks = assign_block_indices(&mut tensors, shards.len());
+
+    // Pass 5: build block summaries and totals.
+    let blocks = summarize_blocks(&tensors);
+    let totals = compute_totals(&tensors);
+
+    Ok(ModelInventory {
+        model_family: cfg.model_family.clone(),
+        checkpoint_path: path.to_path_buf(),
+        shard_count: shards.len() as u32,
+        inferred: InferredHyperparams {
+            n_blocks,
+            ..hp
+        },
+        tensors,
+        blocks,
+        totals,
+        schema_version: SCHEMA_VERSION,
+    })
+}
+
+// --- Shard enumeration -----------------------------------------------------
+
+fn collect_shards(path: &Path, prefix: &str, limit: Option<usize>) -> Result<Vec<PathBuf>> {
+    let mut shards: Vec<PathBuf> = std::fs::read_dir(path)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(prefix))
+                    .unwrap_or(false)
+        })
+        .collect();
+    shards.sort();
+    if let Some(n) = limit {
+        shards.truncate(n);
+    }
+    Ok(shards)
+}
+
+// --- Hyperparameter inference ---------------------------------------------
+
+fn infer_hyperparams(raws_per_shard: &[Vec<RawTensor>]) -> InferredHyperparams {
+    let mut hp = InferredHyperparams::default();
+
+    // Flatten once for convenience; cheap, we only hold references.
+    let all: Vec<&RawTensor> = raws_per_shard.iter().flat_map(|v| v.iter()).collect();
+
+    // d_model + vocab_size: look for the largest 2-D f32 `tensor` (not
+    // quant.*). On Grok-1 this is uniquely the embedding table.
+    let mut best_embed: Option<(u64, u64, u64)> = None; // (numel, vocab, d_model)
+    for t in &all {
+        if !matches!(t.role, TensorRole::Tensor) {
+            continue;
+        }
+        if t.dtype != TensorDType::F32 {
+            continue;
+        }
+        if t.shape.rank() != 2 {
+            continue;
+        }
+        let dims = t.shape.dims();
+        let numel = t.shape.numel();
+        if best_embed.map(|(n, _, _)| numel > n).unwrap_or(true) {
+            best_embed = Some((numel, dims[0], dims[1]));
+        }
+    }
+    if let Some((_, v, d)) = best_embed {
+        hp.vocab_size = Some(v);
+        hp.d_model = Some(d);
+    }
+
+    // n_experts + d_ff: look for the 3-D int8 `quant.weight` tensors. Grok-1
+    // emits two distinct 3-D signatures per layer; both agree on `n_experts`
+    // (leading dim). Prefer the one where the inner product matches
+    // `(d_model, d_ff)`.
+    let d_model = hp.d_model;
+    for t in &all {
+        if !matches!(t.role, TensorRole::QuantWeight) {
+            continue;
+        }
+        if t.dtype != TensorDType::I8 {
+            continue;
+        }
+        if t.shape.rank() != 3 {
+            continue;
+        }
+        let dims = t.shape.dims();
+        let (e, a, b) = (dims[0], dims[1], dims[2]);
+        if hp.n_experts.is_none() {
+            hp.n_experts = Some(e);
+        }
+        if let Some(dm) = d_model {
+            if a == dm && hp.d_ff.is_none() {
+                hp.d_ff = Some(b);
+            } else if b == dm && hp.d_ff.is_none() {
+                hp.d_ff = Some(a);
+            }
+        }
+        if hp.n_experts.is_some() && hp.d_ff.is_some() {
+            break;
+        }
+    }
+
+    hp
+}
+
+// --- Classification --------------------------------------------------------
+
+fn classify_tensor(t: &RawTensor, hp: &InferredHyperparams) -> TensorKind {
+    let dims = t.shape.dims();
+    let rank = t.shape.rank();
+
+    // Paired quant tensors.
+    match (t.role, t.dtype, rank) {
+        (TensorRole::QuantWeight, TensorDType::I8, 3) => {
+            let (e, a, b) = (dims[0], dims[1], dims[2]);
+            let expected_e = hp.n_experts;
+            let d_model = hp.d_model;
+
+            let is_expert_block = expected_e.map(|n| e == n).unwrap_or(false);
+            if is_expert_block {
+                return match d_model {
+                    Some(dm) if a == dm => TensorKind::MoeExpertProjection {
+                        // (E, d_model, d_ff): the up/gate projection. Shape
+                        // alone cannot tell them apart on Grok-1.
+                        projection: MoeProjection::Unresolved,
+                    },
+                    Some(dm) if b == dm => TensorKind::MoeExpertProjection {
+                        projection: MoeProjection::Down,
+                    },
+                    _ => TensorKind::MoeExpertProjection {
+                        projection: MoeProjection::Unresolved,
+                    },
+                };
+            }
+            return TensorKind::Unknown {
+                reason: format!("quant.weight rank=3 shape={:?} unmatched", dims),
+            };
+        }
+        (TensorRole::QuantScales, TensorDType::F32, _) => {
+            return TensorKind::MoeScales;
+        }
+        _ => {}
+    }
+
+    // Plain tensors.
+    if t.role != TensorRole::Tensor {
+        return TensorKind::Unknown {
+            reason: format!("unexpected role={:?} dtype={:?}", t.role, t.dtype),
+        };
+    }
+
+    // Rank-2 f32: embedding or router.
+    if rank == 2 && t.dtype == TensorDType::F32 {
+        let (a, b) = (dims[0], dims[1]);
+        if hp.vocab_size == Some(a) && hp.d_model == Some(b) {
+            return TensorKind::TokenEmbedding;
+        }
+        // Router: (d_model, n_experts) where n_experts is small.
+        if hp.d_model == Some(a) && hp.n_experts == Some(b) {
+            return TensorKind::Router;
+        }
+        // Larger rank-2 f32 that is not the embedding is treated as an f32
+        // attention projection stored outside the quant envelope.
+        return TensorKind::AttnProjF32;
+    }
+
+    // Rank-1 f32 of width d_model: per-block or final norm. Block vs final
+    // is decided after block assignment (see `finalize_norms`). Start as
+    // BlockNorm and let that pass promote the tail-position record to
+    // FinalNorm.
+    if rank == 1 && t.dtype == TensorDType::F32 {
+        if hp.d_model == Some(dims[0]) {
+            return TensorKind::BlockNorm;
+        }
+        return TensorKind::Unknown {
+            reason: format!("rank-1 f32 width={} != d_model", dims[0]),
+        };
+    }
+
+    // Rank-3+ f32 `tensor` (not quant.scales): treat as AttnProjF32 where
+    // plausible, else Unknown.
+    if rank >= 3 && t.dtype == TensorDType::F32 {
+        return TensorKind::AttnProjF32;
+    }
+
+    TensorKind::Unknown {
+        reason: format!("unhandled rank={} dtype={:?} dims={:?}", rank, t.dtype, dims),
+    }
+}
+
+// --- Block assignment ------------------------------------------------------
+
+/// Shard layout assumption for a well-formed Grok-1 checkpoint:
+///
+///   shard 0            = token embedding         (1 shard)
+///   shards 1..=64*K    = 64 transformer blocks,  (K shards / block)
+///   shard (1 + 64*K)   = final norm              (1 shard)
+///
+/// For Grok-1 `ckpt-0` observed in the wild: `K = 12`, total = 770.
+///
+/// If the shard count does not fit this layout exactly, we leave
+/// `block_index` unset and the tail norm un-promoted; downstream consumers
+/// can still use `kind`, shape, and shard_ordinal directly.
+fn assign_block_indices(tensors: &mut [TensorInfo], shard_count: usize) -> Option<u32> {
+    // Try to divide the interior shards into equally-sized blocks, preferring
+    // a known-good K if the numbers agree.
+    if shard_count < 3 {
+        return None;
+    }
+    let interior = shard_count - 2; // drop embedding + final-norm singletons
+    // Candidate block sizes we try, in priority order.
+    let candidates = [12usize];
+    let mut chosen: Option<(usize, usize)> = None; // (k_per_block, n_blocks)
+    for &k in &candidates {
+        if k > 0 && interior % k == 0 {
+            chosen = Some((k, interior / k));
+            break;
+        }
+    }
+
+    let (k_per_block, n_blocks) = chosen?;
+
+    let last_shard = (shard_count - 1) as u32;
+
+    for t in tensors.iter_mut() {
+        let ord = t.shard_ordinal as usize;
+        if ord == 0 {
+            // Embedding: no block assignment.
+            continue;
+        }
+        if ord as u32 == last_shard {
+            // Final norm position. Promote a BlockNorm record to FinalNorm.
+            if matches!(t.kind, TensorKind::BlockNorm) {
+                t.kind = TensorKind::FinalNorm;
+            }
+            continue;
+        }
+        if ord >= 1 && ord <= shard_count - 2 {
+            let b = (ord - 1) / k_per_block;
+            let slot = (ord - 1) % k_per_block;
+            t.block_index = Some(b as u32);
+            t.block_slot = Some(slot as u32);
+        }
+    }
+
+    Some(n_blocks as u32)
+}
+
+// --- Block summaries -------------------------------------------------------
+
+fn summarize_blocks(tensors: &[TensorInfo]) -> Vec<BlockSummary> {
+    use std::collections::BTreeMap;
+
+    // Bucket tensors: None => embedding + final norm singletons, Some(i) => block i.
+    let mut by_block: BTreeMap<Option<u32>, Vec<&TensorInfo>> = BTreeMap::new();
+    for t in tensors {
+        by_block.entry(t.block_index).or_default().push(t);
+    }
+
+    // We want the output order: embedding singleton first, then block 0..N,
+    // then final-norm singleton. To keep a single summary type, we emit
+    // block-assigned entries under `Some(i)` and a synthetic singleton under
+    // `None` whose label distinguishes its members.
+    let mut out: Vec<BlockSummary> = Vec::new();
+
+    // Split the `None` bucket by kind so embedding and final-norm get their
+    // own summary rows.
+    if let Some(singletons) = by_block.remove(&None) {
+        let embed: Vec<&&TensorInfo> = singletons
+            .iter()
+            .filter(|t| matches!(t.kind, TensorKind::TokenEmbedding))
+            .collect();
+        let finals: Vec<&&TensorInfo> = singletons
+            .iter()
+            .filter(|t| matches!(t.kind, TensorKind::FinalNorm))
+            .collect();
+        let other: Vec<&&TensorInfo> = singletons
+            .iter()
+            .filter(|t| {
+                !matches!(
+                    t.kind,
+                    TensorKind::TokenEmbedding | TensorKind::FinalNorm
+                )
+            })
+            .collect();
+
+        if !embed.is_empty() {
+            out.push(build_summary(
+                None,
+                "embedding",
+                embed.iter().map(|t| **t).collect(),
+            ));
+        }
+        for (i, b) in by_block {
+            out.push(build_summary(
+                i,
+                &format!("block_{:03}", i.unwrap_or(0)),
+                b,
+            ));
+        }
+        if !finals.is_empty() {
+            out.push(build_summary(
+                None,
+                "final_norm",
+                finals.iter().map(|t| **t).collect(),
+            ));
+        }
+        if !other.is_empty() {
+            out.push(build_summary(
+                None,
+                "unassigned",
+                other.iter().map(|t| **t).collect(),
+            ));
+        }
+    } else {
+        for (i, b) in by_block {
+            out.push(build_summary(
+                i,
+                &format!("block_{:03}", i.unwrap_or(0)),
+                b,
+            ));
+        }
+    }
+
+    out
+}
+
+fn build_summary(block_index: Option<u32>, label: &str, members: Vec<&TensorInfo>) -> BlockSummary {
+    use std::collections::BTreeMap;
+
+    let shard_range = if members.is_empty() {
+        None
+    } else {
+        let mut lo = u32::MAX;
+        let mut hi = 0u32;
+        for t in &members {
+            lo = lo.min(t.shard_ordinal);
+            hi = hi.max(t.shard_ordinal);
+        }
+        Some(ShardRange { start: lo, end_inclusive: hi })
+    };
+
+    let tensor_count = members.len() as u32;
+    let total_nbytes = members.iter().map(|t| t.nbytes).sum();
+
+    let mut dtypes: Vec<TensorDType> = Vec::new();
+    for t in &members {
+        if !dtypes.contains(&t.dtype) {
+            dtypes.push(t.dtype);
+        }
+    }
+
+    let mut by_kind: BTreeMap<String, (u32, u64)> = BTreeMap::new();
+    for t in &members {
+        let k = t.kind.short_label();
+        let e = by_kind.entry(k).or_insert((0, 0));
+        e.0 += 1;
+        e.1 += t.nbytes;
+    }
+    let kinds: Vec<KindCount> = by_kind
+        .into_iter()
+        .map(|(k, (c, n))| KindCount { kind_label: k, count: c, nbytes: n })
+        .collect();
+
+    BlockSummary {
+        block_index,
+        label: label.to_string(),
+        shard_range,
+        tensor_count,
+        total_nbytes,
+        dtypes,
+        kinds,
+    }
+}
+
+// --- Totals ----------------------------------------------------------------
+
+fn compute_totals(tensors: &[TensorInfo]) -> InventoryTotals {
+    let mut out = InventoryTotals {
+        tensors: tensors.len() as u64,
+        ..Default::default()
+    };
+    for t in tensors {
+        out.total_nbytes += t.nbytes;
+        out.total_elements += t.shape.numel();
+        match t.dtype {
+            TensorDType::F32 => out.f32_tensors += 1,
+            TensorDType::I8 => out.i8_tensors += 1,
+        }
+        match t.role {
+            TensorRole::QuantWeight | TensorRole::QuantScales => out.quant_tensors += 1,
+            TensorRole::Tensor => {}
+        }
+    }
+    out
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// xai-dissect: static structural analysis of Grok-family open weights.
+// Copyright (C) 2026 xai-dissect contributors.
+//
+// Library entry point. The binary (src/main.rs) is a thin CLI on top of
+// this crate; external consumers should depend on the library and the
+// stable export schema produced by `xai_dissect::report`.
+
+pub mod schema;
+pub mod parser;
+pub mod inventory;
+pub mod report;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,206 +1,133 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// xai-dissect: zero-copy metadata extractor for Grok-1 raw JAX/Pickle shards.
-// Copyright (C) 2026 xai-dissect contributors.
+// xai-dissect CLI. Thin wrapper over the library crate. Two subcommands:
 //
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the
-// Free Software Foundation, version 3.
-//
-// This program is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-// Public License for more details. You should have received a copy of the
-// GNU General Public License along with this program. If not, see
-// <https://www.gnu.org/licenses/>.
-//
-// The shards are `pickle.dump(obj, protocol=4)` blobs where `obj` is either
-// a bare `numpy.ndarray` or a `__main__.QuantizedWeight8bit` dataclass
-// wrapping two ndarrays (`weight: int8`, `scales: float32`).
-//
-// We do NOT run a real unpickler. We memory-map each shard and exploit two
-// stable pickle-4 invariants:
-//
-//   1. Every numpy ndarray is reconstructed via a state tuple whose dtype is
-//      built by `numpy.dtype('f4' | 'i1', False, True)`. That guarantees the
-//      immediate byte signature is:
-//
-//          <dtype-class push>  \x8c\x02XX  [\x94]  \x89 \x88 \x87  [\x94]  R
-//
-//      where `XX` is `f4` or `i1`. Anchor on `\x8c\x02XX` and validate the
-//      tight post-amble `\x89 \x88 \x87`.
-//
-//   2. The array payload is always emitted immediately after the fortran-order
-//      bool: `[\x88|\x89] <C|B|\x8e> <len> <raw bytes>`. Scanning forward from
-//      the dtype tag for the first such pair lands exactly on the payload.
-//
-// Backward from the dtype tag we walk a tiny state machine that unwinds the
-// "dtype class push" (full STACK_GLOBAL form or BINGET/LONG_BINGET memo
-// re-fetch) to find the shape tuple's terminator opcode.
+//   dissect    - legacy per-shard byte-table view (parser output only).
+//   inventory  - full checkpoint cartography with JSON / Markdown export.
 
-use std::cmp::min;
-use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Parser;
-use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
-use memchr::memmem;
-use memmap2::Mmap;
+use anyhow::{Context, Result, bail};
+use clap::{Parser, Subcommand};
+use comfy_table::{Cell, ContentArrangement, Table, presets::UTF8_FULL};
 
-// --- Pickle protocol 4 opcodes we touch -------------------------------------
-
-const OP_PROTO: u8 = 0x80;
-
-const OP_SHORT_BINUNICODE: u8 = 0x8c;
-const OP_MEMOIZE: u8 = 0x94;
-const OP_STACK_GLOBAL: u8 = 0x93;
-
-const OP_BINGET: u8 = b'h';        // 0x68  u8 index
-const OP_LONG_BINGET: u8 = b'j';   // 0x6a  u32 index
-
-const OP_SHORT_BINBYTES: u8 = b'C'; // 0x43  u8 len
-const OP_BINBYTES: u8 = b'B';       // 0x42  u32 len
-const OP_BINBYTES8: u8 = 0x8e;      // u64 len
-
-const OP_MARK: u8 = b'(';
-const OP_TUPLE: u8 = b't';
-const OP_TUPLE1: u8 = 0x85;
-const OP_TUPLE2: u8 = 0x86;
-const OP_TUPLE3: u8 = 0x87;
-const OP_EMPTY_TUPLE: u8 = b')';
-
-const OP_BININT1: u8 = b'K'; // 0x4b  u8
-const OP_BININT2: u8 = b'M'; // 0x4d  u16
-const OP_BININT: u8 = b'J';  // 0x4a  i32
-
-const OP_NEWTRUE: u8 = 0x88;
-const OP_NEWFALSE: u8 = 0x89;
-
-// --- Anchor bytes -----------------------------------------------------------
-
-const DTYPE_TAG_F32: &[u8] = b"\x8c\x02f4";
-const DTYPE_TAG_I8: &[u8] = b"\x8c\x02i1";
-
-// QuantizedWeight8bit class reference (strict and loose). The dumper Grok-1
-// used emits both MEMOIZE bytes, but the spec asks us to be lax against a
-// missing trailing \x94 when the Pickler reuses a memo slot.
-const SIG_QW8_STRICT: &[u8] =
-    b"\x8c\x08__main__\x94\x8c\x13QuantizedWeight8bit\x94";
-const SIG_QW8_LOOSE_MODULE: &[u8] = b"\x8c\x08__main__";
-const SIG_QW8_CLASS_TAG: &[u8] = b"\x8c\x13QuantizedWeight8bit";
-
-// --- Types ------------------------------------------------------------------
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum Dtype {
-    F32,
-    I8,
-}
-
-impl Dtype {
-    fn itemsize(self) -> usize {
-        match self {
-            Dtype::F32 => 4,
-            Dtype::I8 => 1,
-        }
-    }
-    fn label(self) -> &'static str {
-        match self {
-            Dtype::F32 => "f32",
-            Dtype::I8 => "int8",
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum Role {
-    Tensor,
-    QuantWeight,
-    QuantScales,
-}
-
-impl Role {
-    fn label(&self) -> &'static str {
-        match self {
-            Role::Tensor => "tensor",
-            Role::QuantWeight => "quant.weight",
-            Role::QuantScales => "quant.scales",
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct TensorEntry {
-    role: Role,
-    dtype: Dtype,
-    shape: Vec<usize>,
-    offset: usize, // absolute byte offset of raw payload within the shard file
-    nbytes: usize,
-}
-
-// --- CLI --------------------------------------------------------------------
+use xai_dissect::inventory::{InventoryConfig, build_inventory};
+use xai_dissect::parser;
+use xai_dissect::report;
+use xai_dissect::schema::{ModelInventory, TensorInfo};
 
 #[derive(Parser, Debug)]
 #[command(
     name = "xai-dissect",
     version,
-    about = "Dissect Grok-1 JAX/Pickle tensor shards without decoding weights"
+    about = "Static structural analysis of Grok-family open-weight checkpoints"
 )]
 struct Cli {
-    /// Directory containing `tensor*` shard files (non-recursive).
-    path: PathBuf,
-
-    /// Only process the first N shards (sorted by filename). Useful for
-    /// verifying extraction against `tensor00000_000` before sweeping a full
-    /// checkpoint directory.
-    #[arg(long)]
-    limit: Option<usize>,
-
-    /// Filename prefix filter. Defaults to `tensor`.
-    #[arg(long, default_value = "tensor")]
-    prefix: String,
+    #[command(subcommand)]
+    command: Command,
 }
 
-// --- Entry point ------------------------------------------------------------
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Parse each shard and print a per-shard tensor table. Raw parser
+    /// output only; no classification, no grouping.
+    Dissect {
+        /// Directory containing `tensor*` shard files (non-recursive).
+        path: PathBuf,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+    },
+    /// Build a full inventory of a checkpoint directory: parse, classify,
+    /// group by block, and optionally export JSON and Markdown.
+    Inventory {
+        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+        path: PathBuf,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Model family tag written into the export header. Only `grok-1`
+        /// is officially supported today.
+        #[arg(long, default_value = "grok-1")]
+        family: String,
+        /// If set, write the full inventory as pretty JSON to this path.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// If set, write the Markdown summary to this path. If unset, the
+        /// Markdown summary is printed to stdout.
+        #[arg(long)]
+        md: Option<PathBuf>,
+    },
+}
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    match cli.command {
+        Command::Dissect { path, limit, prefix } => run_dissect(&path, limit, &prefix),
+        Command::Inventory { path, prefix, limit, family, json, md } => {
+            run_inventory(&path, &prefix, limit, &family, json.as_deref(), md.as_deref())
+        }
+    }
+}
 
-    let md = std::fs::metadata(&cli.path)
-        .with_context(|| format!("stat {}", cli.path.display()))?;
+// --- `dissect` -------------------------------------------------------------
+
+fn run_dissect(path: &std::path::Path, limit: Option<usize>, prefix: &str) -> Result<()> {
+    let md = std::fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
     if !md.is_dir() {
-        bail!("{} is not a directory", cli.path.display());
+        bail!("{} is not a directory", path.display());
     }
 
-    let mut shards: Vec<PathBuf> = std::fs::read_dir(&cli.path)?
+    let mut shards: Vec<PathBuf> = std::fs::read_dir(path)?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
             p.is_file()
                 && p.file_name()
                     .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with(&cli.prefix))
+                    .map(|n| n.starts_with(prefix))
                     .unwrap_or(false)
         })
         .collect();
     shards.sort();
-
     if shards.is_empty() {
-        bail!(
-            "no shards found under {} with prefix '{}'",
-            cli.path.display(),
-            cli.prefix
-        );
+        bail!("no shards found under {} with prefix '{}'", path.display(), prefix);
     }
-
-    if let Some(n) = cli.limit {
+    if let Some(n) = limit {
         shards.truncate(n);
     }
 
     for shard in &shards {
-        match dissect_shard(shard) {
-            Ok(entries) => render_table(shard, &entries),
+        match parser::dissect_shard(shard) {
+            Ok(entries) => {
+                println!("\n{}", shard.display());
+                if entries.is_empty() {
+                    println!("  (no tensors found)");
+                    continue;
+                }
+                let mut table = Table::new();
+                table
+                    .load_preset(UTF8_FULL)
+                    .set_content_arrangement(ContentArrangement::Dynamic)
+                    .set_header(vec!["Idx", "Role", "Dtype", "Shape", "Offset", "Nbytes"]);
+                for (i, e) in entries.iter().enumerate() {
+                    table.add_row(vec![
+                        Cell::new(i),
+                        Cell::new(e.role.label()),
+                        Cell::new(e.dtype.label()),
+                        Cell::new(e.shape.render()),
+                        Cell::new(format!("{:#x}", e.offset)),
+                        Cell::new(e.nbytes),
+                    ]);
+                }
+                println!("{table}");
+            }
             Err(e) => eprintln!("warn: {}: {:#}", shard.display(), e),
         }
     }
@@ -208,416 +135,70 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-// --- Per-shard driver -------------------------------------------------------
+// --- `inventory` -----------------------------------------------------------
 
-fn dissect_shard(path: &Path) -> Result<Vec<TensorEntry>> {
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
-    // Safety: the file is not mutated while the mmap is live.
-    let mm = unsafe { Mmap::map(&file) }.with_context(|| format!("mmap {}", path.display()))?;
-    let bytes: &[u8] = &mm;
+fn run_inventory(
+    path: &std::path::Path,
+    prefix: &str,
+    limit: Option<usize>,
+    family: &str,
+    json_out: Option<&std::path::Path>,
+    md_out: Option<&std::path::Path>,
+) -> Result<()> {
+    let cfg = InventoryConfig {
+        prefix: prefix.to_string(),
+        limit,
+        model_family: family.to_string(),
+    };
+    let inv = build_inventory(path, &cfg)?;
 
-    if bytes.len() < 2 || bytes[0] != OP_PROTO || bytes[1] != 0x04 {
-        bail!(
-            "not a pickle protocol 4 stream (magic={:02x?})",
-            &bytes[..min(2, bytes.len())]
-        );
+    // Always print a compact console summary.
+    print_console_summary(&inv);
+
+    if let Some(p) = json_out {
+        report::write_json(&inv, p)?;
+        eprintln!("wrote JSON inventory -> {}", p.display());
     }
-
-    let mut anchors = find_dtype_anchors(bytes);
-    anchors.sort_by_key(|a| a.tag_pos);
-
-    let mut entries = Vec::with_capacity(anchors.len());
-    for a in &anchors {
-        match extract_tensor(bytes, a) {
-            Ok(e) => entries.push(e),
-            Err(err) => eprintln!(
-                "  skip anchor @ {:#x}: {:#}",
-                a.tag_pos, err
-            ),
-        }
-    }
-
-    let qw8_sites = find_qw8_sites(bytes);
-    assign_qw8_roles(&mut entries, &qw8_sites);
-
-    Ok(entries)
-}
-
-// --- Anchor discovery -------------------------------------------------------
-
-#[derive(Debug, Clone, Copy)]
-struct DtypeAnchor {
-    /// Byte index of the `\x8c\x02XX` short_binunicode naming the dtype.
-    tag_pos: usize,
-    /// First byte AFTER the 4-byte tag (pointer to optional trailing MEMOIZE).
-    after_tag: usize,
-    dtype: Dtype,
-}
-
-/// Locate every dtype tag whose forward post-amble matches numpy's
-/// `np.dtype(str, False, True)` pickle shape. This is the core invariant that
-/// works whether or not any individual MEMOIZE opcode is elided.
-///
-/// Valid post-amble forms (with `P` = after_tag):
-///   * strict: `\x94 \x89 \x88 \x87` at P..P+4
-///   * loose:        `\x89 \x88 \x87` at P..P+3
-fn find_dtype_anchors(bytes: &[u8]) -> Vec<DtypeAnchor> {
-    let mut out: Vec<DtypeAnchor> = Vec::new();
-
-    for (tag, dtype) in [(DTYPE_TAG_F32, Dtype::F32), (DTYPE_TAG_I8, Dtype::I8)] {
-        for pos in memmem::find_iter(bytes, tag) {
-            let after = pos + tag.len();
-            if has_dtype_postamble(bytes, after) {
-                out.push(DtypeAnchor { tag_pos: pos, after_tag: after, dtype });
-            }
-        }
-    }
-    out
-}
-
-fn has_dtype_postamble(bytes: &[u8], after_tag: usize) -> bool {
-    let mut i = after_tag;
-    if bytes.get(i) == Some(&OP_MEMOIZE) {
-        i += 1;
-    }
-    bytes.get(i..i + 3) == Some(&[OP_NEWFALSE, OP_NEWTRUE, OP_TUPLE3])
-}
-
-// --- Per-anchor extraction --------------------------------------------------
-
-fn extract_tensor(bytes: &[u8], anchor: &DtypeAnchor) -> Result<TensorEntry> {
-    let shape = parse_shape_backward(bytes, anchor.tag_pos)?;
-    let (offset, nbytes) = find_payload_forward(bytes, anchor.after_tag)?;
-    let expected = anchor.dtype.itemsize() * shape.iter().product::<usize>();
-    if expected != 0 && expected != nbytes {
-        return Err(anyhow!(
-            "shape/payload mismatch: shape={:?} dtype={} nbytes={} expected={}",
-            shape,
-            anchor.dtype.label(),
-            nbytes,
-            expected
-        ));
-    }
-    Ok(TensorEntry {
-        role: Role::Tensor,
-        dtype: anchor.dtype,
-        shape,
-        offset,
-        nbytes,
-    })
-}
-
-/// Walk backward from the dtype tag through the variable-length "dtype class
-/// push" to reach the shape tuple's terminator byte, then decode the shape.
-///
-/// The dtype class is either:
-///   a) Freshly constructed: push("numpy") push("dtype") STACK_GLOBAL
-///      with each string push being either a literal SHORT_BINUNICODE (with
-///      optional MEMOIZE) or a BINGET/LONG_BINGET re-fetch of a memoized
-///      string; STACK_GLOBAL itself may or may not be followed by MEMOIZE.
-///   b) Pre-memoized and re-fetched: a single BINGET or LONG_BINGET.
-///
-/// We greedily unwind the post-class MEMOIZE, then disambiguate (a) vs (b)
-/// by looking for `\x93` (STACK_GLOBAL) within a 2-byte lookback.
-fn parse_shape_backward(bytes: &[u8], tag_pos: usize) -> Result<Vec<usize>> {
-    let mut p = tag_pos;
-
-    // Skip MEMOIZE that may sit directly after STACK_GLOBAL (case a).
-    p = skip_memoize_back(bytes, p);
-
-    if p >= 1 && bytes[p - 1] == OP_STACK_GLOBAL {
-        // Case (a): consume STACK_GLOBAL and the two string pushes behind it.
-        p -= 1;
-        p = skip_string_push_back(bytes, p)?; // "dtype"
-        p = skip_string_push_back(bytes, p)?; // "numpy"
+    if let Some(p) = md_out {
+        report::write_markdown(&inv, p)?;
+        eprintln!("wrote Markdown report -> {}", p.display());
     } else {
-        // Case (b): a single BINGET / LONG_BINGET of the memoized class.
-        p = skip_binget_back(bytes, p)?;
+        // If no Markdown file was requested, print the Markdown report to
+        // stdout so `cargo run -- inventory <path>` is useful on its own.
+        println!();
+        println!("{}", report::render_markdown(&inv));
     }
 
-    // Between the class push and the shape tuple there may be a shape-MEMOIZE.
-    p = skip_memoize_back(bytes, p);
-
-    decode_shape_tuple_backward(bytes, p)
-}
-
-fn skip_memoize_back(bytes: &[u8], p: usize) -> usize {
-    if p >= 1 && bytes[p - 1] == OP_MEMOIZE {
-        p - 1
-    } else {
-        p
-    }
-}
-
-/// Step over either `h XX` (BINGET) or `j XX XX XX XX` (LONG_BINGET) or
-/// `\x8c LEN <chars>` (SHORT_BINUNICODE, MEMOIZE-less) ending at `p - 1`.
-/// Leaves the cursor on the byte after the consumed sequence (i.e. the new
-/// logical end of the preceding tuple area).
-fn skip_string_push_back(bytes: &[u8], p: usize) -> Result<usize> {
-    // Optional trailing MEMOIZE for the string itself.
-    let p = skip_memoize_back(bytes, p);
-
-    if p >= 2 && bytes[p - 2] == OP_BINGET {
-        return Ok(p - 2);
-    }
-    if p >= 5 && bytes[p - 5] == OP_LONG_BINGET {
-        return Ok(p - 5);
-    }
-    // Literal SHORT_BINUNICODE: last char at p-1, length byte at p-len-1,
-    // opcode at p-len-2. We bound len to <= 32 which covers "numpy"/"dtype".
-    for len in 1..=32usize {
-        if p < len + 2 {
-            break;
-        }
-        if bytes[p - len - 2] == OP_SHORT_BINUNICODE
-            && bytes[p - len - 1] as usize == len
-        {
-            return Ok(p - len - 2);
-        }
-    }
-    Err(anyhow!(
-        "cannot unwind string push ending at {:#x}",
-        p.saturating_sub(1)
-    ))
-}
-
-fn skip_binget_back(bytes: &[u8], p: usize) -> Result<usize> {
-    if p >= 2 && bytes[p - 2] == OP_BINGET {
-        return Ok(p - 2);
-    }
-    if p >= 5 && bytes[p - 5] == OP_LONG_BINGET {
-        return Ok(p - 5);
-    }
-    Err(anyhow!(
-        "expected BINGET/LONG_BINGET before dtype tag at {:#x}",
-        p.saturating_sub(1)
-    ))
-}
-
-fn decode_shape_tuple_backward(bytes: &[u8], end_exclusive: usize) -> Result<Vec<usize>> {
-    if end_exclusive == 0 {
-        bail!("no room for shape tuple at offset {:#x}", end_exclusive);
-    }
-    let term = bytes[end_exclusive - 1];
-    match term {
-        OP_EMPTY_TUPLE => Ok(Vec::new()),
-        OP_TUPLE1 => {
-            let (v, _) = read_int_backward(bytes, end_exclusive - 1)?;
-            Ok(vec![v])
-        }
-        OP_TUPLE2 => {
-            let (v1, p1) = read_int_backward(bytes, end_exclusive - 1)?;
-            let (v0, _) = read_int_backward(bytes, p1)?;
-            Ok(vec![v0, v1])
-        }
-        OP_TUPLE3 => {
-            let (v2, p2) = read_int_backward(bytes, end_exclusive - 1)?;
-            let (v1, p1) = read_int_backward(bytes, p2)?;
-            let (v0, _) = read_int_backward(bytes, p1)?;
-            Ok(vec![v0, v1, v2])
-        }
-        OP_TUPLE => {
-            let mut dims = Vec::new();
-            let mut cursor = end_exclusive - 1;
-            loop {
-                if cursor == 0 {
-                    bail!("ran off start walking MARK..TUPLE shape");
-                }
-                if bytes[cursor - 1] == OP_MARK {
-                    dims.reverse();
-                    return Ok(dims);
-                }
-                let (v, next) = read_int_backward(bytes, cursor)?;
-                dims.push(v);
-                cursor = next;
-            }
-        }
-        other => Err(anyhow!(
-            "unexpected shape terminator opcode 0x{:02x} at offset {:#x}",
-            other,
-            end_exclusive - 1
-        )),
-    }
-}
-
-/// Consume one integer opcode whose final byte sits at `end_exclusive - 1` and
-/// return (value, index_of_first_byte_of_the_opcode).
-fn read_int_backward(bytes: &[u8], end_exclusive: usize) -> Result<(usize, usize)> {
-    if end_exclusive == 0 {
-        bail!("int parse: empty range");
-    }
-    // BININT (J) - 5 bytes
-    if end_exclusive >= 5 && bytes[end_exclusive - 5] == OP_BININT {
-        let v = i32::from_le_bytes(bytes[end_exclusive - 4..end_exclusive].try_into().unwrap());
-        if v < 0 {
-            bail!("negative BININT in shape dim");
-        }
-        return Ok((v as usize, end_exclusive - 5));
-    }
-    // BININT2 (M) - 3 bytes
-    if end_exclusive >= 3 && bytes[end_exclusive - 3] == OP_BININT2 {
-        let v = u16::from_le_bytes(bytes[end_exclusive - 2..end_exclusive].try_into().unwrap());
-        return Ok((v as usize, end_exclusive - 3));
-    }
-    // BININT1 (K) - 2 bytes
-    if end_exclusive >= 2 && bytes[end_exclusive - 2] == OP_BININT1 {
-        return Ok((bytes[end_exclusive - 1] as usize, end_exclusive - 2));
-    }
-    Err(anyhow!(
-        "no BININT* opcode ending at offset {:#x}",
-        end_exclusive - 1
-    ))
-}
-
-/// Scan forward from just after the dtype tag for the `[\x88|\x89] <payload>`
-/// fortran-bool + payload-opcode boundary. Handles SHORT_BINBYTES (C, u8
-/// len), BINBYTES (B, u32 len), and BINBYTES8 (\x8e, u64 len).
-fn find_payload_forward(bytes: &[u8], after_tag: usize) -> Result<(usize, usize)> {
-    let start = after_tag;
-    // The dtype state tuple between the tag and the payload is short and
-    // predictable; 256 bytes is a generous ceiling.
-    let stop = min(bytes.len().saturating_sub(1), start + 256);
-    let mut i = start;
-    while i < stop {
-        let b = bytes[i];
-        if (b == OP_NEWTRUE || b == OP_NEWFALSE) && i + 1 < bytes.len() {
-            let opcode = bytes[i + 1];
-            match opcode {
-                OP_SHORT_BINBYTES => {
-                    let hdr = i + 2;
-                    if hdr >= bytes.len() {
-                        bail!("truncated SHORT_BINBYTES at {:#x}", i + 1);
-                    }
-                    let len = bytes[hdr] as usize;
-                    let data = hdr + 1;
-                    check_payload_bounds(bytes, data, len)?;
-                    return Ok((data, len));
-                }
-                OP_BINBYTES => {
-                    let hdr = i + 2;
-                    if hdr + 4 > bytes.len() {
-                        bail!("truncated BINBYTES header at {:#x}", i + 1);
-                    }
-                    let len = u32::from_le_bytes(bytes[hdr..hdr + 4].try_into().unwrap()) as usize;
-                    let data = hdr + 4;
-                    check_payload_bounds(bytes, data, len)?;
-                    return Ok((data, len));
-                }
-                OP_BINBYTES8 => {
-                    let hdr = i + 2;
-                    if hdr + 8 > bytes.len() {
-                        bail!("truncated BINBYTES8 header at {:#x}", i + 1);
-                    }
-                    let len = u64::from_le_bytes(bytes[hdr..hdr + 8].try_into().unwrap()) as usize;
-                    let data = hdr + 8;
-                    check_payload_bounds(bytes, data, len)?;
-                    return Ok((data, len));
-                }
-                _ => {}
-            }
-        }
-        i += 1;
-    }
-    bail!(
-        "no fortran+payload marker found within {} bytes of dtype tag @ {:#x}",
-        stop - start,
-        after_tag
-    )
-}
-
-fn check_payload_bounds(bytes: &[u8], data: usize, len: usize) -> Result<()> {
-    if data.saturating_add(len) > bytes.len() {
-        bail!(
-            "payload {} bytes overruns file (data_off={:#x}, file_len={})",
-            len,
-            data,
-            bytes.len()
-        );
-    }
     Ok(())
 }
 
-// --- QuantizedWeight8bit grouping ------------------------------------------
+fn print_console_summary(inv: &ModelInventory) {
+    eprintln!(
+        "checkpoint: {}  shards: {}  tensors: {}",
+        inv.checkpoint_path.display(),
+        inv.shard_count,
+        inv.totals.tensors,
+    );
+    let hp = &inv.inferred;
+    eprintln!(
+        "inferred:  vocab={:?}  d_model={:?}  n_experts={:?}  d_ff={:?}  n_blocks={:?}",
+        hp.vocab_size, hp.d_model, hp.n_experts, hp.d_ff, hp.n_blocks,
+    );
 
-fn find_qw8_sites(bytes: &[u8]) -> Vec<usize> {
-    let mut sites: Vec<usize> = memmem::find_iter(bytes, SIG_QW8_STRICT).collect();
-    for pos in memmem::find_iter(bytes, SIG_QW8_LOOSE_MODULE) {
-        let window_end = min(bytes.len(), pos + SIG_QW8_LOOSE_MODULE.len() + 24);
-        if memmem::find(&bytes[pos..window_end], SIG_QW8_CLASS_TAG).is_some()
-            && !sites.contains(&pos)
-        {
-            sites.push(pos);
-        }
+    // Warn if the embedding tensor is missing or there are Unknown records.
+    let has_embedding = inv
+        .tensors
+        .iter()
+        .any(|t: &TensorInfo| matches!(t.kind, xai_dissect::schema::TensorKind::TokenEmbedding));
+    if !has_embedding {
+        eprintln!("warn: no TokenEmbedding tensor classified; hyperparameters may be off");
     }
-    sites.sort();
-    sites.dedup();
-    sites
-}
-
-/// For each QuantizedWeight8bit site, label the first int8 tensor that starts
-/// after it as `QuantWeight` and the first f32 tensor after it as `QuantScales`.
-/// This matches the dataclass field order used in the Grok-1 dumper.
-fn assign_qw8_roles(entries: &mut [TensorEntry], sites: &[usize]) {
-    for &site in sites {
-        let mut weight_idx = None;
-        let mut scales_idx = None;
-        for (idx, e) in entries.iter().enumerate() {
-            if e.offset < site {
-                continue;
-            }
-            match (e.dtype, weight_idx, scales_idx) {
-                (Dtype::I8, None, _) => weight_idx = Some(idx),
-                (Dtype::F32, _, None) => scales_idx = Some(idx),
-                _ => {}
-            }
-            if weight_idx.is_some() && scales_idx.is_some() {
-                break;
-            }
-        }
-        if let Some(i) = weight_idx {
-            entries[i].role = Role::QuantWeight;
-        }
-        if let Some(i) = scales_idx {
-            entries[i].role = Role::QuantScales;
-        }
+    let unknown = inv
+        .tensors
+        .iter()
+        .filter(|t| matches!(t.kind, xai_dissect::schema::TensorKind::Unknown { .. }))
+        .count();
+    if unknown > 0 {
+        eprintln!("warn: {} tensors classified as Unknown", unknown);
     }
-}
-
-// --- Output -----------------------------------------------------------------
-
-fn render_table(path: &Path, entries: &[TensorEntry]) {
-    println!("\n{}", path.display());
-    if entries.is_empty() {
-        println!("  (no tensors found)");
-        return;
-    }
-    let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec!["Idx", "Role", "Dtype", "Shape", "Offset", "Nbytes"]);
-
-    for (i, e) in entries.iter().enumerate() {
-        let shape_str = match e.shape.len() {
-            0 => "()".to_string(),
-            1 => format!("({},)", e.shape[0]),
-            _ => format!(
-                "({})",
-                e.shape
-                    .iter()
-                    .map(|d| d.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-        };
-        table.add_row(vec![
-            Cell::new(i),
-            Cell::new(e.role.label()),
-            Cell::new(e.dtype.label()),
-            Cell::new(shape_str),
-            Cell::new(format!("{:#x}", e.offset)),
-            Cell::new(e.nbytes),
-        ]);
-    }
-    println!("{table}");
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Pickle Protocol 4 byte-grammar scanner for Grok-1 JAX shards. Extracts
+// `(dtype, shape, offset, nbytes)` tuples and `QuantizedWeight8bit` pairing
+// without running a real unpickler or decoding tensor bodies.
+//
+// This module is intentionally free of schema/inventory concerns: it speaks
+// only in terms of raw tensor anchors. The higher layers map these anchors
+// into `schema::TensorInfo` and assign semantics.
+//
+// Stable pickle-4 invariants we rely on (documented in the original
+// single-file CLI):
+//
+//   1. Every `numpy.ndarray` is reconstructed via a state tuple whose dtype
+//      is built by `numpy.dtype('f4' | 'i1', False, True)`. That guarantees
+//      the byte signature `<dtype class push> \x8c\x02XX [\x94] \x89 \x88
+//      \x87 [\x94] R`.
+//   2. The array payload is always emitted immediately after the fortran
+//      bool: `[\x88|\x89] <C|B|\x8e> <len> <raw bytes>`.
+
+use std::cmp::min;
+use std::fs::File;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+use memchr::memmem;
+use memmap2::Mmap;
+
+use crate::schema::{TensorDType, TensorRole, TensorShape};
+
+// --- Pickle protocol 4 opcodes we touch ------------------------------------
+
+const OP_PROTO: u8 = 0x80;
+
+const OP_SHORT_BINUNICODE: u8 = 0x8c;
+const OP_MEMOIZE: u8 = 0x94;
+const OP_STACK_GLOBAL: u8 = 0x93;
+
+const OP_BINGET: u8 = b'h';      // 0x68  u8 index
+const OP_LONG_BINGET: u8 = b'j'; // 0x6a  u32 index
+
+const OP_SHORT_BINBYTES: u8 = b'C'; // 0x43  u8 len
+const OP_BINBYTES: u8 = b'B';       // 0x42  u32 len
+const OP_BINBYTES8: u8 = 0x8e;      // u64 len
+
+const OP_MARK: u8 = b'(';
+const OP_TUPLE: u8 = b't';
+const OP_TUPLE1: u8 = 0x85;
+const OP_TUPLE2: u8 = 0x86;
+const OP_TUPLE3: u8 = 0x87;
+const OP_EMPTY_TUPLE: u8 = b')';
+
+const OP_BININT1: u8 = b'K'; // 0x4b  u8
+const OP_BININT2: u8 = b'M'; // 0x4d  u16
+const OP_BININT: u8 = b'J';  // 0x4a  i32
+
+const OP_NEWTRUE: u8 = 0x88;
+const OP_NEWFALSE: u8 = 0x89;
+
+// --- Anchor bytes ----------------------------------------------------------
+
+const DTYPE_TAG_F32: &[u8] = b"\x8c\x02f4";
+const DTYPE_TAG_I8: &[u8] = b"\x8c\x02i1";
+
+const SIG_QW8_STRICT: &[u8] = b"\x8c\x08__main__\x94\x8c\x13QuantizedWeight8bit\x94";
+const SIG_QW8_LOOSE_MODULE: &[u8] = b"\x8c\x08__main__";
+const SIG_QW8_CLASS_TAG: &[u8] = b"\x8c\x13QuantizedWeight8bit";
+
+// --- Public API ------------------------------------------------------------
+
+/// Raw tensor record as produced by the byte-grammar scanner. No semantic
+/// classification is applied here; that happens in `inventory::classify`.
+#[derive(Clone, Debug)]
+pub struct RawTensor {
+    pub role: TensorRole,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    /// Absolute byte offset of the raw payload within the shard file.
+    pub offset: u64,
+    pub nbytes: u64,
+}
+
+/// Memory-map `path` and extract every tensor anchor it contains. Returns
+/// the tensors sorted by `offset`. `QuantizedWeight8bit` sites are detected
+/// and the adjacent int8/f32 pair is labeled with the matching
+/// `TensorRole::QuantWeight` / `QuantScales`.
+pub fn dissect_shard(path: &Path) -> Result<Vec<RawTensor>> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    // Safety: the file is not mutated while the mmap is live.
+    let mm = unsafe { Mmap::map(&file) }.with_context(|| format!("mmap {}", path.display()))?;
+    let bytes: &[u8] = &mm;
+
+    if bytes.len() < 2 || bytes[0] != OP_PROTO || bytes[1] != 0x04 {
+        bail!(
+            "not a pickle protocol 4 stream (magic={:02x?})",
+            &bytes[..min(2, bytes.len())]
+        );
+    }
+
+    let mut anchors = find_dtype_anchors(bytes);
+    anchors.sort_by_key(|a| a.tag_pos);
+
+    let mut tensors: Vec<RawTensor> = Vec::with_capacity(anchors.len());
+    for a in &anchors {
+        match extract_tensor(bytes, a) {
+            Ok(t) => tensors.push(t),
+            Err(err) => {
+                // Non-fatal: one bad anchor never aborts a shard.
+                eprintln!("  skip anchor @ {:#x} in {}: {:#}", a.tag_pos, path.display(), err);
+            }
+        }
+    }
+
+    let qw8_sites = find_qw8_sites(bytes);
+    assign_qw8_roles(&mut tensors, &qw8_sites);
+
+    // Stable order for all downstream layers.
+    tensors.sort_by_key(|t| t.offset);
+    Ok(tensors)
+}
+
+// --- Anchor discovery ------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+struct DtypeAnchor {
+    /// Byte index of the `\x8c\x02XX` short_binunicode naming the dtype.
+    tag_pos: usize,
+    /// First byte AFTER the 4-byte tag.
+    after_tag: usize,
+    dtype: TensorDType,
+}
+
+fn find_dtype_anchors(bytes: &[u8]) -> Vec<DtypeAnchor> {
+    let mut out: Vec<DtypeAnchor> = Vec::new();
+    for (tag, dtype) in [
+        (DTYPE_TAG_F32, TensorDType::F32),
+        (DTYPE_TAG_I8, TensorDType::I8),
+    ] {
+        for pos in memmem::find_iter(bytes, tag) {
+            let after = pos + tag.len();
+            if has_dtype_postamble(bytes, after) {
+                out.push(DtypeAnchor { tag_pos: pos, after_tag: after, dtype });
+            }
+        }
+    }
+    out
+}
+
+fn has_dtype_postamble(bytes: &[u8], after_tag: usize) -> bool {
+    let mut i = after_tag;
+    if bytes.get(i) == Some(&OP_MEMOIZE) {
+        i += 1;
+    }
+    bytes.get(i..i + 3) == Some(&[OP_NEWFALSE, OP_NEWTRUE, OP_TUPLE3])
+}
+
+// --- Per-anchor extraction -------------------------------------------------
+
+fn extract_tensor(bytes: &[u8], anchor: &DtypeAnchor) -> Result<RawTensor> {
+    let shape_dims = parse_shape_backward(bytes, anchor.tag_pos)?;
+    let (offset, nbytes) = find_payload_forward(bytes, anchor.after_tag)?;
+    let expected = anchor.dtype.itemsize() as u64
+        * shape_dims.iter().copied().fold(1u64, |a, d| a.saturating_mul(d));
+    if expected != 0 && expected != nbytes {
+        return Err(anyhow!(
+            "shape/payload mismatch: shape={:?} dtype={} nbytes={} expected={}",
+            shape_dims,
+            anchor.dtype.label(),
+            nbytes,
+            expected
+        ));
+    }
+    Ok(RawTensor {
+        role: TensorRole::Tensor,
+        dtype: anchor.dtype,
+        shape: TensorShape::new(shape_dims),
+        offset,
+        nbytes,
+    })
+}
+
+fn parse_shape_backward(bytes: &[u8], tag_pos: usize) -> Result<Vec<u64>> {
+    let mut p = tag_pos;
+
+    // Skip MEMOIZE that may sit directly after STACK_GLOBAL.
+    p = skip_memoize_back(bytes, p);
+
+    if p >= 1 && bytes[p - 1] == OP_STACK_GLOBAL {
+        // Fresh dtype class push: push("numpy") push("dtype") STACK_GLOBAL.
+        p -= 1;
+        p = skip_string_push_back(bytes, p)?; // "dtype"
+        p = skip_string_push_back(bytes, p)?; // "numpy"
+    } else {
+        // Pre-memoized class: single BINGET / LONG_BINGET.
+        p = skip_binget_back(bytes, p)?;
+    }
+
+    p = skip_memoize_back(bytes, p);
+    decode_shape_tuple_backward(bytes, p)
+}
+
+fn skip_memoize_back(bytes: &[u8], p: usize) -> usize {
+    if p >= 1 && bytes[p - 1] == OP_MEMOIZE { p - 1 } else { p }
+}
+
+fn skip_string_push_back(bytes: &[u8], p: usize) -> Result<usize> {
+    let p = skip_memoize_back(bytes, p);
+
+    if p >= 2 && bytes[p - 2] == OP_BINGET {
+        return Ok(p - 2);
+    }
+    if p >= 5 && bytes[p - 5] == OP_LONG_BINGET {
+        return Ok(p - 5);
+    }
+    for len in 1..=32usize {
+        if p < len + 2 {
+            break;
+        }
+        if bytes[p - len - 2] == OP_SHORT_BINUNICODE && bytes[p - len - 1] as usize == len {
+            return Ok(p - len - 2);
+        }
+    }
+    Err(anyhow!("cannot unwind string push ending at {:#x}", p.saturating_sub(1)))
+}
+
+fn skip_binget_back(bytes: &[u8], p: usize) -> Result<usize> {
+    if p >= 2 && bytes[p - 2] == OP_BINGET {
+        return Ok(p - 2);
+    }
+    if p >= 5 && bytes[p - 5] == OP_LONG_BINGET {
+        return Ok(p - 5);
+    }
+    Err(anyhow!(
+        "expected BINGET/LONG_BINGET before dtype tag at {:#x}",
+        p.saturating_sub(1)
+    ))
+}
+
+fn decode_shape_tuple_backward(bytes: &[u8], end_exclusive: usize) -> Result<Vec<u64>> {
+    if end_exclusive == 0 {
+        bail!("no room for shape tuple at offset {:#x}", end_exclusive);
+    }
+    let term = bytes[end_exclusive - 1];
+    match term {
+        OP_EMPTY_TUPLE => Ok(Vec::new()),
+        OP_TUPLE1 => {
+            let (v, _) = read_int_backward(bytes, end_exclusive - 1)?;
+            Ok(vec![v])
+        }
+        OP_TUPLE2 => {
+            let (v1, p1) = read_int_backward(bytes, end_exclusive - 1)?;
+            let (v0, _) = read_int_backward(bytes, p1)?;
+            Ok(vec![v0, v1])
+        }
+        OP_TUPLE3 => {
+            let (v2, p2) = read_int_backward(bytes, end_exclusive - 1)?;
+            let (v1, p1) = read_int_backward(bytes, p2)?;
+            let (v0, _) = read_int_backward(bytes, p1)?;
+            Ok(vec![v0, v1, v2])
+        }
+        OP_TUPLE => {
+            let mut dims = Vec::new();
+            let mut cursor = end_exclusive - 1;
+            loop {
+                if cursor == 0 {
+                    bail!("ran off start walking MARK..TUPLE shape");
+                }
+                if bytes[cursor - 1] == OP_MARK {
+                    dims.reverse();
+                    return Ok(dims);
+                }
+                let (v, next) = read_int_backward(bytes, cursor)?;
+                dims.push(v);
+                cursor = next;
+            }
+        }
+        other => Err(anyhow!(
+            "unexpected shape terminator opcode 0x{:02x} at offset {:#x}",
+            other,
+            end_exclusive - 1
+        )),
+    }
+}
+
+fn read_int_backward(bytes: &[u8], end_exclusive: usize) -> Result<(u64, usize)> {
+    if end_exclusive == 0 {
+        bail!("int parse: empty range");
+    }
+    if end_exclusive >= 5 && bytes[end_exclusive - 5] == OP_BININT {
+        let v = i32::from_le_bytes(bytes[end_exclusive - 4..end_exclusive].try_into().unwrap());
+        if v < 0 {
+            bail!("negative BININT in shape dim");
+        }
+        return Ok((v as u64, end_exclusive - 5));
+    }
+    if end_exclusive >= 3 && bytes[end_exclusive - 3] == OP_BININT2 {
+        let v = u16::from_le_bytes(bytes[end_exclusive - 2..end_exclusive].try_into().unwrap());
+        return Ok((v as u64, end_exclusive - 3));
+    }
+    if end_exclusive >= 2 && bytes[end_exclusive - 2] == OP_BININT1 {
+        return Ok((bytes[end_exclusive - 1] as u64, end_exclusive - 2));
+    }
+    Err(anyhow!("no BININT* opcode ending at offset {:#x}", end_exclusive - 1))
+}
+
+fn find_payload_forward(bytes: &[u8], after_tag: usize) -> Result<(u64, u64)> {
+    let start = after_tag;
+    let stop = min(bytes.len().saturating_sub(1), start + 256);
+    let mut i = start;
+    while i < stop {
+        let b = bytes[i];
+        if (b == OP_NEWTRUE || b == OP_NEWFALSE) && i + 1 < bytes.len() {
+            let opcode = bytes[i + 1];
+            match opcode {
+                OP_SHORT_BINBYTES => {
+                    let hdr = i + 2;
+                    if hdr >= bytes.len() {
+                        bail!("truncated SHORT_BINBYTES at {:#x}", i + 1);
+                    }
+                    let len = bytes[hdr] as u64;
+                    let data = (hdr + 1) as u64;
+                    check_payload_bounds(bytes, data, len)?;
+                    return Ok((data, len));
+                }
+                OP_BINBYTES => {
+                    let hdr = i + 2;
+                    if hdr + 4 > bytes.len() {
+                        bail!("truncated BINBYTES header at {:#x}", i + 1);
+                    }
+                    let len = u32::from_le_bytes(bytes[hdr..hdr + 4].try_into().unwrap()) as u64;
+                    let data = (hdr + 4) as u64;
+                    check_payload_bounds(bytes, data, len)?;
+                    return Ok((data, len));
+                }
+                OP_BINBYTES8 => {
+                    let hdr = i + 2;
+                    if hdr + 8 > bytes.len() {
+                        bail!("truncated BINBYTES8 header at {:#x}", i + 1);
+                    }
+                    let len = u64::from_le_bytes(bytes[hdr..hdr + 8].try_into().unwrap());
+                    let data = (hdr + 8) as u64;
+                    check_payload_bounds(bytes, data, len)?;
+                    return Ok((data, len));
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    bail!(
+        "no fortran+payload marker found within {} bytes of dtype tag @ {:#x}",
+        stop - start,
+        after_tag
+    )
+}
+
+fn check_payload_bounds(bytes: &[u8], data: u64, len: u64) -> Result<()> {
+    if data.saturating_add(len) > bytes.len() as u64 {
+        bail!(
+            "payload {} bytes overruns file (data_off={:#x}, file_len={})",
+            len,
+            data,
+            bytes.len()
+        );
+    }
+    Ok(())
+}
+
+// --- QuantizedWeight8bit grouping -----------------------------------------
+
+fn find_qw8_sites(bytes: &[u8]) -> Vec<usize> {
+    let mut sites: Vec<usize> = memmem::find_iter(bytes, SIG_QW8_STRICT).collect();
+    for pos in memmem::find_iter(bytes, SIG_QW8_LOOSE_MODULE) {
+        let window_end = min(bytes.len(), pos + SIG_QW8_LOOSE_MODULE.len() + 24);
+        if memmem::find(&bytes[pos..window_end], SIG_QW8_CLASS_TAG).is_some()
+            && !sites.contains(&pos)
+        {
+            sites.push(pos);
+        }
+    }
+    sites.sort();
+    sites.dedup();
+    sites
+}
+
+fn assign_qw8_roles(tensors: &mut [RawTensor], sites: &[usize]) {
+    for &site in sites {
+        let site_u64 = site as u64;
+        let mut weight_idx = None;
+        let mut scales_idx = None;
+        for (idx, t) in tensors.iter().enumerate() {
+            if t.offset < site_u64 {
+                continue;
+            }
+            match (t.dtype, weight_idx, scales_idx) {
+                (TensorDType::I8, None, _) => weight_idx = Some(idx),
+                (TensorDType::F32, _, None) => scales_idx = Some(idx),
+                _ => {}
+            }
+            if weight_idx.is_some() && scales_idx.is_some() {
+                break;
+            }
+        }
+        if let Some(i) = weight_idx {
+            tensors[i].role = TensorRole::QuantWeight;
+        }
+        if let Some(i) = scales_idx {
+            tensors[i].role = TensorRole::QuantScales;
+        }
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Export layer: stable serialization of `ModelInventory` to JSON and a
+// human-readable Markdown summary. These two formats are the public
+// integration surface for sibling repositories.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::schema::{BlockSummary, ModelInventory};
+
+/// Write the full inventory as pretty-printed JSON. The JSON layout is the
+/// `ModelInventory` struct rendered via serde; its schema version is carried
+/// in the `schema_version` field.
+pub fn write_json(inv: &ModelInventory, out: &Path) -> Result<()> {
+    let s = serde_json::to_string_pretty(inv).context("serialize inventory to json")?;
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Render a Markdown summary report for humans. Intentionally small and
+/// text-only; no plots, no HTML, no colors.
+pub fn render_markdown(inv: &ModelInventory) -> String {
+    let mut md = String::new();
+
+    let _ = writeln!(md, "# xai-dissect inventory");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "- **model_family**: `{}`", inv.model_family);
+    let _ = writeln!(md, "- **checkpoint**: `{}`", inv.checkpoint_path.display());
+    let _ = writeln!(md, "- **shards**: {}", inv.shard_count);
+    let _ = writeln!(md, "- **schema_version**: {}", inv.schema_version);
+
+    // Inferred hyperparameters.
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Inferred hyperparameters");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Field | Value |");
+    let _ = writeln!(md, "| ----- | ----- |");
+    let hp = &inv.inferred;
+    let _ = writeln!(md, "| vocab_size | {} |", fmt_opt(hp.vocab_size));
+    let _ = writeln!(md, "| d_model | {} |", fmt_opt(hp.d_model));
+    let _ = writeln!(md, "| n_experts | {} |", fmt_opt(hp.n_experts));
+    let _ = writeln!(md, "| d_ff | {} |", fmt_opt(hp.d_ff));
+    let _ = writeln!(md, "| n_blocks | {} |", fmt_opt_u32(hp.n_blocks));
+
+    // Totals.
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Totals");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Metric | Value |");
+    let _ = writeln!(md, "| ------ | ----- |");
+    let t = &inv.totals;
+    let _ = writeln!(md, "| tensors | {} |", t.tensors);
+    let _ = writeln!(md, "| f32 tensors | {} |", t.f32_tensors);
+    let _ = writeln!(md, "| int8 tensors | {} |", t.i8_tensors);
+    let _ = writeln!(md, "| quant tensors | {} |", t.quant_tensors);
+    let _ = writeln!(md, "| total elements | {} |", t.total_elements);
+    let _ = writeln!(md, "| total bytes | {} ({}) |", t.total_nbytes, human_bytes(t.total_nbytes));
+
+    // Kind breakdown (across the whole inventory).
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Tensor kinds");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Kind | Count | Bytes |");
+    let _ = writeln!(md, "| ---- | ----: | ----: |");
+    let mut agg: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    for ti in &inv.tensors {
+        let e = agg.entry(ti.kind.short_label()).or_insert((0, 0));
+        e.0 += 1;
+        e.1 += ti.nbytes;
+    }
+    for (k, (c, n)) in &agg {
+        let _ = writeln!(md, "| {} | {} | {} ({}) |", k, c, n, human_bytes(*n));
+    }
+
+    // Block summary table (compact).
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Blocks");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Label | Block | Shards | Tensors | Bytes | Kinds |");
+    let _ = writeln!(md, "| ----- | ----: | ------ | ------: | ----: | ----- |");
+    for b in &inv.blocks {
+        let shards = match b.shard_range {
+            Some(r) => format!("{}..={}", r.start, r.end_inclusive),
+            None => "-".to_string(),
+        };
+        let kinds = render_kinds(b);
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} | {} ({}) | {} |",
+            b.label,
+            fmt_opt_u32(b.block_index),
+            shards,
+            b.tensor_count,
+            b.total_nbytes,
+            human_bytes(b.total_nbytes),
+            kinds
+        );
+    }
+
+    // Exemplar block: dump the tensors of the first block-indexed summary
+    // so the reader can see the per-block layout at a glance.
+    if let Some(exemplar) = inv.blocks.iter().find(|b| b.block_index == Some(0)) {
+        let _ = writeln!(md);
+        let _ = writeln!(md, "## Exemplar block (`{}`)", exemplar.label);
+        let _ = writeln!(md);
+        let _ = writeln!(md, "| Shard | In-shard | Role | Dtype | Shape | Kind | Slot |");
+        let _ = writeln!(md, "| ----: | -------: | ---- | ----- | ----- | ---- | ---: |");
+        for ti in inv.tensors.iter().filter(|t| t.block_index == Some(0)) {
+            let _ = writeln!(
+                md,
+                "| {} | {} | {} | {} | `{}` | {} | {} |",
+                ti.shard_ordinal,
+                ti.in_shard_index,
+                ti.role.label(),
+                ti.dtype.label(),
+                ti.shape.render(),
+                ti.kind.short_label(),
+                fmt_opt_u32(ti.block_slot),
+            );
+        }
+    }
+
+    md
+}
+
+/// Write the Markdown summary to `out`.
+pub fn write_markdown(inv: &ModelInventory, out: &Path) -> Result<()> {
+    let s = render_markdown(inv);
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+fn render_kinds(b: &BlockSummary) -> String {
+    if b.kinds.is_empty() {
+        return "-".to_string();
+    }
+    b.kinds
+        .iter()
+        .map(|k| format!("{}x{}", k.count, k.kind_label))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn fmt_opt(v: Option<u64>) -> String {
+    match v {
+        Some(x) => x.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+fn fmt_opt_u32(v: Option<u32>) -> String {
+    match v {
+        Some(x) => x.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+fn human_bytes(n: u64) -> String {
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut v = n as f64;
+    let mut u = 0usize;
+    while v >= 1024.0 && u + 1 < UNITS.len() {
+        v /= 1024.0;
+        u += 1;
+    }
+    if u == 0 {
+        format!("{} {}", n, UNITS[0])
+    } else {
+        format!("{:.2} {}", v, UNITS[u])
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Core schema types used across the parser, inventory, analysis, and export
+// layers. Any type that is serialized to an export artifact (JSON / CSV /
+// Markdown) must live here, must derive `Serialize`, and must be stable
+// across patch releases.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Numpy-style dtype of a tensor as it lives on disk. The set is intentionally
+/// narrow: Grok-1 shards only contain `float32` and `int8`. New dtypes are
+/// added only when a supported checkpoint actually requires them.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TensorDType {
+    F32,
+    I8,
+}
+
+impl TensorDType {
+    pub fn itemsize(self) -> usize {
+        match self {
+            TensorDType::F32 => 4,
+            TensorDType::I8 => 1,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            TensorDType::F32 => "f32",
+            TensorDType::I8 => "int8",
+        }
+    }
+}
+
+/// Row-major tensor shape. Dimensions are stored left-to-right exactly as
+/// they appear in the on-disk shape tuple.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(transparent)]
+pub struct TensorShape(pub Vec<u64>);
+
+impl TensorShape {
+    pub fn new(dims: Vec<u64>) -> Self {
+        Self(dims)
+    }
+
+    pub fn dims(&self) -> &[u64] {
+        &self.0
+    }
+
+    pub fn rank(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn numel(&self) -> u64 {
+        self.0.iter().copied().fold(1u64, |acc, d| acc.saturating_mul(d))
+    }
+
+    pub fn is_empty_tuple(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn render(&self) -> String {
+        match self.0.len() {
+            0 => "()".to_string(),
+            1 => format!("({},)", self.0[0]),
+            _ => format!(
+                "({})",
+                self.0.iter().map(|d| d.to_string()).collect::<Vec<_>>().join(", ")
+            ),
+        }
+    }
+}
+
+/// Parser-level tag: how a tensor appears inside a pickle shard. Orthogonal
+/// to semantic classification (`TensorKind`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TensorRole {
+    /// A bare `numpy.ndarray` reduced into the pickle stream.
+    Tensor,
+    /// The int8 weight half of a `QuantizedWeight8bit` dataclass.
+    QuantWeight,
+    /// The f32 scales half of a `QuantizedWeight8bit` dataclass.
+    QuantScales,
+}
+
+impl TensorRole {
+    pub fn label(self) -> &'static str {
+        match self {
+            TensorRole::Tensor => "tensor",
+            TensorRole::QuantWeight => "quant.weight",
+            TensorRole::QuantScales => "quant.scales",
+        }
+    }
+}
+
+/// Semantic classification inferred from shape, dtype, and position.
+/// This is a *heuristic* assignment. It is stable for well-formed Grok-1
+/// checkpoints and falls back to `Unknown` elsewhere. See
+/// `docs/tensor-schema.md` for the rules.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "detail")]
+pub enum TensorKind {
+    /// Token embedding table, shape `(vocab_size, d_model)`.
+    TokenEmbedding,
+    /// Final pre-head RMSNorm (or equivalent), shape `(d_model,)`.
+    FinalNorm,
+    /// Per-block RMSNorm, shape `(d_model,)`. Position within the block is
+    /// tracked by `TensorInfo::block_slot`.
+    BlockNorm,
+    /// MoE router / gate table, shape `(d_model, n_experts)`.
+    Router,
+    /// One of the MoE expert feed-forward projections, quantized. The
+    /// specific projection (`up` / `gate` / `down`) cannot always be
+    /// distinguished by shape alone; when it cannot, the projection is
+    /// reported as `Unresolved`.
+    MoeExpertProjection { projection: MoeProjection },
+    /// Companion f32 scales tensor for an MoE expert projection (where it
+    /// lives outside the `QuantizedWeight8bit` envelope).
+    MoeScales,
+    /// Attention projection stored directly as f32 (not quantized). Exact
+    /// role (q / k / v / out) is not determined at cartography time.
+    AttnProjF32,
+    /// Weight tensor that does not fit any of the above signatures.
+    Unknown { reason: String },
+}
+
+impl TensorKind {
+    pub fn short_label(&self) -> String {
+        match self {
+            TensorKind::TokenEmbedding => "token_embedding".into(),
+            TensorKind::FinalNorm => "final_norm".into(),
+            TensorKind::BlockNorm => "block_norm".into(),
+            TensorKind::Router => "router".into(),
+            TensorKind::MoeExpertProjection { projection } => {
+                format!("moe_expert.{}", projection.label())
+            }
+            TensorKind::MoeScales => "moe_scales".into(),
+            TensorKind::AttnProjF32 => "attn_proj_f32".into(),
+            TensorKind::Unknown { .. } => "unknown".into(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MoeProjection {
+    Up,
+    Gate,
+    Down,
+    /// Gate/up cannot be told apart by shape alone on Grok-1; both have the
+    /// same `(n_experts, d_model, d_ff)` signature. The inventory layer
+    /// emits `Unresolved` for those and leaves disambiguation to a later
+    /// analysis pass that inspects ordering within a block.
+    Unresolved,
+}
+
+impl MoeProjection {
+    pub fn label(self) -> &'static str {
+        match self {
+            MoeProjection::Up => "up",
+            MoeProjection::Gate => "gate",
+            MoeProjection::Down => "down",
+            MoeProjection::Unresolved => "unresolved",
+        }
+    }
+}
+
+/// A single tensor as it appears in a shard, plus all metadata needed for
+/// downstream analyzers. One shard may produce one or two `TensorInfo`
+/// records (two for `QuantizedWeight8bit`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TensorInfo {
+    /// Absolute path of the shard file on disk.
+    pub shard_path: PathBuf,
+    /// 0-based ordinal of the shard in the checkpoint's sorted shard list.
+    pub shard_ordinal: u32,
+    /// 0-based index within the shard (in the order tensors were found).
+    pub in_shard_index: u32,
+    pub role: TensorRole,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    /// Byte offset of the raw payload within the shard file.
+    pub offset: u64,
+    /// Payload length in bytes.
+    pub nbytes: u64,
+    /// Inferred semantic classification.
+    pub kind: TensorKind,
+    /// Inferred block (transformer layer) index, if assignable.
+    pub block_index: Option<u32>,
+    /// Position within the block's shard ordering, if assignable.
+    /// Useful for disambiguating multiple tensors of the same kind inside
+    /// one block (e.g. the two `AttnProjF32` tensors per layer).
+    pub block_slot: Option<u32>,
+}
+
+/// Aggregate summary of one transformer block (or the non-block singletons:
+/// the embedding and the final norm).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockSummary {
+    /// `None` for the embedding and the final norm; `Some(i)` for block `i`.
+    pub block_index: Option<u32>,
+    pub label: String,
+    /// Shard ordinals in this block.
+    pub shard_range: Option<ShardRange>,
+    pub tensor_count: u32,
+    pub total_nbytes: u64,
+    pub dtypes: Vec<TensorDType>,
+    pub kinds: Vec<KindCount>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct ShardRange {
+    pub start: u32,
+    pub end_inclusive: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KindCount {
+    pub kind_label: String,
+    pub count: u32,
+    pub nbytes: u64,
+}
+
+/// Top-level, serializable inventory of a checkpoint directory. The JSON
+/// form of this struct is the stable export contract consumed by sibling
+/// repos.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ModelInventory {
+    /// Short identifier of the target family. Currently only `"grok-1"` is
+    /// emitted; `"grok-2"` is reserved for a future release.
+    pub model_family: String,
+    /// Absolute path of the checkpoint directory that was scanned.
+    pub checkpoint_path: PathBuf,
+    /// Total number of shard files inspected.
+    pub shard_count: u32,
+    /// Hyperparameters inferred from the inventory itself.
+    pub inferred: InferredHyperparams,
+    pub tensors: Vec<TensorInfo>,
+    pub blocks: Vec<BlockSummary>,
+    pub totals: InventoryTotals,
+    /// Schema version. Bump on incompatible export changes.
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct InferredHyperparams {
+    pub vocab_size: Option<u64>,
+    pub d_model: Option<u64>,
+    pub n_experts: Option<u64>,
+    pub d_ff: Option<u64>,
+    pub n_blocks: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct InventoryTotals {
+    pub tensors: u64,
+    pub quant_tensors: u64,
+    pub f32_tensors: u64,
+    pub i8_tensors: u64,
+    pub total_nbytes: u64,
+    pub total_elements: u64,
+}


### PR DESCRIPTION
Builds the first usable cartography layer on top of the existing pickle scanner. Produces a machine-readable and human-readable inventory of a Grok-1 checkpoint without reading any tensor bodies. Also folds in the empirical `ckpt-0` shard survey (previously drafted as #7, now closed).

## Commits

1. **`feat(inventory): add cartography layer`** — schema, parser, inventory, report, CLI.
2. **`docs: add Observed: Grok-1 ckpt-0 shard survey`** — `docs/observed-grok1-ckpt0.md`.

## What changes

### Crate layout
- `xai-dissect` becomes a library + binary. `src/lib.rs` exposes `schema`, `parser`, `inventory`, `report`. `src/main.rs` is a thin CLI.

### CLI
Two subcommands (clap):
- `dissect <path>` — preserved legacy per-shard byte table.
- `inventory <path> [--json <out>] [--md <out>] [--prefix tensor] [--limit N] [--family grok-1]` — full checkpoint cartography.

`cargo run --release -- inventory <ckpt-dir>` prints a Markdown summary to stdout. Add `--json` and/or `--md` to write exportable artifacts.

### New modules

- **`src/schema/`** — core serde types. `TensorDType`, `TensorShape`, `TensorRole`, `TensorKind` (`token_embedding` / `final_norm` / `block_norm` / `router` / `moe_expert_projection{up|gate|down|unresolved}` / `moe_scales` / `attn_proj_f32` / `unknown{reason}`), `TensorInfo`, `BlockSummary`, `ShardRange`, `KindCount`, `InferredHyperparams`, `InventoryTotals`, `ModelInventory` (with `schema_version = 1`).
- **`src/parser/`** — existing Pickle Protocol 4 byte-grammar scanner, moved out of `main.rs` unchanged in behavior, rebased on schema types. Public entry: `parser::dissect_shard(path) -> Vec<RawTensor>`.
- **`src/inventory/`** — walks the checkpoint, drives the parser, infers `(vocab_size, d_model, n_experts, d_ff)` from the inventory itself, classifies every tensor by shape + role, and groups by transformer block. Uses the Grok-1 shard-layout model (`K = 12` shards per block) to assign `block_index` / `block_slot` and promote the tail `block_norm` to `final_norm`. Layout-mismatch falls back to unassigned rather than guessing.
- **`src/report/`** — pretty JSON export (stable schema) and a human-readable Markdown summary (header, inferred hyperparams, totals, per-kind breakdown, per-block table, exemplar block dump).

### Docs
- **`docs/tensor-schema.md`** — full schema reference, two-pass hyperparameter inference, per-rule classification table, block assignment formula, and explicit non-inferences (up vs gate ambiguity, attention head geometry, numerical properties).
- **`docs/observed-grok1-ckpt0.md`** — empirical shard-size histogram and per-bucket architectural mapping for the official xAI Grok-1 `ckpt-0` release. Corrected 8-row histogram reconciles exactly to 770 shards (`1 + 128 + 64 + 64 + 64 + 128 + 64 + 257`); per-bucket interpretation pinned to 64 layers × 8 experts × `d_model=6144` × `d_ff=32768`; `--limit 1` single-shard walkthrough plus the full `inventory` invocation.

## Design choices / constraints honored

- Grok-1 first. Grok-2 not promised; schema is designed to absorb it additively (`model_family` tag, new `TensorKind` variants, new block-layout entry, `schema_version` bump).
- Parser / inventory / analysis are separated. This PR adds the first two layers. No routing math, no dequantization, no numerical analysis.
- Classification is shape-based and conservative. Ambiguous cases (up vs gate on Grok-1) are reported as `Unresolved` and deferred to a later pass, not silently guessed.
- Tensor bodies are never read. Everything is metadata over `mmap`'d shards.
- JSON export (`ModelInventory`) is the stable contract; the in-process API is not yet frozen.

## Verification

- `cargo check --all-targets` — clean.
- `cargo build --release` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `./target/release/xai-dissect --help` and both subcommand `--help` outputs verified.
- `./target/release/xai-dissect inventory /tmp/empty-dir` returns the expected "no shards found" error.
- End-to-end run against a real Grok-1 `ckpt-0` is not executed here (requires 297 GiB of weights); the pickle scanner and block-assignment math are unchanged from already-validated behavior and the new classification rules are pure functions of `(shape, dtype, role)`.

## Follow-ups (not this PR)

- Integration tests with synthetic mini-shards.
- Resolve `MoeProjection::Unresolved` (up vs gate) via within-block ordering once we fingerprint the Grok-1 dumper's traversal order.
- Richer attention classification (`AttnProjF32` -> q / k / v / out) once we have a reliable cue.
- `stats.csv` export and per-expert parameter accounting (separate layer).
