### PR TITLE
[codex] Add routing structure report

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,5 @@ pub mod experts;
 pub mod inventory;
 pub mod parser;
 pub mod report;
+pub mod routing;
 pub mod schema;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,16 @@
 
 use std::path::PathBuf;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
-use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
+use comfy_table::{Cell, ContentArrangement, Table, presets::UTF8_FULL};
 
 use xai_dissect::experts::build_expert_atlas;
-use xai_dissect::inventory::{build_inventory, InventoryConfig};
+use xai_dissect::inventory::{InventoryConfig, build_inventory};
 use xai_dissect::parser;
 use xai_dissect::report;
-use xai_dissect::schema::{ExpertAtlas, ModelInventory, TensorInfo};
+use xai_dissect::routing::build_routing_report;
+use xai_dissect::schema::{ExpertAtlas, ModelInventory, RoutingReport, TensorInfo};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -89,6 +90,30 @@ enum Command {
         #[arg(long)]
         md: Option<PathBuf>,
     },
+    /// Build a routing-structure report for a checkpoint directory:
+    /// identify likely router tensors, summarize their geometry, and
+    /// optionally export JSON and Markdown.
+    RoutingReport {
+        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+        path: PathBuf,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Model family tag written into the export header. Only `grok-1`
+        /// is officially supported today.
+        #[arg(long, default_value = "grok-1")]
+        family: String,
+        /// If set, write the full routing report as pretty JSON to this path.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// If set, write the routing Markdown report to this path. If
+        /// unset, the Markdown report is printed to stdout.
+        #[arg(long)]
+        md: Option<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -122,6 +147,21 @@ fn main() -> Result<()> {
             json,
             md,
         } => run_experts(
+            &path,
+            &prefix,
+            limit,
+            &family,
+            json.as_deref(),
+            md.as_deref(),
+        ),
+        Command::RoutingReport {
+            path,
+            prefix,
+            limit,
+            family,
+            json,
+            md,
+        } => run_routing_report(
             &path,
             &prefix,
             limit,
@@ -267,6 +307,41 @@ fn run_experts(
     Ok(())
 }
 
+// --- `routing-report` -----------------------------------------------------
+
+fn run_routing_report(
+    path: &std::path::Path,
+    prefix: &str,
+    limit: Option<usize>,
+    family: &str,
+    json_out: Option<&std::path::Path>,
+    md_out: Option<&std::path::Path>,
+) -> Result<()> {
+    let cfg = InventoryConfig {
+        prefix: prefix.to_string(),
+        limit,
+        model_family: family.to_string(),
+    };
+    let inv = build_inventory(path, &cfg)?;
+    let report_doc = build_routing_report(&inv);
+
+    print_routing_console_summary(&report_doc);
+
+    if let Some(p) = json_out {
+        report::write_routing_json(&report_doc, p)?;
+        eprintln!("wrote JSON routing report -> {}", p.display());
+    }
+    if let Some(p) = md_out {
+        report::write_routing_markdown(&report_doc, p)?;
+        eprintln!("wrote Markdown routing report -> {}", p.display());
+    } else {
+        println!();
+        println!("{}", report::render_routing_markdown(&report_doc));
+    }
+
+    Ok(())
+}
+
 fn print_console_summary(inv: &ModelInventory) {
     eprintln!(
         "checkpoint: {}  shards: {}  tensors: {}",
@@ -318,6 +393,27 @@ fn print_expert_console_summary(atlas: &ExpertAtlas) {
         eprintln!(
             "warn: expert atlas contains {} anomalies",
             atlas.anomalies.len()
+        );
+    }
+}
+
+fn print_routing_console_summary(report_doc: &RoutingReport) {
+    eprintln!(
+        "checkpoint: {}  routing_blocks: {}  candidates: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.relevant_block_count,
+        report_doc.candidate_tensors.len(),
+    );
+    eprintln!(
+        "expected_experts_per_router: {:?}  critical_blocks: {}  anomalies: {}",
+        report_doc.expected_experts_per_router,
+        report_doc.likely_routing_critical_blocks.len(),
+        report_doc.anomalies.len(),
+    );
+    if !report_doc.anomalies.is_empty() {
+        eprintln!(
+            "warn: routing report contains {} anomalies",
+            report_doc.anomalies.len()
         );
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -11,7 +11,10 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::schema::{BlockSummary, ExpertAtlas, ExpertIssueCategory, ModelInventory};
+use crate::schema::{
+    BlockSummary, ExpertAtlas, ExpertIssueCategory, ModelInventory, RoutingIssueCategory,
+    RoutingReport,
+};
 
 /// Write the full inventory as pretty-printed JSON. The JSON layout is the
 /// `ModelInventory` struct rendered via serde; its schema version is carried
@@ -25,6 +28,13 @@ pub fn write_json(inv: &ModelInventory, out: &Path) -> Result<()> {
 /// Write the full expert atlas as pretty-printed JSON.
 pub fn write_expert_json(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
     let s = serde_json::to_string_pretty(atlas).context("serialize expert atlas to json")?;
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Write the full routing report as pretty-printed JSON.
+pub fn write_routing_json(report_doc: &RoutingReport, out: &Path) -> Result<()> {
+    let s = serde_json::to_string_pretty(report_doc).context("serialize routing report to json")?;
     fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
     Ok(())
 }
@@ -326,6 +336,229 @@ pub fn write_expert_markdown(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Render a Markdown summary report for humans from a routing report.
+pub fn render_routing_markdown(report_doc: &RoutingReport) -> String {
+    let mut md = String::new();
+
+    let _ = writeln!(md, "# xai-dissect routing report");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "- **model_family**: `{}`", report_doc.model_family);
+    let _ = writeln!(
+        md,
+        "- **checkpoint**: `{}`",
+        report_doc.checkpoint_path.display()
+    );
+    let _ = writeln!(md, "- **shards**: {}", report_doc.shard_count);
+    let _ = writeln!(
+        md,
+        "- **relevant_blocks**: {}",
+        report_doc.relevant_block_count
+    );
+    let _ = writeln!(
+        md,
+        "- **expected_experts_per_router**: {}",
+        fmt_opt(report_doc.expected_experts_per_router)
+    );
+    let _ = writeln!(md, "- **schema_version**: {}", report_doc.schema_version);
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Candidate routing tensors");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Block | Slot | Shape | Orientation | Experts | Kind | Structural name |"
+    );
+    let _ = writeln!(
+        md,
+        "| ----: | ---: | ----- | ----------- | ------: | ---- | --------------- |"
+    );
+    for tensor in &report_doc.candidate_tensors {
+        let _ = writeln!(
+            md,
+            "| {} | {} | `{}` | {} | {} | {} | `{}` |",
+            tensor
+                .block_index
+                .map(|index| index.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            tensor
+                .block_slot
+                .map(|slot| slot.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            tensor.shape.render(),
+            tensor.orientation.label(),
+            fmt_opt(tensor.linked_expert_count),
+            tensor.kind_label,
+            tensor.structural_name
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Shape and orientation summaries");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Orientation | Count | Blocks | Shapes |");
+    let _ = writeln!(md, "| ----------- | ----: | -----: | ------ |");
+    for summary in &report_doc.orientation_summaries {
+        let shapes = if summary.observed_shapes.is_empty() {
+            "-".to_string()
+        } else {
+            summary
+                .observed_shapes
+                .iter()
+                .map(|shape| shape.render())
+                .collect::<Vec<_>>()
+                .join("<br>")
+        };
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} |",
+            summary.orientation.label(),
+            summary.count,
+            summary.observed_blocks,
+            shapes
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Layer-by-layer routing metadata");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Label | Block | Local experts | Primary candidate | Candidate count |"
+    );
+    let _ = writeln!(
+        md,
+        "| ----- | ----: | ------------: | ----------------- | --------------: |"
+    );
+    for block in &report_doc.blocks {
+        let primary = block
+            .primary_candidate
+            .as_ref()
+            .map(|locator| {
+                format!(
+                    "shard {} idx {} slot {}",
+                    locator.shard_ordinal,
+                    locator.in_shard_index,
+                    locator
+                        .block_slot
+                        .map(|slot| slot.to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                )
+            })
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} | {} |",
+            block.label,
+            block
+                .block_index
+                .map(|index| index.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            fmt_opt(block.local_expert_count),
+            primary,
+            block.candidates.len()
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Gate tensor structural metrics");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Structural name | Input width | Output width | Logits/input | Bytes |"
+    );
+    let _ = writeln!(
+        md,
+        "| --------------- | ----------: | -----------: | -----------: | ----: |"
+    );
+    for tensor in &report_doc.candidate_tensors {
+        let _ = writeln!(
+            md,
+            "| `{}` | {} | {} | {} | {} ({}) |",
+            tensor.structural_name,
+            fmt_opt(tensor.gate_metrics.input_width),
+            fmt_opt(tensor.gate_metrics.output_width),
+            fmt_opt(tensor.gate_metrics.logits_per_input),
+            tensor.gate_metrics.total_nbytes,
+            human_bytes(tensor.gate_metrics.total_nbytes)
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Expert count linkage");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Structural name | Linked experts | Matches inferred experts |"
+    );
+    let _ = writeln!(
+        md,
+        "| --------------- | -------------: | ----------------------- |"
+    );
+    for tensor in &report_doc.candidate_tensors {
+        let _ = writeln!(
+            md,
+            "| `{}` | {} | {} |",
+            tensor.structural_name,
+            fmt_opt(tensor.linked_expert_count),
+            if tensor.matches_inferred_expert_count {
+                "yes"
+            } else {
+                "no"
+            }
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Likely routing-critical blocks");
+    let _ = writeln!(md);
+    if report_doc.likely_routing_critical_blocks.is_empty() {
+        let _ = writeln!(md, "None detected.");
+    } else {
+        let _ = writeln!(md, "| Block | Label | Reason |");
+        let _ = writeln!(md, "| ----: | ----- | ------ |");
+        for block in &report_doc.likely_routing_critical_blocks {
+            let _ = writeln!(
+                md,
+                "| {} | {} | {} |",
+                block
+                    .block_index
+                    .map(|index| index.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                block.label,
+                block.reason
+            );
+        }
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Grok-specific layout notes");
+    let _ = writeln!(md);
+    if report_doc.grok_layout_notes.is_empty() {
+        let _ = writeln!(md, "None detected.");
+    } else {
+        for note in &report_doc.grok_layout_notes {
+            let _ = writeln!(md, "- {}", note);
+        }
+    }
+
+    render_routing_issue_section(&mut md, "Routing anomalies", report_doc, None);
+    render_routing_issue_section(
+        &mut md,
+        "Missing routing candidates",
+        report_doc,
+        Some(RoutingIssueCategory::MissingCandidate),
+    );
+
+    md
+}
+
+/// Write the routing Markdown summary to `out`.
+pub fn write_routing_markdown(report_doc: &RoutingReport, out: &Path) -> Result<()> {
+    let s = render_routing_markdown(report_doc);
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
 // --- Helpers ---------------------------------------------------------------
 
 fn render_kinds(b: &BlockSummary) -> String {
@@ -417,6 +650,72 @@ fn render_issue_section(
             match issue.severity {
                 crate::schema::ExpertIssueSeverity::Warning => "warning",
                 crate::schema::ExpertIssueSeverity::Error => "error",
+            },
+            tensor,
+            issue.message
+        );
+    }
+}
+
+fn render_routing_issue_section(
+    md: &mut String,
+    title: &str,
+    report_doc: &RoutingReport,
+    category: Option<RoutingIssueCategory>,
+) {
+    let issues = report_doc
+        .anomalies
+        .iter()
+        .filter(|issue| {
+            category
+                .map(|category| issue.category == category)
+                .unwrap_or(true)
+        })
+        .collect::<Vec<_>>();
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## {}", title);
+    let _ = writeln!(md);
+
+    if issues.is_empty() {
+        let _ = writeln!(md, "None detected.");
+        return;
+    }
+
+    let _ = writeln!(md, "| Block | Severity | Category | Tensor | Message |");
+    let _ = writeln!(md, "| ----: | -------- | -------- | ------ | ------- |");
+    for issue in issues {
+        let tensor = issue
+            .tensor
+            .as_ref()
+            .map(|tensor| {
+                format!(
+                    "shard {} idx {} slot {}",
+                    tensor.shard_ordinal,
+                    tensor.in_shard_index,
+                    tensor
+                        .block_slot
+                        .map(|slot| slot.to_string())
+                        .unwrap_or_else(|| "?".to_string())
+                )
+            })
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} | {} |",
+            issue
+                .block_index
+                .map(|index| index.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            match issue.severity {
+                crate::schema::RoutingIssueSeverity::Warning => "warning",
+                crate::schema::RoutingIssueSeverity::Error => "error",
+            },
+            match issue.category {
+                crate::schema::RoutingIssueCategory::MissingCandidate => "missing_candidate",
+                crate::schema::RoutingIssueCategory::ShapeSummary => "shape_summary",
+                crate::schema::RoutingIssueCategory::ExpertCountLinkage => "expert_count_linkage",
+                crate::schema::RoutingIssueCategory::LayoutNote => "layout_note",
             },
             tensor,
             issue.message

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,0 +1,655 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Routing-structure analysis derived from `ModelInventory`. This layer
+// identifies candidate router tensors, summarizes their shape/orientation,
+// links them to block-local expert structure, and reports layout anomalies
+// without executing any routing logic.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::schema::{
+    InferredHyperparams, ModelInventory, RoutingBlockReport, RoutingCriticalBlock,
+    RoutingGateMetrics, RoutingIssue, RoutingIssueCategory, RoutingIssueSeverity,
+    RoutingOrientation, RoutingOrientationSummary, RoutingReport, RoutingTensorLocator,
+    RoutingTensorRef, ShardRange, TensorDType, TensorInfo, TensorKind, TensorRole, TensorShape,
+};
+
+pub const ROUTING_REPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone)]
+struct Candidate<'a> {
+    tensor: &'a TensorInfo,
+    orientation: RoutingOrientation,
+    expert_axis: Option<u32>,
+    linked_expert_count: Option<u64>,
+    structural_name: String,
+    gate_metrics: RoutingGateMetrics,
+}
+
+/// Build a routing-oriented structural report from an inventory.
+pub fn build_routing_report(inv: &ModelInventory) -> RoutingReport {
+    let mut by_block: BTreeMap<Option<u32>, Vec<&TensorInfo>> = BTreeMap::new();
+    for tensor in &inv.tensors {
+        by_block.entry(tensor.block_index).or_default().push(tensor);
+    }
+
+    let mut blocks = Vec::new();
+    let mut candidate_tensors = Vec::new();
+    let mut anomalies = Vec::new();
+
+    for (block_index, mut members) in by_block {
+        members.sort_by_key(|t| {
+            (
+                t.block_slot.unwrap_or(u32::MAX),
+                t.shard_ordinal,
+                t.in_shard_index,
+            )
+        });
+
+        let label = block_label(block_index);
+        let local_expert_count = local_expert_count(&members);
+        let candidates = routing_candidates(
+            &label,
+            &members,
+            inv.inferred.n_experts,
+            inv.inferred.d_model,
+            local_expert_count,
+        );
+        let primary_candidate = select_primary_candidate(&candidates).map(locator_from_candidate);
+
+        if local_expert_count.is_some() && candidates.is_empty() {
+            anomalies.push(RoutingIssue {
+                severity: RoutingIssueSeverity::Warning,
+                category: RoutingIssueCategory::MissingCandidate,
+                block_index,
+                tensor: None,
+                message: "block carries expert projections but no routing candidate was identified"
+                    .to_string(),
+            });
+        }
+
+        if candidates.len() > 1 {
+            anomalies.push(RoutingIssue {
+                severity: RoutingIssueSeverity::Warning,
+                category: RoutingIssueCategory::ShapeSummary,
+                block_index,
+                tensor: None,
+                message: format!(
+                    "multiple routing candidates identified in {}: {}",
+                    label,
+                    candidates
+                        .iter()
+                        .map(|candidate| candidate.tensor.shape.render())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            });
+        }
+
+        if let Some(primary) = select_primary_candidate(&candidates) {
+            if matches!(
+                primary.orientation,
+                RoutingOrientation::Ambiguous | RoutingOrientation::Unknown
+            ) {
+                anomalies.push(RoutingIssue {
+                    severity: RoutingIssueSeverity::Warning,
+                    category: RoutingIssueCategory::ShapeSummary,
+                    block_index,
+                    tensor: Some(locator_from_candidate(primary)),
+                    message: format!(
+                        "primary routing candidate has unclear orientation: {}",
+                        primary.tensor.shape.render()
+                    ),
+                });
+            }
+            if let Some(local) = local_expert_count {
+                if primary.linked_expert_count != Some(local) {
+                    anomalies.push(RoutingIssue {
+                        severity: RoutingIssueSeverity::Warning,
+                        category: RoutingIssueCategory::ExpertCountLinkage,
+                        block_index,
+                        tensor: Some(locator_from_candidate(primary)),
+                        message: format!(
+                            "routing tensor expert count {:?} does not match local expert count {}",
+                            primary.linked_expert_count, local
+                        ),
+                    });
+                }
+            }
+        }
+
+        let refs = candidates
+            .iter()
+            .map(|candidate| tensor_ref_from_candidate(candidate, inv.inferred.n_experts))
+            .collect::<Vec<_>>();
+        candidate_tensors.extend(refs.iter().cloned());
+
+        if !refs.is_empty() || local_expert_count.is_some() {
+            blocks.push(RoutingBlockReport {
+                block_index,
+                label,
+                shard_range: shard_range(&members),
+                local_expert_count,
+                primary_candidate,
+                candidates: refs,
+            });
+        }
+    }
+
+    let orientation_summaries = orientation_summaries(&candidate_tensors);
+    let likely_routing_critical_blocks = likely_routing_critical_blocks(&blocks);
+    let grok_layout_notes =
+        grok_layout_notes(&blocks, inv.inferred.d_model, inv.inferred.n_experts);
+    let relevant_block_count = blocks
+        .iter()
+        .filter(|block| block.block_index.is_some())
+        .count() as u32;
+    let expected_experts_per_router = mode_u64(
+        candidate_tensors
+            .iter()
+            .filter_map(|tensor| tensor.linked_expert_count)
+            .collect(),
+    );
+
+    RoutingReport {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        shard_count: inv.shard_count,
+        inferred: InferredHyperparams {
+            vocab_size: inv.inferred.vocab_size,
+            d_model: inv.inferred.d_model,
+            n_experts: inv.inferred.n_experts,
+            d_ff: inv.inferred.d_ff,
+            n_blocks: inv.inferred.n_blocks,
+        },
+        relevant_block_count,
+        expected_experts_per_router,
+        candidate_tensors,
+        blocks,
+        orientation_summaries,
+        likely_routing_critical_blocks,
+        grok_layout_notes,
+        anomalies,
+        schema_version: ROUTING_REPORT_SCHEMA_VERSION,
+    }
+}
+
+fn routing_candidates<'a>(
+    label: &str,
+    members: &[&'a TensorInfo],
+    inferred_experts: Option<u64>,
+    d_model: Option<u64>,
+    local_expert_count: Option<u64>,
+) -> Vec<Candidate<'a>> {
+    let mut candidates = Vec::new();
+    let mut ordinal = 0u32;
+
+    for tensor in members {
+        let is_router_kind = matches!(tensor.kind, TensorKind::Router);
+        let expert_axis = infer_expert_axis(tensor, inferred_experts, local_expert_count);
+        let is_shape_candidate = tensor.role == TensorRole::Tensor
+            && tensor.dtype == TensorDType::F32
+            && tensor.shape.rank() >= 2
+            && expert_axis.is_some();
+        if !is_router_kind && !is_shape_candidate {
+            continue;
+        }
+
+        let linked_expert_count = expert_axis.map(|axis| tensor.shape.dims()[axis as usize]);
+        let orientation = infer_orientation(tensor, d_model, inferred_experts, local_expert_count);
+        let structural_name = match tensor.block_slot {
+            Some(slot) => format!("{label}.routing_slot_{slot:02}"),
+            None => {
+                let name = format!("{label}.routing_candidate_{ordinal:02}");
+                ordinal += 1;
+                name
+            }
+        };
+        let gate_metrics = gate_metrics(tensor, orientation, linked_expert_count);
+
+        candidates.push(Candidate {
+            tensor,
+            orientation,
+            expert_axis,
+            linked_expert_count,
+            structural_name,
+            gate_metrics,
+        });
+    }
+
+    candidates
+}
+
+fn infer_expert_axis(
+    tensor: &TensorInfo,
+    inferred_experts: Option<u64>,
+    local_expert_count: Option<u64>,
+) -> Option<u32> {
+    let mut matched_axes = Vec::new();
+    let expected = [local_expert_count, inferred_experts];
+    for (index, dim) in tensor.shape.dims().iter().copied().enumerate() {
+        if expected.iter().flatten().any(|expected| *expected == dim) {
+            matched_axes.push(index as u32);
+        }
+    }
+
+    if matched_axes.len() == 1 {
+        return matched_axes.first().copied();
+    }
+    if matches!(tensor.kind, TensorKind::Router) && tensor.shape.rank() == 2 {
+        return Some(1);
+    }
+    None
+}
+
+fn infer_orientation(
+    tensor: &TensorInfo,
+    d_model: Option<u64>,
+    inferred_experts: Option<u64>,
+    local_expert_count: Option<u64>,
+) -> RoutingOrientation {
+    let dims = tensor.shape.dims();
+    let expert_count = local_expert_count.or(inferred_experts);
+
+    if dims.len() == 2 {
+        let (a, b) = (dims[0], dims[1]);
+        if let (Some(dm), Some(experts)) = (d_model, expert_count) {
+            if a == dm && b == experts {
+                return RoutingOrientation::DModelToExperts;
+            }
+            if a == experts && b == dm {
+                return RoutingOrientation::ExpertsToDModel;
+            }
+        }
+        if let Some(experts) = expert_count {
+            if a == experts && b == experts {
+                return RoutingOrientation::Ambiguous;
+            }
+            if a == experts {
+                return RoutingOrientation::ExpertAxisLeading;
+            }
+            if b == experts {
+                return RoutingOrientation::ExpertAxisTrailing;
+            }
+        }
+        return RoutingOrientation::Unknown;
+    }
+
+    let Some(axis) = infer_expert_axis(tensor, inferred_experts, local_expert_count) else {
+        return RoutingOrientation::Unknown;
+    };
+    if axis == 0 {
+        return RoutingOrientation::ExpertAxisLeading;
+    }
+    if axis as usize == dims.len().saturating_sub(1) {
+        return RoutingOrientation::ExpertAxisTrailing;
+    }
+    RoutingOrientation::Ambiguous
+}
+
+fn gate_metrics(
+    tensor: &TensorInfo,
+    orientation: RoutingOrientation,
+    linked_expert_count: Option<u64>,
+) -> RoutingGateMetrics {
+    let dims = tensor.shape.dims();
+    let (input_width, output_width, expert_count, logits_per_input) = if dims.len() == 2 {
+        match orientation {
+            RoutingOrientation::DModelToExperts => {
+                (Some(dims[0]), Some(dims[1]), Some(dims[1]), Some(dims[1]))
+            }
+            RoutingOrientation::ExpertsToDModel => {
+                (Some(dims[1]), Some(dims[0]), Some(dims[0]), Some(dims[0]))
+            }
+            RoutingOrientation::ExpertAxisLeading => {
+                (Some(dims[1]), Some(dims[0]), Some(dims[0]), Some(dims[0]))
+            }
+            RoutingOrientation::ExpertAxisTrailing => {
+                (Some(dims[0]), Some(dims[1]), Some(dims[1]), Some(dims[1]))
+            }
+            RoutingOrientation::Ambiguous | RoutingOrientation::Unknown => {
+                (None, None, linked_expert_count, linked_expert_count)
+            }
+        }
+    } else {
+        (None, None, linked_expert_count, linked_expert_count)
+    };
+
+    RoutingGateMetrics {
+        total_elements: tensor.shape.numel(),
+        total_nbytes: tensor.nbytes,
+        input_width,
+        output_width,
+        expert_count,
+        logits_per_input,
+    }
+}
+
+fn local_expert_count(members: &[&TensorInfo]) -> Option<u64> {
+    mode_u64(
+        members
+            .iter()
+            .filter_map(|tensor| match tensor.kind {
+                TensorKind::MoeExpertProjection { .. } if tensor.shape.rank() == 3 => {
+                    tensor.shape.dims().first().copied()
+                }
+                _ => None,
+            })
+            .collect(),
+    )
+}
+
+fn select_primary_candidate<'a>(candidates: &'a [Candidate<'a>]) -> Option<&'a Candidate<'a>> {
+    candidates
+        .iter()
+        .find(|candidate| matches!(candidate.tensor.kind, TensorKind::Router))
+        .or_else(|| candidates.first())
+}
+
+fn tensor_ref_from_candidate(
+    candidate: &Candidate<'_>,
+    inferred_experts: Option<u64>,
+) -> RoutingTensorRef {
+    RoutingTensorRef {
+        shard_ordinal: candidate.tensor.shard_ordinal,
+        in_shard_index: candidate.tensor.in_shard_index,
+        block_index: candidate.tensor.block_index,
+        block_slot: candidate.tensor.block_slot,
+        role: candidate.tensor.role,
+        dtype: candidate.tensor.dtype,
+        shape: candidate.tensor.shape.clone(),
+        kind_label: candidate.tensor.kind.short_label(),
+        orientation: candidate.orientation,
+        expert_axis: candidate.expert_axis,
+        linked_expert_count: candidate.linked_expert_count,
+        matches_inferred_expert_count: candidate
+            .linked_expert_count
+            .map(|count| Some(count) == inferred_experts)
+            .unwrap_or(false),
+        structural_name: candidate.structural_name.clone(),
+        gate_metrics: candidate.gate_metrics.clone(),
+    }
+}
+
+fn locator_from_candidate(candidate: &Candidate<'_>) -> RoutingTensorLocator {
+    RoutingTensorLocator {
+        shard_ordinal: candidate.tensor.shard_ordinal,
+        in_shard_index: candidate.tensor.in_shard_index,
+        block_slot: candidate.tensor.block_slot,
+    }
+}
+
+fn orientation_summaries(candidates: &[RoutingTensorRef]) -> Vec<RoutingOrientationSummary> {
+    #[derive(Default)]
+    struct SummaryAcc {
+        count: u32,
+        shapes: Vec<TensorShape>,
+        blocks: BTreeSet<Option<u32>>,
+    }
+
+    let mut by_orientation: BTreeMap<RoutingOrientation, SummaryAcc> = BTreeMap::new();
+    for candidate in candidates {
+        let acc = by_orientation.entry(candidate.orientation).or_default();
+        acc.count += 1;
+        if !acc.shapes.contains(&candidate.shape) {
+            acc.shapes.push(candidate.shape.clone());
+        }
+        acc.blocks.insert(candidate.block_index);
+    }
+
+    by_orientation
+        .into_iter()
+        .map(|(orientation, acc)| RoutingOrientationSummary {
+            orientation,
+            count: acc.count,
+            observed_shapes: acc.shapes,
+            observed_blocks: acc.blocks.len() as u32,
+        })
+        .collect()
+}
+
+fn likely_routing_critical_blocks(blocks: &[RoutingBlockReport]) -> Vec<RoutingCriticalBlock> {
+    blocks
+        .iter()
+        .filter(|block| block.primary_candidate.is_some())
+        .map(|block| RoutingCriticalBlock {
+            block_index: block.block_index,
+            label: block.label.clone(),
+            reason: match block.local_expert_count {
+                Some(experts) => format!(
+                    "contains a primary routing candidate linked to a {}-expert MoE block",
+                    experts
+                ),
+                None => "contains a primary routing candidate without confirmed expert linkage"
+                    .to_string(),
+            },
+            primary_candidate: block.primary_candidate.clone(),
+        })
+        .collect()
+}
+
+fn grok_layout_notes(
+    blocks: &[RoutingBlockReport],
+    d_model: Option<u64>,
+    inferred_experts: Option<u64>,
+) -> Vec<String> {
+    let mut notes = Vec::new();
+    let primaries = blocks
+        .iter()
+        .filter_map(|block| {
+            block
+                .primary_candidate
+                .as_ref()
+                .map(|locator| (block, locator))
+        })
+        .collect::<Vec<_>>();
+
+    if !primaries.is_empty()
+        && primaries.iter().all(|(block, locator)| {
+            block.candidates.iter().any(|candidate| {
+                candidate.shard_ordinal == locator.shard_ordinal
+                    && candidate.in_shard_index == locator.in_shard_index
+                    && candidate.dtype == TensorDType::F32
+                    && candidate.role == TensorRole::Tensor
+                    && candidate.orientation == RoutingOrientation::DModelToExperts
+            })
+        })
+    {
+        notes.push(
+            "Primary routing candidates are plain f32 tensors oriented from d_model to expert logits."
+                .to_string(),
+        );
+    }
+
+    let primary_slots = primaries
+        .iter()
+        .filter_map(|(_, locator)| locator.block_slot)
+        .collect::<Vec<_>>();
+    if !primary_slots.is_empty() && primary_slots.iter().all(|slot| *slot == primary_slots[0]) {
+        notes.push(format!(
+            "Primary routing candidates occupy a stable block slot ({}) across observed blocks.",
+            primary_slots[0]
+        ));
+    }
+
+    if let (Some(dm), Some(experts)) = (d_model, inferred_experts) {
+        let shape = TensorShape::new(vec![dm, experts]).render();
+        if primaries.iter().all(|(block, locator)| {
+            block.candidates.iter().any(|candidate| {
+                candidate.shard_ordinal == locator.shard_ordinal
+                    && candidate.in_shard_index == locator.in_shard_index
+                    && candidate.shape.dims() == [dm, experts]
+            })
+        }) {
+            notes.push(format!(
+                "Observed primary routing tensors match the Grok-style router shape `{shape}`."
+            ));
+        }
+    }
+
+    if blocks.iter().any(|block| block.block_index.is_none()) {
+        notes.push(
+            "At least one routing candidate is unassigned to a block; this usually indicates a truncated checkpoint scan or an unexpected shard layout."
+                .to_string(),
+        );
+    }
+
+    notes
+}
+
+fn shard_range(members: &[&TensorInfo]) -> Option<ShardRange> {
+    if members.is_empty() {
+        return None;
+    }
+    let mut start = u32::MAX;
+    let mut end_inclusive = 0u32;
+    for tensor in members {
+        start = start.min(tensor.shard_ordinal);
+        end_inclusive = end_inclusive.max(tensor.shard_ordinal);
+    }
+    Some(ShardRange {
+        start,
+        end_inclusive,
+    })
+}
+
+fn block_label(block_index: Option<u32>) -> String {
+    match block_index {
+        Some(index) => format!("block_{index:03}"),
+        None => "unassigned".to_string(),
+    }
+}
+
+fn mode_u64(values: Vec<u64>) -> Option<u64> {
+    let mut counts: BTreeMap<u64, usize> = BTreeMap::new();
+    for value in values {
+        *counts.entry(value).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(value, count)| (*count, *value))
+        .map(|(value, _)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::schema::{
+        BlockSummary, InferredHyperparams, InventoryTotals, ModelInventory, RoutingOrientation,
+        TensorDType, TensorInfo, TensorKind, TensorRole, TensorShape,
+    };
+
+    use super::build_routing_report;
+
+    #[test]
+    fn report_discovers_primary_router_and_orientation() {
+        let inv = inventory(vec![
+            tensor(
+                2,
+                Some(0),
+                Some(11),
+                TensorRole::Tensor,
+                TensorDType::F32,
+                vec![6144, 8],
+                TensorKind::Router,
+            ),
+            tensor(
+                3,
+                Some(0),
+                Some(1),
+                TensorRole::QuantWeight,
+                TensorDType::I8,
+                vec![8, 6144, 32768],
+                TensorKind::MoeExpertProjection {
+                    projection: crate::schema::MoeProjection::Unresolved,
+                },
+            ),
+        ]);
+
+        let report = build_routing_report(&inv);
+
+        assert_eq!(report.relevant_block_count, 1);
+        assert_eq!(report.candidate_tensors.len(), 1);
+        assert_eq!(
+            report.candidate_tensors[0].orientation,
+            RoutingOrientation::DModelToExperts
+        );
+        assert!(report.anomalies.is_empty());
+    }
+
+    #[test]
+    fn report_flags_moe_block_without_router() {
+        let inv = inventory(vec![tensor(
+            3,
+            Some(0),
+            Some(1),
+            TensorRole::QuantWeight,
+            TensorDType::I8,
+            vec![8, 6144, 32768],
+            TensorKind::MoeExpertProjection {
+                projection: crate::schema::MoeProjection::Unresolved,
+            },
+        )]);
+
+        let report = build_routing_report(&inv);
+
+        assert!(
+            report
+                .anomalies
+                .iter()
+                .any(|issue| issue.message.contains("no routing candidate"))
+        );
+    }
+
+    fn inventory(tensors: Vec<TensorInfo>) -> ModelInventory {
+        ModelInventory {
+            model_family: "grok-1".to_string(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1"),
+            shard_count: tensors.len() as u32,
+            inferred: InferredHyperparams {
+                vocab_size: Some(131072),
+                d_model: Some(6144),
+                n_experts: Some(8),
+                d_ff: Some(32768),
+                n_blocks: Some(1),
+            },
+            tensors,
+            blocks: vec![BlockSummary {
+                block_index: Some(0),
+                label: "block_000".to_string(),
+                shard_range: None,
+                tensor_count: 0,
+                total_nbytes: 0,
+                dtypes: Vec::new(),
+                kinds: Vec::new(),
+            }],
+            totals: InventoryTotals::default(),
+            schema_version: 1,
+        }
+    }
+
+    fn tensor(
+        shard_ordinal: u32,
+        block_index: Option<u32>,
+        block_slot: Option<u32>,
+        role: TensorRole,
+        dtype: TensorDType,
+        shape: Vec<u64>,
+        kind: TensorKind,
+    ) -> TensorInfo {
+        TensorInfo {
+            shard_path: PathBuf::from(format!("/tmp/tensor{shard_ordinal:05}_000")),
+            shard_ordinal,
+            in_shard_index: 0,
+            role,
+            dtype,
+            shape: TensorShape::new(shape),
+            offset: 0,
+            nbytes: 0,
+            kind,
+            block_index,
+            block_slot,
+        }
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -367,6 +367,135 @@ pub enum ExpertIssueCategory {
     LayoutAnomaly,
 }
 
+/// Top-level, serializable routing-oriented view of a checkpoint directory.
+/// This is derived from `ModelInventory` and remains structural only.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingReport {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub shard_count: u32,
+    pub inferred: InferredHyperparams,
+    pub relevant_block_count: u32,
+    pub expected_experts_per_router: Option<u64>,
+    pub candidate_tensors: Vec<RoutingTensorRef>,
+    pub blocks: Vec<RoutingBlockReport>,
+    pub orientation_summaries: Vec<RoutingOrientationSummary>,
+    pub likely_routing_critical_blocks: Vec<RoutingCriticalBlock>,
+    pub grok_layout_notes: Vec<String>,
+    pub anomalies: Vec<RoutingIssue>,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingBlockReport {
+    pub block_index: Option<u32>,
+    pub label: String,
+    pub shard_range: Option<ShardRange>,
+    pub local_expert_count: Option<u64>,
+    pub primary_candidate: Option<RoutingTensorLocator>,
+    pub candidates: Vec<RoutingTensorRef>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingTensorRef {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_index: Option<u32>,
+    pub block_slot: Option<u32>,
+    pub role: TensorRole,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    pub kind_label: String,
+    pub orientation: RoutingOrientation,
+    pub expert_axis: Option<u32>,
+    pub linked_expert_count: Option<u64>,
+    pub matches_inferred_expert_count: bool,
+    pub structural_name: String,
+    pub gate_metrics: RoutingGateMetrics,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingGateMetrics {
+    pub total_elements: u64,
+    pub total_nbytes: u64,
+    pub input_width: Option<u64>,
+    pub output_width: Option<u64>,
+    pub expert_count: Option<u64>,
+    pub logits_per_input: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingOrientationSummary {
+    pub orientation: RoutingOrientation,
+    pub count: u32,
+    pub observed_shapes: Vec<TensorShape>,
+    pub observed_blocks: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingCriticalBlock {
+    pub block_index: Option<u32>,
+    pub label: String,
+    pub reason: String,
+    pub primary_candidate: Option<RoutingTensorLocator>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingOrientation {
+    DModelToExperts,
+    ExpertsToDModel,
+    ExpertAxisLeading,
+    ExpertAxisTrailing,
+    Ambiguous,
+    Unknown,
+}
+
+impl RoutingOrientation {
+    pub fn label(self) -> &'static str {
+        match self {
+            RoutingOrientation::DModelToExperts => "d_model_to_experts",
+            RoutingOrientation::ExpertsToDModel => "experts_to_d_model",
+            RoutingOrientation::ExpertAxisLeading => "expert_axis_leading",
+            RoutingOrientation::ExpertAxisTrailing => "expert_axis_trailing",
+            RoutingOrientation::Ambiguous => "ambiguous",
+            RoutingOrientation::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingIssue {
+    pub severity: RoutingIssueSeverity,
+    pub category: RoutingIssueCategory,
+    pub block_index: Option<u32>,
+    pub tensor: Option<RoutingTensorLocator>,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingTensorLocator {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_slot: Option<u32>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingIssueSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingIssueCategory {
+    MissingCandidate,
+    ShapeSummary,
+    ExpertCountLinkage,
+    LayoutNote,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct InferredHyperparams {
     pub vocab_size: Option<u64>,


### PR DESCRIPTION
## What changed
- add a new `src/routing` analysis module that identifies candidate routing tensors from `ModelInventory`
- add a `routing-report` CLI subcommand with JSON and Markdown export
- add routing report schema types and renderers covering orientation summaries, gate tensor metrics, expert-count linkage, likely routing-critical blocks, and Grok-specific layout notes

## Why
The repo could classify router tensors, but it did not yet explain where routing likely lives or how the routing geometry is organized layer by layer. This adds that inspection layer without introducing router forward logic or runtime dependencies.

## Impact
- `cargo run -- routing-report <path-to-checkpoint>` now produces a structural routing report
- downstream consumers can inspect candidate routing tensors, their orientation, their relationship to expert counts, and layout anomalies
- the change stays within `xai-dissect`'s parser/analysis boundary and does not overlap with `corinth-canal` runtime concerns

## Validation
- `cargo test`
- `cargo run -- routing-report /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 26 --json /tmp/grok1_routing.json --md /tmp/grok1_routing.md`

## Notes
- the Grok-1 smoke run produced two `(6144, 8)` routing candidates with `d_model_to_experts` orientation and one expected anomaly caused by the truncated `--limit 26` scan leaving the first block's router just outside the sample window
- PR was opened through the GitHub connector