### PR TITLE
[codex] Add Grok-1 expert atlas analysis

### DIFF
--- a/src/experts/mod.rs
+++ b/src/experts/mod.rs
@@ -1,0 +1,713 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Expert-level structural analysis derived from `ModelInventory`. This layer
+// maps block-local MoE tensor families, associates each family with every
+// expert index, and reports missing or irregular layout patterns.
+
+use std::collections::BTreeMap;
+
+use crate::schema::{
+    ExpertAtlas, ExpertBlock, ExpertIssue, ExpertIssueCategory, ExpertIssueSeverity,
+    ExpertNamingCheck, ExpertNamingPattern, ExpertSlice, ExpertSliceTensor, ExpertTensorRef,
+    InferredHyperparams, ModelInventory, MoeProjection, ShardRange, TensorDType, TensorInfo,
+    TensorKind, TensorRole, TensorShape,
+};
+
+pub const EXPERT_ATLAS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone)]
+struct Candidate<'a> {
+    tensor: &'a TensorInfo,
+    projection: MoeProjection,
+    expert_count: Option<u64>,
+    family_label: String,
+    structural_name: String,
+}
+
+/// Build an expert atlas from an inventory. This pass never touches tensor
+/// bodies; it operates solely on the normalized inventory records.
+pub fn build_expert_atlas(inv: &ModelInventory) -> ExpertAtlas {
+    let mut by_block: BTreeMap<u32, Vec<&TensorInfo>> = BTreeMap::new();
+    for tensor in &inv.tensors {
+        if let Some(block_index) = tensor.block_index {
+            by_block.entry(block_index).or_default().push(tensor);
+        }
+    }
+
+    let mut blocks: Vec<ExpertBlock> = Vec::new();
+    let mut anomalies: Vec<ExpertIssue> = Vec::new();
+
+    for (block_index, mut members) in by_block {
+        members.sort_by_key(|t| {
+            (
+                t.block_slot.unwrap_or(u32::MAX),
+                t.shard_ordinal,
+                t.in_shard_index,
+            )
+        });
+        let candidates = expert_candidates(
+            block_index,
+            &members,
+            inv.inferred.n_experts,
+            inv.inferred.d_model,
+        );
+        let block_expert_count = block_expert_count(block_index, &candidates, &mut anomalies);
+
+        if candidates.is_empty() {
+            anomalies.push(ExpertIssue {
+                severity: ExpertIssueSeverity::Error,
+                category: ExpertIssueCategory::MissingOrIrregularTensor,
+                block_index: Some(block_index),
+                tensor: None,
+                message: "no expert-stacked tensors detected in this block".to_string(),
+            });
+        }
+
+        let slots: Vec<u32> = candidates
+            .iter()
+            .filter_map(|c| c.tensor.block_slot)
+            .collect();
+        if !slots.is_empty() && !is_contiguous(&slots) {
+            anomalies.push(ExpertIssue {
+                severity: ExpertIssueSeverity::Warning,
+                category: ExpertIssueCategory::LayoutAnomaly,
+                block_index: Some(block_index),
+                tensor: None,
+                message: format!("expert tensor slots are not contiguous: {:?}", slots),
+            });
+        }
+
+        let tensors = candidates
+            .iter()
+            .map(|candidate| ExpertTensorRef {
+                shard_ordinal: candidate.tensor.shard_ordinal,
+                in_shard_index: candidate.tensor.in_shard_index,
+                block_slot: candidate.tensor.block_slot,
+                role: candidate.tensor.role,
+                dtype: candidate.tensor.dtype,
+                shape: candidate.tensor.shape.clone(),
+                kind_label: candidate.tensor.kind.short_label(),
+                projection: candidate.projection,
+                expert_axis: candidate.expert_count.map(|_| 0),
+                expert_count: candidate.expert_count,
+                family_label: candidate.family_label.clone(),
+                structural_name: candidate.structural_name.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let experts = build_expert_slices(block_index, block_expert_count, &candidates);
+
+        blocks.push(ExpertBlock {
+            block_index,
+            shard_range: shard_range(&members),
+            expert_count: block_expert_count,
+            tensors,
+            experts,
+        });
+    }
+
+    let expected_experts_per_block =
+        mode_u64(blocks.iter().filter_map(|b| b.expert_count).collect());
+    let canonical_layout = canonical_layout_signature(&blocks);
+
+    for block in &blocks {
+        if let Some(expected) = expected_experts_per_block {
+            if block.expert_count != Some(expected) {
+                anomalies.push(ExpertIssue {
+                    severity: ExpertIssueSeverity::Warning,
+                    category: ExpertIssueCategory::NamingConsistency,
+                    block_index: Some(block.block_index),
+                    tensor: None,
+                    message: format!(
+                        "expert count {:?} does not match checkpoint-wide expectation {}",
+                        block.expert_count, expected
+                    ),
+                });
+            }
+        }
+
+        if let Some(expected_layout) = canonical_layout.as_ref() {
+            let layout = layout_signature(block);
+            if &layout != expected_layout {
+                anomalies.push(ExpertIssue {
+                    severity: ExpertIssueSeverity::Warning,
+                    category: ExpertIssueCategory::LayoutAnomaly,
+                    block_index: Some(block.block_index),
+                    tensor: None,
+                    message: format!("expert layout differs from canonical pattern: {:?}", layout),
+                });
+            }
+        }
+    }
+
+    let naming_patterns = build_naming_patterns(&blocks);
+    let naming_checks = build_naming_checks(&blocks, expected_experts_per_block, canonical_layout);
+
+    ExpertAtlas {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        shard_count: inv.shard_count,
+        inferred: InferredHyperparams {
+            vocab_size: inv.inferred.vocab_size,
+            d_model: inv.inferred.d_model,
+            n_experts: inv.inferred.n_experts,
+            d_ff: inv.inferred.d_ff,
+            n_blocks: inv.inferred.n_blocks,
+        },
+        relevant_block_count: blocks.len() as u32,
+        expected_experts_per_block,
+        blocks,
+        naming_patterns,
+        naming_checks,
+        anomalies,
+        schema_version: EXPERT_ATLAS_SCHEMA_VERSION,
+    }
+}
+
+fn expert_candidates<'a>(
+    block_index: u32,
+    members: &[&'a TensorInfo],
+    expected_experts: Option<u64>,
+    d_model: Option<u64>,
+) -> Vec<Candidate<'a>> {
+    let mut candidates = Vec::new();
+    let mut ordinal = 0u32;
+
+    for tensor in members {
+        let Some(projection) = infer_expert_projection(tensor, expected_experts, d_model) else {
+            continue;
+        };
+        let expert_count = tensor.shape.dims().first().copied();
+        let family_label = match tensor.block_slot {
+            Some(slot) => format!("expert_slot_{slot:02}"),
+            None => {
+                let label = format!("expert_tensor_{ordinal:02}");
+                ordinal += 1;
+                label
+            }
+        };
+        let structural_name = format!("block_{block_index:03}.{}", family_label);
+        candidates.push(Candidate {
+            tensor,
+            projection,
+            expert_count,
+            family_label,
+            structural_name,
+        });
+    }
+
+    candidates
+}
+
+fn infer_expert_projection(
+    tensor: &TensorInfo,
+    expected_experts: Option<u64>,
+    d_model: Option<u64>,
+) -> Option<MoeProjection> {
+    match &tensor.kind {
+        TensorKind::MoeExpertProjection { projection } => return Some(*projection),
+        TensorKind::MoeScales => {
+            if tensor.shape.dims().first().copied() == expected_experts {
+                return Some(MoeProjection::Unresolved);
+            }
+        }
+        _ => {}
+    }
+
+    if tensor.role != TensorRole::QuantWeight {
+        return None;
+    }
+    if tensor.dtype != TensorDType::I8 {
+        return None;
+    }
+    if tensor.shape.rank() != 3 {
+        return None;
+    }
+
+    let dims = tensor.shape.dims();
+    if let Some(expected) = expected_experts {
+        if dims[0] != expected {
+            return None;
+        }
+    }
+
+    if let Some(dm) = d_model {
+        if dims[2] == dm {
+            return Some(MoeProjection::Down);
+        }
+        if dims[1] == dm {
+            return Some(MoeProjection::Unresolved);
+        }
+    }
+
+    Some(MoeProjection::Unresolved)
+}
+
+fn block_expert_count(
+    block_index: u32,
+    candidates: &[Candidate<'_>],
+    anomalies: &mut Vec<ExpertIssue>,
+) -> Option<u64> {
+    let counts = candidates
+        .iter()
+        .filter_map(|c| c.expert_count)
+        .collect::<Vec<_>>();
+    let expected = mode_u64(counts.clone());
+
+    if counts.is_empty() {
+        return None;
+    }
+
+    if counts.iter().any(|count| Some(*count) != expected) {
+        anomalies.push(ExpertIssue {
+            severity: ExpertIssueSeverity::Warning,
+            category: ExpertIssueCategory::MissingOrIrregularTensor,
+            block_index: Some(block_index),
+            tensor: None,
+            message: format!("expert tensors disagree on expert count: {:?}", counts),
+        });
+    }
+
+    expected
+}
+
+fn build_expert_slices(
+    block_index: u32,
+    expert_count: Option<u64>,
+    candidates: &[Candidate<'_>],
+) -> Vec<ExpertSlice> {
+    let Some(expert_count) = expert_count else {
+        return Vec::new();
+    };
+
+    let mut experts = Vec::new();
+    for expert_index in 0..expert_count {
+        let tensors = candidates
+            .iter()
+            .filter(|candidate| candidate.expert_count == Some(expert_count))
+            .map(|candidate| ExpertSliceTensor {
+                family_label: candidate.family_label.clone(),
+                structural_name: format!(
+                    "block_{block_index:03}.{}.expert_{expert_index:02}",
+                    candidate.family_label
+                ),
+                source_shard_ordinal: candidate.tensor.shard_ordinal,
+                source_in_shard_index: candidate.tensor.in_shard_index,
+                source_block_slot: candidate.tensor.block_slot,
+                projection: candidate.projection,
+                dtype: candidate.tensor.dtype,
+                slice_shape: TensorShape::new(candidate.tensor.shape.dims()[1..].to_vec()),
+            })
+            .collect::<Vec<_>>();
+
+        experts.push(ExpertSlice {
+            expert_index: expert_index as u32,
+            tensors,
+        });
+    }
+
+    experts
+}
+
+fn shard_range(members: &[&TensorInfo]) -> Option<ShardRange> {
+    if members.is_empty() {
+        return None;
+    }
+    let mut start = u32::MAX;
+    let mut end_inclusive = 0u32;
+    for tensor in members {
+        start = start.min(tensor.shard_ordinal);
+        end_inclusive = end_inclusive.max(tensor.shard_ordinal);
+    }
+    Some(ShardRange {
+        start,
+        end_inclusive,
+    })
+}
+
+fn is_contiguous(values: &[u32]) -> bool {
+    values
+        .windows(2)
+        .all(|window| window[1] == window[0].saturating_add(1))
+}
+
+fn canonical_layout_signature(blocks: &[ExpertBlock]) -> Option<Vec<String>> {
+    let signatures = blocks.iter().map(layout_signature).collect::<Vec<_>>();
+    mode_vec_string(signatures)
+}
+
+fn layout_signature(block: &ExpertBlock) -> Vec<String> {
+    block
+        .tensors
+        .iter()
+        .map(|tensor| {
+            format!(
+                "{}|{}|{}|{}",
+                tensor.family_label,
+                tensor.projection.label(),
+                tensor.dtype.label(),
+                tensor.shape.render()
+            )
+        })
+        .collect()
+}
+
+fn build_naming_patterns(blocks: &[ExpertBlock]) -> Vec<ExpertNamingPattern> {
+    #[derive(Default)]
+    struct PatternAcc {
+        projection: Option<MoeProjection>,
+        block_slots: Vec<u32>,
+        shapes: Vec<TensorShape>,
+        blocks: u32,
+    }
+
+    let mut patterns: BTreeMap<String, PatternAcc> = BTreeMap::new();
+    for block in blocks {
+        let mut seen_in_block: Vec<String> = Vec::new();
+        for tensor in &block.tensors {
+            let entry = patterns.entry(tensor.family_label.clone()).or_default();
+            entry.projection.get_or_insert(tensor.projection);
+            if let Some(slot) = tensor.block_slot {
+                if !entry.block_slots.contains(&slot) {
+                    entry.block_slots.push(slot);
+                }
+            }
+            if !entry.shapes.contains(&tensor.shape) {
+                entry.shapes.push(tensor.shape.clone());
+            }
+            if !seen_in_block.contains(&tensor.family_label) {
+                entry.blocks += 1;
+                seen_in_block.push(tensor.family_label.clone());
+            }
+        }
+    }
+
+    patterns
+        .into_iter()
+        .map(|(family_label, mut acc)| {
+            acc.block_slots.sort_unstable();
+            ExpertNamingPattern {
+                pattern: format!("block_{{block}}.{}.expert_{{expert}}", family_label),
+                family_label,
+                projection: acc.projection.unwrap_or(MoeProjection::Unresolved),
+                block_slots: acc.block_slots,
+                observed_shapes: acc.shapes,
+                observed_blocks: acc.blocks,
+            }
+        })
+        .collect()
+}
+
+fn build_naming_checks(
+    blocks: &[ExpertBlock],
+    expected_experts_per_block: Option<u64>,
+    canonical_layout: Option<Vec<String>>,
+) -> Vec<ExpertNamingCheck> {
+    let family_counts = blocks
+        .iter()
+        .map(|b| b.tensors.len() as u64)
+        .collect::<Vec<_>>();
+    let expected_family_count = mode_u64(family_counts.clone());
+
+    let expert_count_consistent = expected_experts_per_block.is_some()
+        && blocks
+            .iter()
+            .all(|block| block.expert_count == expected_experts_per_block);
+    let family_count_consistent = expected_family_count.is_some()
+        && family_counts
+            .iter()
+            .all(|count| Some(*count) == expected_family_count);
+    let layout_consistent = if let Some(canonical) = canonical_layout.as_ref() {
+        blocks
+            .iter()
+            .all(|block| layout_signature(block) == *canonical)
+    } else {
+        false
+    };
+
+    vec![
+        ExpertNamingCheck {
+            check: "expert_blocks_present".to_string(),
+            passed: !blocks.is_empty(),
+            detail: if blocks.is_empty() {
+                "no block-local expert tensors were discovered".to_string()
+            } else {
+                format!("discovered expert tensors in {} blocks", blocks.len())
+            },
+        },
+        ExpertNamingCheck {
+            check: "expert_count_consistent".to_string(),
+            passed: expert_count_consistent,
+            detail: match expected_experts_per_block {
+                Some(expected) => format!("expected {} experts per block", expected),
+                None => "could not derive a checkpoint-wide expert count".to_string(),
+            },
+        },
+        ExpertNamingCheck {
+            check: "expert_family_count_consistent".to_string(),
+            passed: family_count_consistent,
+            detail: match expected_family_count {
+                Some(expected) => format!("expected {} expert tensor families per block", expected),
+                None => "could not derive a canonical expert-family count".to_string(),
+            },
+        },
+        ExpertNamingCheck {
+            check: "expert_layout_pattern_consistent".to_string(),
+            passed: layout_consistent,
+            detail: canonical_layout
+                .map(|layout| format!("canonical inferred pattern: {:?}", layout))
+                .unwrap_or_else(|| "could not derive a canonical expert layout".to_string()),
+        },
+    ]
+}
+
+fn mode_u64(values: Vec<u64>) -> Option<u64> {
+    let mut counts: BTreeMap<u64, usize> = BTreeMap::new();
+    for value in values {
+        *counts.entry(value).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(value, count)| (*count, *value))
+        .map(|(value, _)| value)
+}
+
+fn mode_vec_string(values: Vec<Vec<String>>) -> Option<Vec<String>> {
+    let mut counts: BTreeMap<Vec<String>, usize> = BTreeMap::new();
+    for value in values {
+        *counts.entry(value).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(value, count)| (*count, value.len()))
+        .map(|(value, _)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::schema::{
+        InferredHyperparams, InventoryTotals, ModelInventory, TensorDType, TensorInfo, TensorKind,
+        TensorRole, TensorShape,
+    };
+
+    use super::build_expert_atlas;
+
+    #[test]
+    fn atlas_discovers_expert_blocks_and_slices() {
+        let inv = inventory_with_blocks(vec![
+            block(
+                0,
+                vec![
+                    tensor(
+                        1,
+                        0,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                    tensor(
+                        2,
+                        1,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 32768, 6144],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Down,
+                        },
+                    ),
+                    tensor(
+                        3,
+                        2,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                ],
+            ),
+            block(
+                1,
+                vec![
+                    tensor(
+                        13,
+                        0,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                    tensor(
+                        14,
+                        1,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 32768, 6144],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Down,
+                        },
+                    ),
+                    tensor(
+                        15,
+                        2,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                ],
+            ),
+        ]);
+
+        let atlas = build_expert_atlas(&inv);
+
+        assert_eq!(atlas.relevant_block_count, 2);
+        assert_eq!(atlas.expected_experts_per_block, Some(8));
+        assert!(atlas.anomalies.is_empty());
+        assert_eq!(atlas.blocks[0].experts.len(), 8);
+        assert_eq!(atlas.blocks[0].experts[0].tensors.len(), 3);
+        assert!(atlas.naming_checks.iter().all(|check| check.passed));
+    }
+
+    #[test]
+    fn atlas_flags_missing_expert_family() {
+        let inv = inventory_with_blocks(vec![
+            block(
+                0,
+                vec![
+                    tensor(
+                        1,
+                        0,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                    tensor(
+                        2,
+                        1,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 32768, 6144],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Down,
+                        },
+                    ),
+                    tensor(
+                        3,
+                        2,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                ],
+            ),
+            block(
+                1,
+                vec![
+                    tensor(
+                        13,
+                        0,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6144, 32768],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Unresolved,
+                        },
+                    ),
+                    tensor(
+                        14,
+                        1,
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 32768, 6144],
+                        TensorKind::MoeExpertProjection {
+                            projection: crate::schema::MoeProjection::Down,
+                        },
+                    ),
+                ],
+            ),
+        ]);
+
+        let atlas = build_expert_atlas(&inv);
+
+        assert!(atlas
+            .anomalies
+            .iter()
+            .any(|issue| issue.message.contains("canonical pattern")));
+        assert!(atlas
+            .naming_checks
+            .iter()
+            .any(|check| check.check == "expert_family_count_consistent" && !check.passed));
+    }
+
+    fn inventory_with_blocks(blocks: Vec<Vec<TensorInfo>>) -> ModelInventory {
+        let tensors = blocks.into_iter().flatten().collect::<Vec<_>>();
+        ModelInventory {
+            model_family: "grok-1".to_string(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1"),
+            shard_count: tensors.len() as u32,
+            inferred: InferredHyperparams {
+                vocab_size: Some(131072),
+                d_model: Some(6144),
+                n_experts: Some(8),
+                d_ff: Some(32768),
+                n_blocks: Some(2),
+            },
+            tensors,
+            blocks: Vec::new(),
+            totals: InventoryTotals::default(),
+            schema_version: 1,
+        }
+    }
+
+    fn block(block_index: u32, tensors: Vec<TensorInfo>) -> Vec<TensorInfo> {
+        tensors
+            .into_iter()
+            .enumerate()
+            .map(|(slot, mut tensor)| {
+                tensor.block_index = Some(block_index);
+                tensor.block_slot = Some(slot as u32);
+                tensor
+            })
+            .collect()
+    }
+
+    fn tensor(
+        shard_ordinal: u32,
+        in_shard_index: u32,
+        role: TensorRole,
+        dtype: TensorDType,
+        shape: Vec<u64>,
+        kind: TensorKind,
+    ) -> TensorInfo {
+        TensorInfo {
+            shard_path: PathBuf::from(format!("/tmp/tensor{shard_ordinal:05}_000")),
+            shard_ordinal,
+            in_shard_index,
+            role,
+            dtype,
+            shape: TensorShape::new(shape),
+            offset: 0,
+            nbytes: 0,
+            kind,
+            block_index: None,
+            block_slot: None,
+        }
+    }
+}

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 
 use crate::parser::{self, RawTensor};
 use crate::schema::{
@@ -49,8 +49,7 @@ impl Default for InventoryConfig {
 
 /// Build a full `ModelInventory` for the checkpoint directory at `path`.
 pub fn build_inventory(path: &Path, cfg: &InventoryConfig) -> Result<ModelInventory> {
-    let md = std::fs::metadata(path)
-        .with_context(|| format!("stat {}", path.display()))?;
+    let md = std::fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
     if !md.is_dir() {
         bail!("{} is not a directory", path.display());
     }
@@ -81,8 +80,7 @@ pub fn build_inventory(path: &Path, cfg: &InventoryConfig) -> Result<ModelInvent
 
     // Pass 3: classify each raw tensor into a TensorKind.
     let mut tensors: Vec<TensorInfo> = Vec::new();
-    for (shard_ordinal, (shard_path, raws)) in
-        shards.iter().zip(raws_per_shard.iter()).enumerate()
+    for (shard_ordinal, (shard_path, raws)) in shards.iter().zip(raws_per_shard.iter()).enumerate()
     {
         for (in_shard_index, raw) in raws.iter().enumerate() {
             let kind = classify_tensor(raw, &hp);
@@ -114,10 +112,7 @@ pub fn build_inventory(path: &Path, cfg: &InventoryConfig) -> Result<ModelInvent
         model_family: cfg.model_family.clone(),
         checkpoint_path: path.to_path_buf(),
         shard_count: shards.len() as u32,
-        inferred: InferredHyperparams {
-            n_blocks,
-            ..hp
-        },
+        inferred: InferredHyperparams { n_blocks, ..hp },
         tensors,
         blocks,
         totals,
@@ -294,7 +289,10 @@ fn classify_tensor(t: &RawTensor, hp: &InferredHyperparams) -> TensorKind {
     }
 
     TensorKind::Unknown {
-        reason: format!("unhandled rank={} dtype={:?} dims={:?}", rank, t.dtype, dims),
+        reason: format!(
+            "unhandled rank={} dtype={:?} dims={:?}",
+            rank, t.dtype, dims
+        ),
     }
 }
 
@@ -318,7 +316,7 @@ fn assign_block_indices(tensors: &mut [TensorInfo], shard_count: usize) -> Optio
         return None;
     }
     let interior = shard_count - 2; // drop embedding + final-norm singletons
-    // Candidate block sizes we try, in priority order.
+                                    // Candidate block sizes we try, in priority order.
     let candidates = [12usize];
     let mut chosen: Option<(usize, usize)> = None; // (k_per_block, n_blocks)
     for &k in &candidates {
@@ -386,12 +384,7 @@ fn summarize_blocks(tensors: &[TensorInfo]) -> Vec<BlockSummary> {
             .collect();
         let other: Vec<&&TensorInfo> = singletons
             .iter()
-            .filter(|t| {
-                !matches!(
-                    t.kind,
-                    TensorKind::TokenEmbedding | TensorKind::FinalNorm
-                )
-            })
+            .filter(|t| !matches!(t.kind, TensorKind::TokenEmbedding | TensorKind::FinalNorm))
             .collect();
 
         if !embed.is_empty() {
@@ -402,11 +395,7 @@ fn summarize_blocks(tensors: &[TensorInfo]) -> Vec<BlockSummary> {
             ));
         }
         for (i, b) in by_block {
-            out.push(build_summary(
-                i,
-                &format!("block_{:03}", i.unwrap_or(0)),
-                b,
-            ));
+            out.push(build_summary(i, &format!("block_{:03}", i.unwrap_or(0)), b));
         }
         if !finals.is_empty() {
             out.push(build_summary(
@@ -424,11 +413,7 @@ fn summarize_blocks(tensors: &[TensorInfo]) -> Vec<BlockSummary> {
         }
     } else {
         for (i, b) in by_block {
-            out.push(build_summary(
-                i,
-                &format!("block_{:03}", i.unwrap_or(0)),
-                b,
-            ));
+            out.push(build_summary(i, &format!("block_{:03}", i.unwrap_or(0)), b));
         }
     }
 
@@ -447,7 +432,10 @@ fn build_summary(block_index: Option<u32>, label: &str, members: Vec<&TensorInfo
             lo = lo.min(t.shard_ordinal);
             hi = hi.max(t.shard_ordinal);
         }
-        Some(ShardRange { start: lo, end_inclusive: hi })
+        Some(ShardRange {
+            start: lo,
+            end_inclusive: hi,
+        })
     };
 
     let tensor_count = members.len() as u32;
@@ -469,7 +457,11 @@ fn build_summary(block_index: Option<u32>, label: &str, members: Vec<&TensorInfo
     }
     let kinds: Vec<KindCount> = by_kind
         .into_iter()
-        .map(|(k, (c, n))| KindCount { kind_label: k, count: c, nbytes: n })
+        .map(|(k, (c, n))| KindCount {
+            kind_label: k,
+            count: c,
+            nbytes: n,
+        })
         .collect();
 
     BlockSummary {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 // this crate; external consumers should depend on the library and the
 // stable export schema produced by `xai_dissect::report`.
 
-pub mod schema;
-pub mod parser;
+pub mod experts;
 pub mod inventory;
+pub mod parser;
 pub mod report;
+pub mod schema;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,15 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
-use comfy_table::{Cell, ContentArrangement, Table, presets::UTF8_FULL};
+use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
 
-use xai_dissect::inventory::{InventoryConfig, build_inventory};
+use xai_dissect::experts::build_expert_atlas;
+use xai_dissect::inventory::{build_inventory, InventoryConfig};
 use xai_dissect::parser;
 use xai_dissect::report;
-use xai_dissect::schema::{ModelInventory, TensorInfo};
+use xai_dissect::schema::{ExpertAtlas, ModelInventory, TensorInfo};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -64,15 +65,70 @@ enum Command {
         #[arg(long)]
         md: Option<PathBuf>,
     },
+    /// Build an expert-level atlas of a checkpoint directory: discover
+    /// expert-stacked tensors, map blocks to expert counts, and optionally
+    /// export JSON and Markdown.
+    Experts {
+        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+        path: PathBuf,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Model family tag written into the export header. Only `grok-1`
+        /// is officially supported today.
+        #[arg(long, default_value = "grok-1")]
+        family: String,
+        /// If set, write the full expert atlas as pretty JSON to this path.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// If set, write the expert atlas Markdown report to this path. If
+        /// unset, the Markdown report is printed to stdout.
+        #[arg(long)]
+        md: Option<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Command::Dissect { path, limit, prefix } => run_dissect(&path, limit, &prefix),
-        Command::Inventory { path, prefix, limit, family, json, md } => {
-            run_inventory(&path, &prefix, limit, &family, json.as_deref(), md.as_deref())
-        }
+        Command::Dissect {
+            path,
+            limit,
+            prefix,
+        } => run_dissect(&path, limit, &prefix),
+        Command::Inventory {
+            path,
+            prefix,
+            limit,
+            family,
+            json,
+            md,
+        } => run_inventory(
+            &path,
+            &prefix,
+            limit,
+            &family,
+            json.as_deref(),
+            md.as_deref(),
+        ),
+        Command::Experts {
+            path,
+            prefix,
+            limit,
+            family,
+            json,
+            md,
+        } => run_experts(
+            &path,
+            &prefix,
+            limit,
+            &family,
+            json.as_deref(),
+            md.as_deref(),
+        ),
     }
 }
 
@@ -97,7 +153,11 @@ fn run_dissect(path: &std::path::Path, limit: Option<usize>, prefix: &str) -> Re
         .collect();
     shards.sort();
     if shards.is_empty() {
-        bail!("no shards found under {} with prefix '{}'", path.display(), prefix);
+        bail!(
+            "no shards found under {} with prefix '{}'",
+            path.display(),
+            prefix
+        );
     }
     if let Some(n) = limit {
         shards.truncate(n);
@@ -172,6 +232,41 @@ fn run_inventory(
     Ok(())
 }
 
+// --- `experts` -------------------------------------------------------------
+
+fn run_experts(
+    path: &std::path::Path,
+    prefix: &str,
+    limit: Option<usize>,
+    family: &str,
+    json_out: Option<&std::path::Path>,
+    md_out: Option<&std::path::Path>,
+) -> Result<()> {
+    let cfg = InventoryConfig {
+        prefix: prefix.to_string(),
+        limit,
+        model_family: family.to_string(),
+    };
+    let inv = build_inventory(path, &cfg)?;
+    let atlas = build_expert_atlas(&inv);
+
+    print_expert_console_summary(&atlas);
+
+    if let Some(p) = json_out {
+        report::write_expert_json(&atlas, p)?;
+        eprintln!("wrote JSON expert atlas -> {}", p.display());
+    }
+    if let Some(p) = md_out {
+        report::write_expert_markdown(&atlas, p)?;
+        eprintln!("wrote Markdown expert atlas -> {}", p.display());
+    } else {
+        println!();
+        println!("{}", report::render_expert_markdown(&atlas));
+    }
+
+    Ok(())
+}
+
 fn print_console_summary(inv: &ModelInventory) {
     eprintln!(
         "checkpoint: {}  shards: {}  tensors: {}",
@@ -200,5 +295,29 @@ fn print_console_summary(inv: &ModelInventory) {
         .count();
     if unknown > 0 {
         eprintln!("warn: {} tensors classified as Unknown", unknown);
+    }
+}
+
+fn print_expert_console_summary(atlas: &ExpertAtlas) {
+    eprintln!(
+        "checkpoint: {}  blocks: {}  expected_experts_per_block: {:?}",
+        atlas.checkpoint_path.display(),
+        atlas.relevant_block_count,
+        atlas.expected_experts_per_block,
+    );
+    eprintln!(
+        "naming_checks: {}  anomalies: {}",
+        atlas
+            .naming_checks
+            .iter()
+            .filter(|check| check.passed)
+            .count(),
+        atlas.anomalies.len(),
+    );
+    if !atlas.anomalies.is_empty() {
+        eprintln!(
+            "warn: expert atlas contains {} anomalies",
+            atlas.anomalies.len()
+        );
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,7 +22,7 @@ use std::cmp::min;
 use std::fs::File;
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use memchr::memmem;
 use memmap2::Mmap;
 
@@ -36,12 +36,12 @@ const OP_SHORT_BINUNICODE: u8 = 0x8c;
 const OP_MEMOIZE: u8 = 0x94;
 const OP_STACK_GLOBAL: u8 = 0x93;
 
-const OP_BINGET: u8 = b'h';      // 0x68  u8 index
+const OP_BINGET: u8 = b'h'; // 0x68  u8 index
 const OP_LONG_BINGET: u8 = b'j'; // 0x6a  u32 index
 
 const OP_SHORT_BINBYTES: u8 = b'C'; // 0x43  u8 len
-const OP_BINBYTES: u8 = b'B';       // 0x42  u32 len
-const OP_BINBYTES8: u8 = 0x8e;      // u64 len
+const OP_BINBYTES: u8 = b'B'; // 0x42  u32 len
+const OP_BINBYTES8: u8 = 0x8e; // u64 len
 
 const OP_MARK: u8 = b'(';
 const OP_TUPLE: u8 = b't';
@@ -52,7 +52,7 @@ const OP_EMPTY_TUPLE: u8 = b')';
 
 const OP_BININT1: u8 = b'K'; // 0x4b  u8
 const OP_BININT2: u8 = b'M'; // 0x4d  u16
-const OP_BININT: u8 = b'J';  // 0x4a  i32
+const OP_BININT: u8 = b'J'; // 0x4a  i32
 
 const OP_NEWTRUE: u8 = 0x88;
 const OP_NEWFALSE: u8 = 0x89;
@@ -106,7 +106,12 @@ pub fn dissect_shard(path: &Path) -> Result<Vec<RawTensor>> {
             Ok(t) => tensors.push(t),
             Err(err) => {
                 // Non-fatal: one bad anchor never aborts a shard.
-                eprintln!("  skip anchor @ {:#x} in {}: {:#}", a.tag_pos, path.display(), err);
+                eprintln!(
+                    "  skip anchor @ {:#x} in {}: {:#}",
+                    a.tag_pos,
+                    path.display(),
+                    err
+                );
             }
         }
     }
@@ -139,7 +144,11 @@ fn find_dtype_anchors(bytes: &[u8]) -> Vec<DtypeAnchor> {
         for pos in memmem::find_iter(bytes, tag) {
             let after = pos + tag.len();
             if has_dtype_postamble(bytes, after) {
-                out.push(DtypeAnchor { tag_pos: pos, after_tag: after, dtype });
+                out.push(DtypeAnchor {
+                    tag_pos: pos,
+                    after_tag: after,
+                    dtype,
+                });
             }
         }
     }
@@ -160,7 +169,10 @@ fn extract_tensor(bytes: &[u8], anchor: &DtypeAnchor) -> Result<RawTensor> {
     let shape_dims = parse_shape_backward(bytes, anchor.tag_pos)?;
     let (offset, nbytes) = find_payload_forward(bytes, anchor.after_tag)?;
     let expected = anchor.dtype.itemsize() as u64
-        * shape_dims.iter().copied().fold(1u64, |a, d| a.saturating_mul(d));
+        * shape_dims
+            .iter()
+            .copied()
+            .fold(1u64, |a, d| a.saturating_mul(d));
     if expected != 0 && expected != nbytes {
         return Err(anyhow!(
             "shape/payload mismatch: shape={:?} dtype={} nbytes={} expected={}",
@@ -200,7 +212,11 @@ fn parse_shape_backward(bytes: &[u8], tag_pos: usize) -> Result<Vec<u64>> {
 }
 
 fn skip_memoize_back(bytes: &[u8], p: usize) -> usize {
-    if p >= 1 && bytes[p - 1] == OP_MEMOIZE { p - 1 } else { p }
+    if p >= 1 && bytes[p - 1] == OP_MEMOIZE {
+        p - 1
+    } else {
+        p
+    }
 }
 
 fn skip_string_push_back(bytes: &[u8], p: usize) -> Result<usize> {
@@ -220,7 +236,10 @@ fn skip_string_push_back(bytes: &[u8], p: usize) -> Result<usize> {
             return Ok(p - len - 2);
         }
     }
-    Err(anyhow!("cannot unwind string push ending at {:#x}", p.saturating_sub(1)))
+    Err(anyhow!(
+        "cannot unwind string push ending at {:#x}",
+        p.saturating_sub(1)
+    ))
 }
 
 fn skip_binget_back(bytes: &[u8], p: usize) -> Result<usize> {
@@ -300,7 +319,10 @@ fn read_int_backward(bytes: &[u8], end_exclusive: usize) -> Result<(u64, usize)>
     if end_exclusive >= 2 && bytes[end_exclusive - 2] == OP_BININT1 {
         return Ok((bytes[end_exclusive - 1] as u64, end_exclusive - 2));
     }
-    Err(anyhow!("no BININT* opcode ending at offset {:#x}", end_exclusive - 1))
+    Err(anyhow!(
+        "no BININT* opcode ending at offset {:#x}",
+        end_exclusive - 1
+    ))
 }
 
 fn find_payload_forward(bytes: &[u8], after_tag: usize) -> Result<(u64, u64)> {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -11,13 +11,20 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::schema::{BlockSummary, ModelInventory};
+use crate::schema::{BlockSummary, ExpertAtlas, ExpertIssueCategory, ModelInventory};
 
 /// Write the full inventory as pretty-printed JSON. The JSON layout is the
 /// `ModelInventory` struct rendered via serde; its schema version is carried
 /// in the `schema_version` field.
 pub fn write_json(inv: &ModelInventory, out: &Path) -> Result<()> {
     let s = serde_json::to_string_pretty(inv).context("serialize inventory to json")?;
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Write the full expert atlas as pretty-printed JSON.
+pub fn write_expert_json(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
+    let s = serde_json::to_string_pretty(atlas).context("serialize expert atlas to json")?;
     fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
     Ok(())
 }
@@ -59,7 +66,12 @@ pub fn render_markdown(inv: &ModelInventory) -> String {
     let _ = writeln!(md, "| int8 tensors | {} |", t.i8_tensors);
     let _ = writeln!(md, "| quant tensors | {} |", t.quant_tensors);
     let _ = writeln!(md, "| total elements | {} |", t.total_elements);
-    let _ = writeln!(md, "| total bytes | {} ({}) |", t.total_nbytes, human_bytes(t.total_nbytes));
+    let _ = writeln!(
+        md,
+        "| total bytes | {} ({}) |",
+        t.total_nbytes,
+        human_bytes(t.total_nbytes)
+    );
 
     // Kind breakdown (across the whole inventory).
     let _ = writeln!(md);
@@ -108,8 +120,14 @@ pub fn render_markdown(inv: &ModelInventory) -> String {
         let _ = writeln!(md);
         let _ = writeln!(md, "## Exemplar block (`{}`)", exemplar.label);
         let _ = writeln!(md);
-        let _ = writeln!(md, "| Shard | In-shard | Role | Dtype | Shape | Kind | Slot |");
-        let _ = writeln!(md, "| ----: | -------: | ---- | ----- | ----- | ---- | ---: |");
+        let _ = writeln!(
+            md,
+            "| Shard | In-shard | Role | Dtype | Shape | Kind | Slot |"
+        );
+        let _ = writeln!(
+            md,
+            "| ----: | -------: | ---- | ----- | ----- | ---- | ---: |"
+        );
         for ti in inv.tensors.iter().filter(|t| t.block_index == Some(0)) {
             let _ = writeln!(
                 md,
@@ -131,6 +149,179 @@ pub fn render_markdown(inv: &ModelInventory) -> String {
 /// Write the Markdown summary to `out`.
 pub fn write_markdown(inv: &ModelInventory, out: &Path) -> Result<()> {
     let s = render_markdown(inv);
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Render a Markdown summary report for humans from an expert atlas.
+pub fn render_expert_markdown(atlas: &ExpertAtlas) -> String {
+    let mut md = String::new();
+
+    let _ = writeln!(md, "# xai-dissect expert atlas");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "- **model_family**: `{}`", atlas.model_family);
+    let _ = writeln!(
+        md,
+        "- **checkpoint**: `{}`",
+        atlas.checkpoint_path.display()
+    );
+    let _ = writeln!(md, "- **shards**: {}", atlas.shard_count);
+    let _ = writeln!(md, "- **relevant_blocks**: {}", atlas.relevant_block_count);
+    let _ = writeln!(
+        md,
+        "- **expected_experts_per_block**: {}",
+        fmt_opt(atlas.expected_experts_per_block)
+    );
+    let _ = writeln!(md, "- **schema_version**: {}", atlas.schema_version);
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Expert counts by block");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Block | Experts | Expert tensors | Slots | Shapes |");
+    let _ = writeln!(md, "| ----: | ------: | -------------: | ----- | ------ |");
+    for block in &atlas.blocks {
+        let slots = if block.tensors.is_empty() {
+            "-".to_string()
+        } else {
+            block
+                .tensors
+                .iter()
+                .map(|tensor| {
+                    tensor
+                        .block_slot
+                        .map(|slot| slot.to_string())
+                        .unwrap_or_else(|| "?".to_string())
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let shapes = if block.tensors.is_empty() {
+            "-".to_string()
+        } else {
+            block
+                .tensors
+                .iter()
+                .map(|tensor| format!("{} {}", tensor.family_label, tensor.shape.render()))
+                .collect::<Vec<_>>()
+                .join("<br>")
+        };
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} | {} |",
+            block.block_index,
+            fmt_opt(block.expert_count),
+            block.tensors.len(),
+            slots,
+            shapes
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Tensor naming patterns");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Family | Pattern | Projection | Slots | Shapes | Blocks |"
+    );
+    let _ = writeln!(
+        md,
+        "| ------ | ------- | ---------- | ----- | ------ | -----: |"
+    );
+    for pattern in &atlas.naming_patterns {
+        let shapes = if pattern.observed_shapes.is_empty() {
+            "-".to_string()
+        } else {
+            pattern
+                .observed_shapes
+                .iter()
+                .map(|shape| shape.render())
+                .collect::<Vec<_>>()
+                .join("<br>")
+        };
+        let slots = if pattern.block_slots.is_empty() {
+            "-".to_string()
+        } else {
+            pattern
+                .block_slots
+                .iter()
+                .map(|slot| slot.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let _ = writeln!(
+            md,
+            "| {} | `{}` | {} | {} | {} | {} |",
+            pattern.family_label,
+            pattern.pattern,
+            pattern.projection.label(),
+            slots,
+            shapes,
+            pattern.observed_blocks
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Naming consistency checks");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Check | Result | Detail |");
+    let _ = writeln!(md, "| ----- | ------ | ------ |");
+    for check in &atlas.naming_checks {
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} |",
+            check.check,
+            if check.passed { "pass" } else { "fail" },
+            check.detail
+        );
+    }
+
+    render_issue_section(
+        &mut md,
+        "Missing or irregular expert tensors",
+        atlas,
+        ExpertIssueCategory::MissingOrIrregularTensor,
+    );
+    render_issue_section(
+        &mut md,
+        "Layout anomalies",
+        atlas,
+        ExpertIssueCategory::LayoutAnomaly,
+    );
+
+    if let Some(block) = atlas.blocks.first() {
+        let _ = writeln!(md);
+        let _ = writeln!(md, "## Exemplar block (`block_{:03}`)", block.block_index);
+        let _ = writeln!(md);
+        let _ = writeln!(md, "| Expert | Tensor associations |");
+        let _ = writeln!(md, "| -----: | ------------------- |");
+        for expert in &block.experts {
+            let associations = if expert.tensors.is_empty() {
+                "-".to_string()
+            } else {
+                expert
+                    .tensors
+                    .iter()
+                    .map(|tensor| {
+                        format!(
+                            "`{}` {} `{}`",
+                            tensor.structural_name,
+                            tensor.projection.label(),
+                            tensor.slice_shape.render()
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("<br>")
+            };
+            let _ = writeln!(md, "| {} | {} |", expert.expert_index, associations);
+        }
+    }
+
+    md
+}
+
+/// Write the expert atlas Markdown summary to `out`.
+pub fn write_expert_markdown(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
+    let s = render_expert_markdown(atlas);
     fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
     Ok(())
 }
@@ -174,5 +365,61 @@ fn human_bytes(n: u64) -> String {
         format!("{} {}", n, UNITS[0])
     } else {
         format!("{:.2} {}", v, UNITS[u])
+    }
+}
+
+fn render_issue_section(
+    md: &mut String,
+    title: &str,
+    atlas: &ExpertAtlas,
+    category: ExpertIssueCategory,
+) {
+    let issues = atlas
+        .anomalies
+        .iter()
+        .filter(|issue| issue.category == category)
+        .collect::<Vec<_>>();
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## {}", title);
+    let _ = writeln!(md);
+
+    if issues.is_empty() {
+        let _ = writeln!(md, "None detected.");
+        return;
+    }
+
+    let _ = writeln!(md, "| Block | Severity | Tensor | Message |");
+    let _ = writeln!(md, "| ----: | -------- | ------ | ------- |");
+    for issue in issues {
+        let tensor = issue
+            .tensor
+            .as_ref()
+            .map(|tensor| {
+                format!(
+                    "shard {} idx {} slot {}",
+                    tensor.shard_ordinal,
+                    tensor.in_shard_index,
+                    tensor
+                        .block_slot
+                        .map(|slot| slot.to_string())
+                        .unwrap_or_else(|| "?".to_string())
+                )
+            })
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} |",
+            issue
+                .block_index
+                .map(|index| index.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            match issue.severity {
+                crate::schema::ExpertIssueSeverity::Warning => "warning",
+                crate::schema::ExpertIssueSeverity::Error => "error",
+            },
+            tensor,
+            issue.message
+        );
     }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -55,7 +55,10 @@ impl TensorShape {
     }
 
     pub fn numel(&self) -> u64 {
-        self.0.iter().copied().fold(1u64, |acc, d| acc.saturating_mul(d))
+        self.0
+            .iter()
+            .copied()
+            .fold(1u64, |acc, d| acc.saturating_mul(d))
     }
 
     pub fn is_empty_tuple(&self) -> bool {
@@ -68,7 +71,11 @@ impl TensorShape {
             1 => format!("({},)", self.0[0]),
             _ => format!(
                 "({})",
-                self.0.iter().map(|d| d.to_string()).collect::<Vec<_>>().join(", ")
+                self.0
+                    .iter()
+                    .map(|d| d.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
         }
     }
@@ -244,6 +251,120 @@ pub struct ModelInventory {
     pub totals: InventoryTotals,
     /// Schema version. Bump on incompatible export changes.
     pub schema_version: u32,
+}
+
+/// Top-level, serializable expert-level view of a checkpoint directory.
+/// This is derived entirely from `ModelInventory` and never requires a
+/// forward pass or tensor-body reads.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertAtlas {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub shard_count: u32,
+    pub inferred: InferredHyperparams,
+    pub relevant_block_count: u32,
+    pub expected_experts_per_block: Option<u64>,
+    pub blocks: Vec<ExpertBlock>,
+    pub naming_patterns: Vec<ExpertNamingPattern>,
+    pub naming_checks: Vec<ExpertNamingCheck>,
+    pub anomalies: Vec<ExpertIssue>,
+    pub schema_version: u32,
+}
+
+/// Expert-oriented summary of one transformer block.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertBlock {
+    pub block_index: u32,
+    pub shard_range: Option<ShardRange>,
+    pub expert_count: Option<u64>,
+    pub tensors: Vec<ExpertTensorRef>,
+    pub experts: Vec<ExpertSlice>,
+}
+
+/// One tensor family that participates in the block's expert layout.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertTensorRef {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_slot: Option<u32>,
+    pub role: TensorRole,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    pub kind_label: String,
+    pub projection: MoeProjection,
+    pub expert_axis: Option<u32>,
+    pub expert_count: Option<u64>,
+    pub family_label: String,
+    pub structural_name: String,
+}
+
+/// One expert index within a block, associated to the tensor families that
+/// carry expert-stacked parameters.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertSlice {
+    pub expert_index: u32,
+    pub tensors: Vec<ExpertSliceTensor>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertSliceTensor {
+    pub family_label: String,
+    pub structural_name: String,
+    pub source_shard_ordinal: u32,
+    pub source_in_shard_index: u32,
+    pub source_block_slot: Option<u32>,
+    pub projection: MoeProjection,
+    pub dtype: TensorDType,
+    pub slice_shape: TensorShape,
+}
+
+/// Aggregate structural naming pattern inferred from the block slot layout.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertNamingPattern {
+    pub family_label: String,
+    pub pattern: String,
+    pub projection: MoeProjection,
+    pub block_slots: Vec<u32>,
+    pub observed_shapes: Vec<TensorShape>,
+    pub observed_blocks: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertNamingCheck {
+    pub check: String,
+    pub passed: bool,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertIssue {
+    pub severity: ExpertIssueSeverity,
+    pub category: ExpertIssueCategory,
+    pub block_index: Option<u32>,
+    pub tensor: Option<ExpertTensorLocator>,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpertTensorLocator {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_slot: Option<u32>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpertIssueSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpertIssueCategory {
+    MissingOrIrregularTensor,
+    NamingConsistency,
+    LayoutAnomaly,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
## What changed
- add a new `src/experts` analysis module that derives expert structure from `ModelInventory`
- add an `experts` CLI subcommand that builds an expert atlas and exports JSON or Markdown
- add expert-atlas schema types and report renderers for block-to-expert mapping, per-expert tensor associations, naming checks, and anomaly reporting

## Why
The repo could inventory Grok-1 tensors, but it could not yet answer how a checkpoint is organized at the expert level. This adds a parser-driven, structural MoE view without introducing runtime or inference logic.

## Impact
- `cargo run -- experts <path-to-checkpoint>` now produces a useful expert atlas
- downstream consumers can use the exported JSON and Markdown artifacts to inspect expert counts, slot patterns, and irregularities
- the change stays within the repo's analysis boundary: no forward pass, no logits, no quantization work

## Validation
- `cargo test`
- `cargo run -- experts /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 14`

## Notes
- local `gh` auth is invalid on this machine, so the PR was opened via the GitHub connector
- a full-checkpoint atlas sweep was started locally; the smoke validation above completed successfully against the real Grok-1 checkpoint