### PR TITLE
[codex] Add stats and SAAQ-readiness profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Static structural analysis of the Grok family of open-weight checkpoints.
 
 `xai-dissect` parses raw xAI weight shards (Pickle Protocol 4 / JAX dumps),
-builds a tensor inventory, and emits architecture, expert, and routing
-reports. It is a read-only structural tool: it never loads tensor bodies,
-never runs the model, and never produces inference output.
+builds a tensor inventory, and emits architecture, expert, routing, and
+offline profiling reports. It is a read-only analysis tool: it never mutates
+weights, never runs the model, and never produces inference output. The
+inventory/expert/routing paths stay parser-driven; the stats/SAAQ-readiness
+paths may sample tensor payload values for profiling.
 
 Current target:
 
@@ -29,6 +31,10 @@ here.
   (up / gate / down), quantization layout (`int8` weight + `f32` scales).
 - Routing analysis: router/gate tensor identification, shape consistency
   across layers, top-k inference from shape alone where possible.
+- Offline stats profiling: sampled norm / variance / outlier / sparsity-ish
+  heuristics per tensor and per layer.
+- SAAQ-readiness profiling: routing-critical vs. potentially compressible
+  regions, plus ranked candidate target manifests for future experiments.
 - Summary statistics: parameter counts (raw / effective / per-expert),
   quantized vs. unquantized byte budgets, shard-size histograms.
 - Exportable findings: stable, machine-readable artifacts (JSON / CSV /
@@ -38,7 +44,8 @@ here.
 
 - A full inference runtime. No forward pass, no sampler, no decode loop.
 - Projector logic (neuromorphic or otherwise).
-- SAAQ latent calibration, SAAQ scoring, or any latent-space experiments.
+- SAAQ latent calibration, SAAQ scoring, or latent-space experiments beyond
+  offline readiness profiling.
 - GPU kernels, CUDA/Metal/ROCm code, or perf tuning of matmul paths.
 - Symbolic regression over weights or activations.
 - Plot-heavy / dashboard-heavy interactive analysis.
@@ -68,10 +75,10 @@ never projects anything itself.
 
 ### SAAQ-latent
 `SAAQ-latent` owns SAAQ latent calibration and latent-space analysis.
-`xai-dissect` does not compute SAAQ scores, does not calibrate latents, and
-does not load tensor values into memory. The boundary is sharp: `xai-dissect`
-stops at "this tensor lives at this offset with this shape and dtype"; any
-interpretation of its numerical contents belongs in `SAAQ-latent`.
+`xai-dissect` does not compute SAAQ scores and does not calibrate latents.
+Its role is upstream reconnaissance: sampled tensor statistics, routing-risk
+flags, and candidate-target manifests that help decide where future SAAQ work
+should focus.
 
 ### Surrogate_Viz.jl
 `Surrogate_Viz.jl` owns visualization and dashboarding. `xai-dissect` emits
@@ -85,20 +92,25 @@ plots, does not ship a UI, and does not embed a plotting stack.
 cargo build --release
 
 # Inventory an entire checkpoint directory.
-./target/release/xai-dissect /path/to/grok-1/ckpt-0
+./target/release/xai-dissect inventory /path/to/grok-1/ckpt-0
 
 # Peek at a single shard.
-./target/release/xai-dissect /path/to/grok-1/ckpt-0 --limit 1
+./target/release/xai-dissect dissect /path/to/grok-1/ckpt-0 --limit 1
 
-# Non-default shard filename prefix.
-./target/release/xai-dissect /path/to/dump --prefix shard_
+# Expert and routing structure.
+./target/release/xai-dissect experts /path/to/grok-1/ckpt-0
+./target/release/xai-dissect routing-report /path/to/grok-1/ckpt-0
+
+# Offline profiling for future SAAQ work.
+./target/release/xai-dissect stats /path/to/grok-1/ckpt-0
+./target/release/xai-dissect saaq-readiness /path/to/grok-1/ckpt-0
 ```
 
-The CLI memory-maps each shard, validates the PROTO 4 header, scans the
-pickle byte grammar for ndarray anchors, and prints one row per tensor:
-`Idx | Role | Dtype | Shape | Offset | Nbytes`. `QuantizedWeight8bit`
-dataclasses are split into `quant.weight` (`int8`) and `quant.scales`
-(`f32`) rows. No tensor bodies are read.
+The parser-oriented commands memory-map each shard, validate the PROTO 4
+header, scan the pickle byte grammar for ndarray anchors, and classify the
+resulting tensors without executing model code. The stats-oriented commands
+reuse those offsets and sample tensor payload values for offline profiling;
+they still do not mutate weights or run inference.
 
 See `docs/architecture.md` for the intended layer breakdown and
 `docs/non_goals.md` for the full non-goals list.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ testable against a single shard or a full checkpoint directory.
         |
         +--> [ expert analysis ]   -> MoE expert geometry
         +--> [ routing analysis ]  -> router / gate geometry
-        +--> [ stats ]             -> parameter & byte accounting
+        +--> [ stats ]             -> offline tensor-value profiling
         |
         v
   [ reports / exports ]  -> JSON, CSV, Markdown
@@ -82,16 +82,16 @@ Explicitly does not execute routing, does not rank experts, and does not
 touch activation data.
 
 ### 6. stats
-Summary accounting over the inventory:
+Offline profiling over the inventory plus sampled tensor payloads:
 
-- total parameters (raw, effective after dequant accounting)
-- bytes on disk, bytes after notional dequant
-- shard-size histogram (the "6 MiB / 36 MiB / 1.5 GiB / 3 GiB" story for
-  Grok-1)
-- per-layer and per-role breakdowns
+- norm, variance, outlier, and sparsity-ish summaries
+- per-layer and per-tensor metrics
+- SAAQ-readiness scouting: likely routing-critical vs. potentially
+  compressible regions
+- ranked candidate-target manifests for future experiments
 
-Pure arithmetic over inventory records; no I/O beyond what inventory
-already did.
+Read-only payload sampling is allowed here. No weight mutation, no
+quantization runtime, and no model execution.
 
 ### 7. reports / exports
 Emits stable, machine-readable artifacts:
@@ -100,7 +100,8 @@ Emits stable, machine-readable artifacts:
 - `architecture.md` - human-readable summary (layer count, d_model,
   n_experts, head geometry, norm placement)
 - `experts.json` / `routing.json` - structured findings from (4) and (5)
-- `stats.csv` - parameter and byte accounting
+- `stats.json` / `saaq-readiness.json` - structured profiling outputs from (6)
+- `candidate-manifest.json` - ranked machine-readable target list for future experiments
 
 Exports are the only supported integration surface for downstream repos
 (`corinth-canal`, `SAAQ-latent`, `Surrogate_Viz.jl`). No in-process API is

--- a/docs/non_goals.md
+++ b/docs/non_goals.md
@@ -8,8 +8,10 @@ entirely. Pull requests expanding into these areas will be rejected.
 
 ### Inference runtime
 - No forward pass, no decode loop, no sampler, no KV cache.
-- No tensor body loads into host or device memory.
 - No model execution of any kind, even for "just a sanity check".
+
+Offline tensor-value sampling for stats profiling is in scope; runtime model
+execution is not.
 
 ### Projector logic
 - No spiking / neuromorphic projection of activations or weights.
@@ -18,7 +20,8 @@ entirely. Pull requests expanding into these areas will be rejected.
 
 ### SAAQ latent calibration
 - No SAAQ scoring, calibration, or latent-space analysis.
-- No numerical interpretation of tensor contents.
+- No numerical interpretation that turns into a latent-space method or a
+  quantization runtime.
 - Latent work lives in `SAAQ-latent`.
 
 ### GPU kernels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub mod parser;
 pub mod report;
 pub mod routing;
 pub mod schema;
+pub mod stats;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ use xai_dissect::inventory::{InventoryConfig, build_inventory};
 use xai_dissect::parser;
 use xai_dissect::report;
 use xai_dissect::routing::build_routing_report;
-use xai_dissect::schema::{ExpertAtlas, ModelInventory, RoutingReport, TensorInfo};
+use xai_dissect::schema::{
+    ExpertAtlas, ModelInventory, RoutingReport, SaaqReadinessReport, StatsProfileReport, TensorInfo,
+};
+use xai_dissect::stats::{StatsConfig, build_saaq_readiness_report, build_stats_report};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -114,6 +117,59 @@ enum Command {
         #[arg(long)]
         md: Option<PathBuf>,
     },
+    /// Profile tensor payload statistics for offline analysis.
+    Stats {
+        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+        path: PathBuf,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Model family tag written into the export header. Only `grok-1`
+        /// is officially supported today.
+        #[arg(long, default_value = "grok-1")]
+        family: String,
+        /// Maximum sampled values per tensor.
+        #[arg(long, default_value_t = 65_536)]
+        sample_values: usize,
+        /// If set, write the stats profile as pretty JSON to this path.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// If set, write the stats Markdown report to this path. If unset,
+        /// the Markdown report is printed to stdout.
+        #[arg(long)]
+        md: Option<PathBuf>,
+    },
+    /// Rank likely SAAQ experiment targets without applying SAAQ itself.
+    SaaqReadiness {
+        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+        path: PathBuf,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Model family tag written into the export header. Only `grok-1`
+        /// is officially supported today.
+        #[arg(long, default_value = "grok-1")]
+        family: String,
+        /// Maximum sampled values per tensor.
+        #[arg(long, default_value_t = 65_536)]
+        sample_values: usize,
+        /// If set, write the SAAQ-readiness report as pretty JSON.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// If set, write the SAAQ-readiness Markdown report. If unset, the
+        /// Markdown report is printed to stdout.
+        #[arg(long)]
+        md: Option<PathBuf>,
+        /// If set, write the machine-readable candidate manifest as pretty JSON.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -168,6 +224,42 @@ fn main() -> Result<()> {
             &family,
             json.as_deref(),
             md.as_deref(),
+        ),
+        Command::Stats {
+            path,
+            prefix,
+            limit,
+            family,
+            sample_values,
+            json,
+            md,
+        } => run_stats(
+            &path,
+            &prefix,
+            limit,
+            &family,
+            sample_values,
+            json.as_deref(),
+            md.as_deref(),
+        ),
+        Command::SaaqReadiness {
+            path,
+            prefix,
+            limit,
+            family,
+            sample_values,
+            json,
+            md,
+            manifest,
+        } => run_saaq_readiness(
+            &path,
+            &prefix,
+            limit,
+            &family,
+            sample_values,
+            json.as_deref(),
+            md.as_deref(),
+            manifest.as_deref(),
         ),
     }
 }
@@ -342,6 +434,92 @@ fn run_routing_report(
     Ok(())
 }
 
+// --- `stats` --------------------------------------------------------------
+
+fn run_stats(
+    path: &std::path::Path,
+    prefix: &str,
+    limit: Option<usize>,
+    family: &str,
+    sample_values: usize,
+    json_out: Option<&std::path::Path>,
+    md_out: Option<&std::path::Path>,
+) -> Result<()> {
+    let cfg = InventoryConfig {
+        prefix: prefix.to_string(),
+        limit,
+        model_family: family.to_string(),
+    };
+    let inv = build_inventory(path, &cfg)?;
+    let stats_cfg = StatsConfig {
+        max_sample_values: sample_values,
+        ..Default::default()
+    };
+    let report_doc = build_stats_report(&inv, &stats_cfg)?;
+
+    print_stats_console_summary(&report_doc);
+
+    if let Some(p) = json_out {
+        report::write_stats_json(&report_doc, p)?;
+        eprintln!("wrote JSON stats report -> {}", p.display());
+    }
+    if let Some(p) = md_out {
+        report::write_stats_markdown(&report_doc, p)?;
+        eprintln!("wrote Markdown stats report -> {}", p.display());
+    } else {
+        println!();
+        println!("{}", report::render_stats_markdown(&report_doc));
+    }
+
+    Ok(())
+}
+
+// --- `saaq-readiness` -----------------------------------------------------
+
+fn run_saaq_readiness(
+    path: &std::path::Path,
+    prefix: &str,
+    limit: Option<usize>,
+    family: &str,
+    sample_values: usize,
+    json_out: Option<&std::path::Path>,
+    md_out: Option<&std::path::Path>,
+    manifest_out: Option<&std::path::Path>,
+) -> Result<()> {
+    let cfg = InventoryConfig {
+        prefix: prefix.to_string(),
+        limit,
+        model_family: family.to_string(),
+    };
+    let inv = build_inventory(path, &cfg)?;
+    let stats_cfg = StatsConfig {
+        max_sample_values: sample_values,
+        ..Default::default()
+    };
+    let stats = build_stats_report(&inv, &stats_cfg)?;
+    let readiness = build_saaq_readiness_report(&inv, &stats);
+
+    print_saaq_console_summary(&readiness);
+
+    if let Some(p) = json_out {
+        report::write_saaq_readiness_json(&readiness, p)?;
+        eprintln!("wrote JSON SAAQ-readiness report -> {}", p.display());
+    }
+    if let Some(p) = md_out {
+        report::write_saaq_readiness_markdown(&readiness, p)?;
+        eprintln!("wrote Markdown SAAQ-readiness report -> {}", p.display());
+    } else {
+        println!();
+        println!("{}", report::render_saaq_readiness_markdown(&readiness));
+    }
+    if let Some(p) = manifest_out {
+        report::write_candidate_manifest_json(&readiness.manifest, p)?;
+        eprintln!("wrote candidate manifest -> {}", p.display());
+    }
+
+    Ok(())
+}
+
 fn print_console_summary(inv: &ModelInventory) {
     eprintln!(
         "checkpoint: {}  shards: {}  tensors: {}",
@@ -414,6 +592,36 @@ fn print_routing_console_summary(report_doc: &RoutingReport) {
         eprintln!(
             "warn: routing report contains {} anomalies",
             report_doc.anomalies.len()
+        );
+    }
+}
+
+fn print_stats_console_summary(report_doc: &StatsProfileReport) {
+    eprintln!(
+        "checkpoint: {}  tensors: {}  layers: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.tensors.len(),
+        report_doc.layers.len(),
+    );
+    eprintln!(
+        "sample_values_per_tensor: {}  mean_rms: {:.6}  mean_variance: {:.6}",
+        report_doc.sampling.max_sample_values,
+        report_doc.norm_summary.mean_rms,
+        report_doc.variance_summary.mean_variance,
+    );
+}
+
+fn print_saaq_console_summary(report_doc: &SaaqReadinessReport) {
+    eprintln!(
+        "checkpoint: {}  candidate_targets: {}  routing_critical: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.candidate_targets.len(),
+        report_doc.routing_critical_tensors.len(),
+    );
+    if let Some(top) = report_doc.candidate_targets.first() {
+        eprintln!(
+            "top_candidate: {}  readiness: {:.3}  risk: {:.3}",
+            top.structural_name, top.readiness_score, top.risk_score,
         );
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::schema::{
-    BlockSummary, ExpertAtlas, ExpertIssueCategory, ModelInventory, RoutingIssueCategory,
-    RoutingReport,
+    BlockSummary, CandidateTensorManifest, ExpertAtlas, ExpertIssueCategory, ModelInventory,
+    RoutingIssueCategory, RoutingReport, SaaqDisposition, SaaqReadinessReport, StatsProfileReport,
 };
 
 /// Write the full inventory as pretty-printed JSON. The JSON layout is the
@@ -35,6 +35,29 @@ pub fn write_expert_json(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
 /// Write the full routing report as pretty-printed JSON.
 pub fn write_routing_json(report_doc: &RoutingReport, out: &Path) -> Result<()> {
     let s = serde_json::to_string_pretty(report_doc).context("serialize routing report to json")?;
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Write the full stats profile as pretty-printed JSON.
+pub fn write_stats_json(report_doc: &StatsProfileReport, out: &Path) -> Result<()> {
+    let s = serde_json::to_string_pretty(report_doc).context("serialize stats report to json")?;
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Write the full SAAQ-readiness report as pretty-printed JSON.
+pub fn write_saaq_readiness_json(report_doc: &SaaqReadinessReport, out: &Path) -> Result<()> {
+    let s = serde_json::to_string_pretty(report_doc)
+        .context("serialize saaq-readiness report to json")?;
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Write the candidate manifest as pretty-printed JSON.
+pub fn write_candidate_manifest_json(manifest: &CandidateTensorManifest, out: &Path) -> Result<()> {
+    let s =
+        serde_json::to_string_pretty(manifest).context("serialize candidate manifest to json")?;
     fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
     Ok(())
 }
@@ -559,6 +582,277 @@ pub fn write_routing_markdown(report_doc: &RoutingReport, out: &Path) -> Result<
     Ok(())
 }
 
+/// Render a Markdown summary report for humans from a stats profile.
+pub fn render_stats_markdown(report_doc: &StatsProfileReport) -> String {
+    let mut md = String::new();
+
+    let _ = writeln!(md, "# xai-dissect stats report");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "- **model_family**: `{}`", report_doc.model_family);
+    let _ = writeln!(
+        md,
+        "- **checkpoint**: `{}`",
+        report_doc.checkpoint_path.display()
+    );
+    let _ = writeln!(md, "- **shards**: {}", report_doc.shard_count);
+    let _ = writeln!(
+        md,
+        "- **sample_values_per_tensor**: {}",
+        report_doc.sampling.max_sample_values
+    );
+    let _ = writeln!(md, "- **schema_version**: {}", report_doc.schema_version);
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Norm summary");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "- **mean_rms**: {:.6}",
+        report_doc.norm_summary.mean_rms
+    );
+    render_ranked_table(&mut md, "Top RMS tensors", &report_doc.norm_summary.top_rms);
+    render_ranked_table(&mut md, "Top L2 tensors", &report_doc.norm_summary.top_l2);
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Variance summary");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "- **mean_variance**: {:.6}",
+        report_doc.variance_summary.mean_variance
+    );
+    render_ranked_table(
+        &mut md,
+        "Top variance tensors",
+        &report_doc.variance_summary.top_variance,
+    );
+    render_ranked_table(
+        &mut md,
+        "Lowest variance tensors",
+        &report_doc.variance_summary.lowest_variance,
+    );
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Outlier summary");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "- **mean_outlier_fraction**: {:.6}",
+        report_doc.outlier_summary.mean_outlier_fraction
+    );
+    render_ranked_table(
+        &mut md,
+        "Most outlier-heavy tensors",
+        &report_doc.outlier_summary.most_outlier_heavy,
+    );
+    render_ranked_table(
+        &mut md,
+        "Highest peak-to-RMS tensors",
+        &report_doc.outlier_summary.highest_peak_to_rms,
+    );
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Per-layer metrics");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Label | Block | Tensors | Bytes | Mean RMS | Mean variance | Mean outlier frac | Routing tensors | Candidate-like tensors |"
+    );
+    let _ = writeln!(
+        md,
+        "| ----- | ----: | ------: | ----: | -------: | ------------: | ----------------: | --------------: | ---------------------: |"
+    );
+    for layer in &report_doc.layers {
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} ({}) | {:.6} | {:.6} | {:.6} | {} | {} |",
+            layer.label,
+            fmt_opt_u32(layer.block_index),
+            layer.tensor_count,
+            layer.total_nbytes,
+            human_bytes(layer.total_nbytes),
+            layer.mean_rms,
+            layer.mean_variance,
+            layer.mean_outlier_fraction,
+            layer.routing_tensor_count,
+            layer.compressible_candidate_count
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Per-tensor metrics");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Tensor | Kind | Dtype | Shape | RMS | Variance | Zero frac | Near-zero frac | Outlier frac | Distribution |"
+    );
+    let _ = writeln!(
+        md,
+        "| ------ | ---- | ----- | ----- | ---: | -------: | --------: | -------------: | -----------: | ------------ |"
+    );
+    for tensor in &report_doc.tensors {
+        let _ = writeln!(
+            md,
+            "| `{}` | {} | {} | `{}` | {:.6} | {:.6} | {:.4} | {:.4} | {:.4} | {} |",
+            tensor.structural_name,
+            tensor.kind_label,
+            tensor.dtype.label(),
+            tensor.shape.render(),
+            tensor.rms,
+            tensor.variance,
+            tensor.zero_fraction,
+            tensor.near_zero_fraction,
+            tensor.outlier_fraction,
+            tensor.distribution_label
+        );
+    }
+
+    md
+}
+
+/// Write the stats Markdown summary to `out`.
+pub fn write_stats_markdown(report_doc: &StatsProfileReport, out: &Path) -> Result<()> {
+    let s = render_stats_markdown(report_doc);
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
+/// Render a Markdown summary report for humans from a SAAQ-readiness report.
+pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> String {
+    let mut md = String::new();
+
+    let _ = writeln!(md, "# xai-dissect SAAQ-readiness report");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "- **model_family**: `{}`", report_doc.model_family);
+    let _ = writeln!(
+        md,
+        "- **checkpoint**: `{}`",
+        report_doc.checkpoint_path.display()
+    );
+    let _ = writeln!(md, "- **shards**: {}", report_doc.shard_count);
+    let _ = writeln!(
+        md,
+        "- **candidate_targets**: {}",
+        report_doc.candidate_targets.len()
+    );
+    let _ = writeln!(
+        md,
+        "- **routing_critical_tensors**: {}",
+        report_doc.routing_critical_tensors.len()
+    );
+    let _ = writeln!(md, "- **schema_version**: {}", report_doc.schema_version);
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Candidate target tensors");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Rank | Tensor | Kind | Region | Readiness | Opportunity | Risk | Disposition |"
+    );
+    let _ = writeln!(
+        md,
+        "| ---: | ------ | ---- | ------ | --------: | ----------: | ---: | ----------- |"
+    );
+    for candidate in &report_doc.candidate_targets {
+        let _ = writeln!(
+            md,
+            "| {} | `{}` | {} | {} | {:.3} | {:.3} | {:.3} | {} |",
+            candidate.rank,
+            candidate.structural_name,
+            candidate.kind_label,
+            saaq_region_label(candidate.region_class),
+            candidate.readiness_score,
+            candidate.opportunity_score,
+            candidate.risk_score,
+            saaq_disposition_label(candidate.disposition)
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Routing-critical tensors");
+    let _ = writeln!(md);
+    if report_doc.routing_critical_tensors.is_empty() {
+        let _ = writeln!(md, "None detected.");
+    } else {
+        let _ = writeln!(md, "| Tensor | Readiness | Risk | Reasons |");
+        let _ = writeln!(md, "| ------ | --------: | ---: | ------- |");
+        for candidate in &report_doc.routing_critical_tensors {
+            let _ = writeln!(
+                md,
+                "| `{}` | {:.3} | {:.3} | {} |",
+                candidate.structural_name,
+                candidate.readiness_score,
+                candidate.risk_score,
+                candidate.reasons.join("<br>")
+            );
+        }
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Highest-risk tensors");
+    let _ = writeln!(md);
+    if report_doc.risky_tensors.is_empty() {
+        let _ = writeln!(md, "None detected.");
+    } else {
+        let _ = writeln!(md, "| Tensor | Region | Risk | Reasons |");
+        let _ = writeln!(md, "| ------ | ------ | ---: | ------- |");
+        for candidate in &report_doc.risky_tensors {
+            let _ = writeln!(
+                md,
+                "| `{}` | {} | {:.3} | {} |",
+                candidate.structural_name,
+                saaq_region_label(candidate.region_class),
+                candidate.risk_score,
+                candidate.reasons.join("<br>")
+            );
+        }
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Layer readiness");
+    let _ = writeln!(md);
+    let _ = writeln!(
+        md,
+        "| Label | Block | Routing critical | Candidate targets | Mean readiness | Max risk |"
+    );
+    let _ = writeln!(
+        md,
+        "| ----- | ----: | ---------------- | ----------------: | -------------: | -------: |"
+    );
+    for layer in &report_doc.layer_readiness {
+        let _ = writeln!(
+            md,
+            "| {} | {} | {} | {} | {:.3} | {:.3} |",
+            layer.label,
+            fmt_opt_u32(layer.block_index),
+            if layer.routing_critical { "yes" } else { "no" },
+            layer.candidate_target_count,
+            layer.mean_readiness_score,
+            layer.max_risk_score
+        );
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Notes");
+    let _ = writeln!(md);
+    if report_doc.notes.is_empty() {
+        let _ = writeln!(md, "None.");
+    } else {
+        for note in &report_doc.notes {
+            let _ = writeln!(md, "- {}", note);
+        }
+    }
+
+    md
+}
+
+/// Write the SAAQ-readiness Markdown summary to `out`.
+pub fn write_saaq_readiness_markdown(report_doc: &SaaqReadinessReport, out: &Path) -> Result<()> {
+    let s = render_saaq_readiness_markdown(report_doc);
+    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
 // --- Helpers ---------------------------------------------------------------
 
 fn render_kinds(b: &BlockSummary) -> String {
@@ -720,5 +1014,46 @@ fn render_routing_issue_section(
             tensor,
             issue.message
         );
+    }
+}
+
+fn render_ranked_table(md: &mut String, title: &str, rows: &[crate::schema::RankedTensorStat]) {
+    let _ = writeln!(md);
+    let _ = writeln!(md, "### {}", title);
+    let _ = writeln!(md);
+    if rows.is_empty() {
+        let _ = writeln!(md, "None detected.");
+        return;
+    }
+    let _ = writeln!(md, "| Tensor | Kind | Block | Value |");
+    let _ = writeln!(md, "| ------ | ---- | ----: | ----: |");
+    for row in rows {
+        let _ = writeln!(
+            md,
+            "| `{}` | {} | {} | {:.6} |",
+            row.structural_name,
+            row.kind_label,
+            fmt_opt_u32(row.block_index),
+            row.value
+        );
+    }
+}
+
+fn saaq_region_label(region: crate::schema::SaaqRegionClass) -> &'static str {
+    match region {
+        crate::schema::SaaqRegionClass::RoutingCritical => "routing_critical",
+        crate::schema::SaaqRegionClass::NormalizationSensitive => "normalization_sensitive",
+        crate::schema::SaaqRegionClass::AlreadyCompressed => "already_compressed",
+        crate::schema::SaaqRegionClass::PotentialCompressionTarget => "potential_target",
+        crate::schema::SaaqRegionClass::EmbeddingHeavy => "embedding_heavy",
+        crate::schema::SaaqRegionClass::Unknown => "unknown",
+    }
+}
+
+fn saaq_disposition_label(disposition: SaaqDisposition) -> &'static str {
+    match disposition {
+        SaaqDisposition::Candidate => "candidate",
+        SaaqDisposition::ObserveOnly => "observe_only",
+        SaaqDisposition::AvoidForNow => "avoid_for_now",
     }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -496,6 +496,187 @@ pub enum RoutingIssueCategory {
     LayoutNote,
 }
 
+/// Top-level, serializable tensor-statistics profile. Unlike the inventory,
+/// this document is allowed to summarize sampled tensor payload values, but
+/// it remains offline analysis only.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StatsProfileReport {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub shard_count: u32,
+    pub inferred: InferredHyperparams,
+    pub sampling: StatsSamplingConfig,
+    pub tensors: Vec<TensorStats>,
+    pub layers: Vec<LayerStats>,
+    pub norm_summary: NormSummary,
+    pub variance_summary: VarianceSummary,
+    pub outlier_summary: OutlierSummary,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StatsSamplingConfig {
+    pub max_sample_values: u64,
+    pub f32_near_zero_abs: f64,
+    pub i8_near_zero_abs: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TensorStats {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_index: Option<u32>,
+    pub block_slot: Option<u32>,
+    pub structural_name: String,
+    pub role: TensorRole,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    pub kind_label: String,
+    pub sampled: bool,
+    pub total_values: u64,
+    pub sample_values: u64,
+    pub total_nbytes: u64,
+    pub mean: f64,
+    pub variance: f64,
+    pub stddev: f64,
+    pub min: f64,
+    pub max: f64,
+    pub max_abs: f64,
+    pub l1_norm: f64,
+    pub l2_norm: f64,
+    pub rms: f64,
+    pub zero_fraction: f64,
+    pub near_zero_fraction: f64,
+    pub positive_fraction: f64,
+    pub negative_fraction: f64,
+    pub outlier_fraction: f64,
+    pub peak_to_rms: f64,
+    pub distribution_label: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LayerStats {
+    pub block_index: Option<u32>,
+    pub label: String,
+    pub tensor_count: u32,
+    pub sampled_tensor_count: u32,
+    pub total_nbytes: u64,
+    pub mean_rms: f64,
+    pub mean_variance: f64,
+    pub mean_outlier_fraction: f64,
+    pub routing_tensor_count: u32,
+    pub compressible_candidate_count: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RankedTensorStat {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub structural_name: String,
+    pub kind_label: String,
+    pub block_index: Option<u32>,
+    pub value: f64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NormSummary {
+    pub mean_rms: f64,
+    pub max_rms: Option<RankedTensorStat>,
+    pub max_l2: Option<RankedTensorStat>,
+    pub top_rms: Vec<RankedTensorStat>,
+    pub top_l2: Vec<RankedTensorStat>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VarianceSummary {
+    pub mean_variance: f64,
+    pub max_variance: Option<RankedTensorStat>,
+    pub min_variance: Option<RankedTensorStat>,
+    pub top_variance: Vec<RankedTensorStat>,
+    pub lowest_variance: Vec<RankedTensorStat>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OutlierSummary {
+    pub mean_outlier_fraction: f64,
+    pub most_outlier_heavy: Vec<RankedTensorStat>,
+    pub highest_peak_to_rms: Vec<RankedTensorStat>,
+}
+
+/// Top-level, serializable profiling report for future SAAQ experiments.
+/// This does not apply SAAQ; it identifies where experiments may be
+/// promising or risky.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SaaqReadinessReport {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub shard_count: u32,
+    pub inferred: InferredHyperparams,
+    pub candidate_targets: Vec<SaaqCandidate>,
+    pub routing_critical_tensors: Vec<SaaqCandidate>,
+    pub risky_tensors: Vec<SaaqCandidate>,
+    pub layer_readiness: Vec<SaaqLayerReadiness>,
+    pub notes: Vec<String>,
+    pub manifest: CandidateTensorManifest,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CandidateTensorManifest {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub candidates: Vec<SaaqCandidate>,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SaaqCandidate {
+    pub rank: u32,
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_index: Option<u32>,
+    pub block_slot: Option<u32>,
+    pub structural_name: String,
+    pub kind_label: String,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    pub region_class: SaaqRegionClass,
+    pub disposition: SaaqDisposition,
+    pub readiness_score: f64,
+    pub opportunity_score: f64,
+    pub risk_score: f64,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SaaqLayerReadiness {
+    pub block_index: Option<u32>,
+    pub label: String,
+    pub routing_critical: bool,
+    pub candidate_target_count: u32,
+    pub mean_readiness_score: f64,
+    pub max_risk_score: f64,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SaaqRegionClass {
+    RoutingCritical,
+    NormalizationSensitive,
+    AlreadyCompressed,
+    PotentialCompressionTarget,
+    EmbeddingHeavy,
+    Unknown,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SaaqDisposition {
+    Candidate,
+    ObserveOnly,
+    AvoidForNow,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct InferredHyperparams {
     pub vocab_size: Option<u64>,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,0 +1,942 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Offline tensor-payload profiling for SAAQ-readiness scouting. This layer
+// may read tensor payload bytes, but it never mutates weights and never
+// executes model code.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs::File;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use memmap2::Mmap;
+
+use crate::routing::build_routing_report;
+use crate::schema::{
+    CandidateTensorManifest, InferredHyperparams, LayerStats, ModelInventory, NormSummary,
+    OutlierSummary, RankedTensorStat, RoutingReport, SaaqCandidate, SaaqDisposition,
+    SaaqLayerReadiness, SaaqReadinessReport, SaaqRegionClass, StatsProfileReport,
+    StatsSamplingConfig, TensorDType, TensorInfo, TensorKind, TensorStats, VarianceSummary,
+};
+
+pub const STATS_PROFILE_SCHEMA_VERSION: u32 = 1;
+pub const SAAQ_READINESS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Debug)]
+pub struct StatsConfig {
+    pub max_sample_values: usize,
+    pub f32_near_zero_abs: f64,
+    pub i8_near_zero_abs: i64,
+}
+
+impl Default for StatsConfig {
+    fn default() -> Self {
+        Self {
+            max_sample_values: 65_536,
+            f32_near_zero_abs: 1e-3,
+            i8_near_zero_abs: 1,
+        }
+    }
+}
+
+/// Build a tensor-statistics profile from an inventory.
+pub fn build_stats_report(inv: &ModelInventory, cfg: &StatsConfig) -> Result<StatsProfileReport> {
+    let mut shard_cache = ShardCache::default();
+    let mut tensors = Vec::with_capacity(inv.tensors.len());
+
+    for tensor in &inv.tensors {
+        let bytes = shard_cache.tensor_bytes(tensor)?;
+        tensors.push(profile_tensor(tensor, bytes, cfg)?);
+    }
+
+    let layers = summarize_layers(&tensors);
+    let norm_summary = summarize_norms(&tensors);
+    let variance_summary = summarize_variance(&tensors);
+    let outlier_summary = summarize_outliers(&tensors);
+
+    Ok(StatsProfileReport {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        shard_count: inv.shard_count,
+        inferred: clone_hyperparams(&inv.inferred),
+        sampling: StatsSamplingConfig {
+            max_sample_values: cfg.max_sample_values as u64,
+            f32_near_zero_abs: cfg.f32_near_zero_abs,
+            i8_near_zero_abs: cfg.i8_near_zero_abs,
+        },
+        tensors,
+        layers,
+        norm_summary,
+        variance_summary,
+        outlier_summary,
+        schema_version: STATS_PROFILE_SCHEMA_VERSION,
+    })
+}
+
+/// Build a SAAQ-readiness report from an inventory. This reuses the routing
+/// analysis and the tensor statistics profile to rank candidate tensors.
+pub fn build_saaq_readiness_report(
+    inv: &ModelInventory,
+    stats: &StatsProfileReport,
+) -> SaaqReadinessReport {
+    let routing = build_routing_report(inv);
+    let routing_locs = routing_tensor_set(&routing);
+    let routing_blocks = routing_block_set(&routing);
+
+    let mut scored = stats
+        .tensors
+        .iter()
+        .map(|tensor| score_tensor(tensor, inv, &routing, &routing_locs, &routing_blocks))
+        .collect::<Vec<_>>();
+
+    scored.sort_by(|a, b| {
+        b.readiness_score
+            .partial_cmp(&a.readiness_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for (index, candidate) in scored.iter_mut().enumerate() {
+        candidate.rank = (index + 1) as u32;
+    }
+
+    let mut candidate_targets = scored
+        .iter()
+        .filter(|candidate| candidate.disposition == SaaqDisposition::Candidate)
+        .cloned()
+        .collect::<Vec<_>>();
+    if candidate_targets.is_empty() {
+        if let Some(fallback) = scored.iter().find(|candidate| {
+            !matches!(
+                candidate.region_class,
+                SaaqRegionClass::RoutingCritical
+                    | SaaqRegionClass::NormalizationSensitive
+                    | SaaqRegionClass::AlreadyCompressed
+            )
+        }) {
+            let mut fallback = fallback.clone();
+            fallback.disposition = SaaqDisposition::Candidate;
+            fallback
+                .reasons
+                .push("promoted as the best available non-routing target in a constrained sample".to_string());
+            candidate_targets.push(fallback);
+        }
+    }
+    let routing_critical_tensors = scored
+        .iter()
+        .filter(|candidate| candidate.region_class == SaaqRegionClass::RoutingCritical)
+        .cloned()
+        .collect::<Vec<_>>();
+    let risky_tensors = scored
+        .iter()
+        .filter(|candidate| candidate.risk_score >= 0.7)
+        .take(25)
+        .cloned()
+        .collect::<Vec<_>>();
+    let layer_readiness = summarize_layer_readiness(&scored, &routing_blocks);
+    let notes = build_saaq_notes(&candidate_targets, &routing_critical_tensors, &routing);
+    let manifest = CandidateTensorManifest {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        candidates: candidate_targets.clone(),
+        schema_version: SAAQ_READINESS_SCHEMA_VERSION,
+    };
+
+    SaaqReadinessReport {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        shard_count: inv.shard_count,
+        inferred: clone_hyperparams(&inv.inferred),
+        candidate_targets,
+        routing_critical_tensors,
+        risky_tensors,
+        layer_readiness,
+        notes,
+        manifest,
+        schema_version: SAAQ_READINESS_SCHEMA_VERSION,
+    }
+}
+
+#[derive(Default)]
+struct ShardCache {
+    by_path: HashMap<PathBuf, Mmap>,
+}
+
+impl ShardCache {
+    fn tensor_bytes<'a>(&'a mut self, tensor: &TensorInfo) -> Result<&'a [u8]> {
+        if !self.by_path.contains_key(&tensor.shard_path) {
+            let file = File::open(&tensor.shard_path)
+                .with_context(|| format!("open {}", tensor.shard_path.display()))?;
+            let mm = unsafe { Mmap::map(&file) }
+                .with_context(|| format!("mmap {}", tensor.shard_path.display()))?;
+            self.by_path.insert(tensor.shard_path.clone(), mm);
+        }
+        let mm = self
+            .by_path
+            .get(&tensor.shard_path)
+            .expect("inserted mmap missing");
+        let start = tensor.offset as usize;
+        let end = start.saturating_add(tensor.nbytes as usize);
+        if end > mm.len() {
+            bail!(
+                "tensor payload overruns shard: {} [{}..{}) > {}",
+                tensor.shard_path.display(),
+                start,
+                end,
+                mm.len()
+            );
+        }
+        Ok(&mm[start..end])
+    }
+}
+
+fn profile_tensor(tensor: &TensorInfo, bytes: &[u8], cfg: &StatsConfig) -> Result<TensorStats> {
+    let values = sample_tensor_values(tensor, bytes, cfg.max_sample_values)?;
+    if values.is_empty() {
+        bail!(
+            "tensor {} has no values after sampling",
+            tensor_structural_name(tensor)
+        );
+    }
+
+    let sample_values = values.len() as u64;
+    let total_values = tensor.shape.numel();
+    let sampled = sample_values < total_values;
+
+    let mean = values.iter().copied().sum::<f64>() / sample_values as f64;
+    let variance = values
+        .iter()
+        .map(|v| {
+            let d = *v - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / sample_values as f64;
+    let stddev = variance.sqrt();
+    let min = values.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let max_abs = values.iter().copied().map(f64::abs).fold(0.0, f64::max);
+    let l1_norm = values.iter().copied().map(f64::abs).sum::<f64>();
+    let l2_norm = values.iter().copied().map(|v| v * v).sum::<f64>().sqrt();
+    let rms = (values.iter().copied().map(|v| v * v).sum::<f64>() / sample_values as f64).sqrt();
+
+    let near_zero_abs = match tensor.dtype {
+        TensorDType::F32 => cfg.f32_near_zero_abs,
+        TensorDType::I8 => cfg.i8_near_zero_abs as f64,
+    };
+    let zero_count = values.iter().filter(|v| **v == 0.0).count() as u64;
+    let near_zero_count = values.iter().filter(|v| v.abs() <= near_zero_abs).count() as u64;
+    let positive_count = values.iter().filter(|v| **v > 0.0).count() as u64;
+    let negative_count = values.iter().filter(|v| **v < 0.0).count() as u64;
+    let outlier_count = if stddev > 0.0 {
+        values
+            .iter()
+            .filter(|v| ((*v - mean).abs() / stddev) > 6.0)
+            .count() as u64
+    } else {
+        0
+    };
+    let peak_to_rms = if rms > 0.0 { max_abs / rms } else { 0.0 };
+    let distribution_label = distribution_label(
+        zero_count as f64 / sample_values as f64,
+        near_zero_count as f64 / sample_values as f64,
+        outlier_count as f64 / sample_values as f64,
+        peak_to_rms,
+    );
+
+    Ok(TensorStats {
+        shard_ordinal: tensor.shard_ordinal,
+        in_shard_index: tensor.in_shard_index,
+        block_index: tensor.block_index,
+        block_slot: tensor.block_slot,
+        structural_name: tensor_structural_name(tensor),
+        role: tensor.role,
+        dtype: tensor.dtype,
+        shape: tensor.shape.clone(),
+        kind_label: tensor.kind.short_label(),
+        sampled,
+        total_values,
+        sample_values,
+        total_nbytes: tensor.nbytes,
+        mean,
+        variance,
+        stddev,
+        min,
+        max,
+        max_abs,
+        l1_norm,
+        l2_norm,
+        rms,
+        zero_fraction: zero_count as f64 / sample_values as f64,
+        near_zero_fraction: near_zero_count as f64 / sample_values as f64,
+        positive_fraction: positive_count as f64 / sample_values as f64,
+        negative_fraction: negative_count as f64 / sample_values as f64,
+        outlier_fraction: outlier_count as f64 / sample_values as f64,
+        peak_to_rms,
+        distribution_label,
+    })
+}
+
+fn sample_tensor_values(
+    tensor: &TensorInfo,
+    bytes: &[u8],
+    max_sample_values: usize,
+) -> Result<Vec<f64>> {
+    let total_values = tensor.shape.numel() as usize;
+    if total_values == 0 {
+        return Ok(Vec::new());
+    }
+    let itemsize = tensor.dtype.itemsize();
+    if bytes.len() != total_values.saturating_mul(itemsize) {
+        bail!(
+            "tensor byte length mismatch for {}: got {} expected {}",
+            tensor_structural_name(tensor),
+            bytes.len(),
+            total_values.saturating_mul(itemsize)
+        );
+    }
+
+    let sample_len = total_values.min(max_sample_values.max(1));
+    let mut out = Vec::with_capacity(sample_len);
+    if sample_len == total_values {
+        for index in 0..total_values {
+            out.push(read_value(tensor.dtype, bytes, index));
+        }
+    } else {
+        for sample_index in 0..sample_len {
+            let index = sample_index.saturating_mul(total_values) / sample_len;
+            out.push(read_value(tensor.dtype, bytes, index));
+        }
+    }
+    Ok(out)
+}
+
+fn read_value(dtype: TensorDType, bytes: &[u8], index: usize) -> f64 {
+    match dtype {
+        TensorDType::F32 => {
+            let start = index * 4;
+            let mut raw = [0u8; 4];
+            raw.copy_from_slice(&bytes[start..start + 4]);
+            f32::from_le_bytes(raw) as f64
+        }
+        TensorDType::I8 => (bytes[index] as i8) as f64,
+    }
+}
+
+fn distribution_label(
+    zero_fraction: f64,
+    near_zero_fraction: f64,
+    outlier_fraction: f64,
+    peak_to_rms: f64,
+) -> String {
+    if zero_fraction >= 0.2 {
+        "zero_heavy".to_string()
+    } else if near_zero_fraction >= 0.5 {
+        "near_zero_heavy".to_string()
+    } else if outlier_fraction >= 0.01 || peak_to_rms >= 20.0 {
+        "outlier_heavy".to_string()
+    } else {
+        "dense_balanced".to_string()
+    }
+}
+
+fn summarize_layers(tensors: &[TensorStats]) -> Vec<LayerStats> {
+    let mut by_layer: BTreeMap<(Option<u32>, String), Vec<&TensorStats>> = BTreeMap::new();
+    for tensor in tensors {
+        let label = layer_label_for_tensor(tensor);
+        by_layer
+            .entry((tensor.block_index, label))
+            .or_default()
+            .push(tensor);
+    }
+
+    by_layer
+        .into_iter()
+        .map(|((block_index, label), members)| {
+            let tensor_count = members.len() as u32;
+            let sampled_tensor_count =
+                members.iter().filter(|tensor| tensor.sampled).count() as u32;
+            let total_nbytes = members
+                .iter()
+                .map(|tensor| tensor.total_nbytes)
+                .sum::<u64>();
+            let mean_rms =
+                members.iter().map(|tensor| tensor.rms).sum::<f64>() / tensor_count as f64;
+            let mean_variance =
+                members.iter().map(|tensor| tensor.variance).sum::<f64>() / tensor_count as f64;
+            let mean_outlier_fraction = members
+                .iter()
+                .map(|tensor| tensor.outlier_fraction)
+                .sum::<f64>()
+                / tensor_count as f64;
+            let routing_tensor_count = members
+                .iter()
+                .filter(|tensor| tensor.kind_label == "router")
+                .count() as u32;
+            let compressible_candidate_count = members
+                .iter()
+                .filter(|tensor| is_potential_compression_target(tensor))
+                .count() as u32;
+
+            LayerStats {
+                block_index,
+                label,
+                tensor_count,
+                sampled_tensor_count,
+                total_nbytes,
+                mean_rms,
+                mean_variance,
+                mean_outlier_fraction,
+                routing_tensor_count,
+                compressible_candidate_count,
+            }
+        })
+        .collect()
+}
+
+fn summarize_norms(tensors: &[TensorStats]) -> NormSummary {
+    let mean_rms = mean_of(tensors.iter().map(|tensor| tensor.rms));
+    NormSummary {
+        mean_rms,
+        max_rms: rank_max_by(tensors, |tensor| tensor.rms),
+        max_l2: rank_max_by(tensors, |tensor| tensor.l2_norm),
+        top_rms: top_by_desc(tensors, |tensor| tensor.rms, 10),
+        top_l2: top_by_desc(tensors, |tensor| tensor.l2_norm, 10),
+    }
+}
+
+fn summarize_variance(tensors: &[TensorStats]) -> VarianceSummary {
+    VarianceSummary {
+        mean_variance: mean_of(tensors.iter().map(|tensor| tensor.variance)),
+        max_variance: rank_max_by(tensors, |tensor| tensor.variance),
+        min_variance: rank_min_by(tensors, |tensor| tensor.variance),
+        top_variance: top_by_desc(tensors, |tensor| tensor.variance, 10),
+        lowest_variance: top_by_asc(tensors, |tensor| tensor.variance, 10),
+    }
+}
+
+fn summarize_outliers(tensors: &[TensorStats]) -> OutlierSummary {
+    OutlierSummary {
+        mean_outlier_fraction: mean_of(tensors.iter().map(|tensor| tensor.outlier_fraction)),
+        most_outlier_heavy: top_by_desc(tensors, |tensor| tensor.outlier_fraction, 10),
+        highest_peak_to_rms: top_by_desc(tensors, |tensor| tensor.peak_to_rms, 10),
+    }
+}
+
+fn rank_max_by<F>(tensors: &[TensorStats], f: F) -> Option<RankedTensorStat>
+where
+    F: Fn(&TensorStats) -> f64,
+{
+    tensors
+        .iter()
+        .max_by(|a, b| f(a).partial_cmp(&f(b)).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|tensor| ranked_tensor_stat(tensor, f(tensor)))
+}
+
+fn rank_min_by<F>(tensors: &[TensorStats], f: F) -> Option<RankedTensorStat>
+where
+    F: Fn(&TensorStats) -> f64,
+{
+    tensors
+        .iter()
+        .min_by(|a, b| f(a).partial_cmp(&f(b)).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|tensor| ranked_tensor_stat(tensor, f(tensor)))
+}
+
+fn top_by_desc<F>(tensors: &[TensorStats], f: F, limit: usize) -> Vec<RankedTensorStat>
+where
+    F: Fn(&TensorStats) -> f64,
+{
+    let mut items = tensors
+        .iter()
+        .map(|tensor| ranked_tensor_stat(tensor, f(tensor)))
+        .collect::<Vec<_>>();
+    items.sort_by(|a, b| {
+        b.value
+            .partial_cmp(&a.value)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    items.truncate(limit);
+    items
+}
+
+fn top_by_asc<F>(tensors: &[TensorStats], f: F, limit: usize) -> Vec<RankedTensorStat>
+where
+    F: Fn(&TensorStats) -> f64,
+{
+    let mut items = tensors
+        .iter()
+        .map(|tensor| ranked_tensor_stat(tensor, f(tensor)))
+        .collect::<Vec<_>>();
+    items.sort_by(|a, b| {
+        a.value
+            .partial_cmp(&b.value)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    items.truncate(limit);
+    items
+}
+
+fn ranked_tensor_stat(tensor: &TensorStats, value: f64) -> RankedTensorStat {
+    RankedTensorStat {
+        shard_ordinal: tensor.shard_ordinal,
+        in_shard_index: tensor.in_shard_index,
+        structural_name: tensor.structural_name.clone(),
+        kind_label: tensor.kind_label.clone(),
+        block_index: tensor.block_index,
+        value,
+    }
+}
+
+fn mean_of<I>(iter: I) -> f64
+where
+    I: IntoIterator<Item = f64>,
+{
+    let mut count = 0u64;
+    let mut total = 0.0;
+    for value in iter {
+        total += value;
+        count += 1;
+    }
+    if count == 0 {
+        0.0
+    } else {
+        total / count as f64
+    }
+}
+
+fn score_tensor(
+    tensor: &TensorStats,
+    inv: &ModelInventory,
+    routing: &RoutingReport,
+    routing_locs: &BTreeSet<(u32, u32)>,
+    routing_blocks: &BTreeSet<Option<u32>>,
+) -> SaaqCandidate {
+    let region_class = classify_region(tensor, routing_locs, routing_blocks);
+    let size_score = if inv.totals.total_nbytes > 0 {
+        tensor.total_nbytes as f64 / inv.totals.total_nbytes as f64
+    } else {
+        0.0
+    };
+    let sparsity_score = (tensor.zero_fraction * 0.7 + tensor.near_zero_fraction * 0.3).min(1.0);
+    let outlier_penalty = (tensor.outlier_fraction * 20.0)
+        .min(1.0)
+        .max((tensor.peak_to_rms / 50.0).min(1.0));
+    let dtype_bonus = match tensor.dtype {
+        TensorDType::F32 => 1.0,
+        TensorDType::I8 => 0.05,
+    };
+    let opportunity_score = clamp01(
+        size_score.sqrt() * 0.45
+            + sparsity_score * 0.25
+            + (1.0 - outlier_penalty) * 0.2
+            + dtype_bonus * 0.1,
+    );
+
+    let structural_penalty = match region_class {
+        SaaqRegionClass::RoutingCritical => 0.95,
+        SaaqRegionClass::NormalizationSensitive => 0.85,
+        SaaqRegionClass::AlreadyCompressed => 0.9,
+        SaaqRegionClass::EmbeddingHeavy => 0.55,
+        SaaqRegionClass::PotentialCompressionTarget => 0.2,
+        SaaqRegionClass::Unknown => 0.4,
+    };
+    let risk_score = clamp01(structural_penalty * 0.65 + outlier_penalty * 0.35);
+    let readiness_score = clamp01(opportunity_score * (1.0 - structural_penalty * 0.85));
+    let disposition = match region_class {
+        SaaqRegionClass::PotentialCompressionTarget if readiness_score >= 0.15 => {
+            SaaqDisposition::Candidate
+        }
+        SaaqRegionClass::EmbeddingHeavy if readiness_score >= 0.12 => SaaqDisposition::Candidate,
+        SaaqRegionClass::RoutingCritical
+        | SaaqRegionClass::NormalizationSensitive
+        | SaaqRegionClass::AlreadyCompressed => SaaqDisposition::AvoidForNow,
+        _ => SaaqDisposition::ObserveOnly,
+    };
+
+    let mut reasons = Vec::new();
+    reasons.push(format!("distribution={}", tensor.distribution_label));
+    reasons.push(format!(
+        "sampled_values={}/{}",
+        tensor.sample_values, tensor.total_values
+    ));
+    reasons.push(format!("zero_fraction={:.4}", tensor.zero_fraction));
+    reasons.push(format!(
+        "near_zero_fraction={:.4}",
+        tensor.near_zero_fraction
+    ));
+    reasons.push(format!("outlier_fraction={:.4}", tensor.outlier_fraction));
+    reasons.push(format!("peak_to_rms={:.3}", tensor.peak_to_rms));
+    if region_class == SaaqRegionClass::RoutingCritical {
+        reasons.push("linked to routing structure".to_string());
+    }
+    if routing
+        .likely_routing_critical_blocks
+        .iter()
+        .any(|block| block.block_index == tensor.block_index)
+        && region_class != SaaqRegionClass::RoutingCritical
+    {
+        reasons.push("lives in a routing-critical block".to_string());
+    }
+
+    SaaqCandidate {
+        rank: 0,
+        shard_ordinal: tensor.shard_ordinal,
+        in_shard_index: tensor.in_shard_index,
+        block_index: tensor.block_index,
+        block_slot: tensor.block_slot,
+        structural_name: tensor.structural_name.clone(),
+        kind_label: tensor.kind_label.clone(),
+        dtype: tensor.dtype,
+        shape: tensor.shape.clone(),
+        region_class,
+        disposition,
+        readiness_score,
+        opportunity_score,
+        risk_score,
+        reasons,
+    }
+}
+
+fn classify_region(
+    tensor: &TensorStats,
+    routing_locs: &BTreeSet<(u32, u32)>,
+    routing_blocks: &BTreeSet<Option<u32>>,
+) -> SaaqRegionClass {
+    if routing_locs.contains(&(tensor.shard_ordinal, tensor.in_shard_index))
+        || tensor.kind_label == "router"
+    {
+        return SaaqRegionClass::RoutingCritical;
+    }
+    if tensor.kind_label == "block_norm" || tensor.kind_label == "final_norm" {
+        return SaaqRegionClass::NormalizationSensitive;
+    }
+    if tensor.dtype == TensorDType::I8
+        || tensor.kind_label.starts_with("moe_scales")
+        || tensor.kind_label.starts_with("moe_expert.")
+    {
+        return SaaqRegionClass::AlreadyCompressed;
+    }
+    if tensor.kind_label == "token_embedding" {
+        return SaaqRegionClass::EmbeddingHeavy;
+    }
+    if tensor.dtype == TensorDType::F32
+        && (tensor.kind_label == "attn_proj_f32"
+            || tensor.kind_label == "unknown"
+            || routing_blocks.contains(&tensor.block_index))
+    {
+        return SaaqRegionClass::PotentialCompressionTarget;
+    }
+    SaaqRegionClass::Unknown
+}
+
+fn summarize_layer_readiness(
+    candidates: &[SaaqCandidate],
+    routing_blocks: &BTreeSet<Option<u32>>,
+) -> Vec<SaaqLayerReadiness> {
+    let mut by_layer: BTreeMap<(Option<u32>, String), Vec<&SaaqCandidate>> = BTreeMap::new();
+    for candidate in candidates {
+        let label = match candidate.block_index {
+            Some(index) => format!("block_{index:03}"),
+            None => "unassigned".to_string(),
+        };
+        by_layer
+            .entry((candidate.block_index, label))
+            .or_default()
+            .push(candidate);
+    }
+
+    by_layer
+        .into_iter()
+        .map(|((block_index, label), members)| {
+            let candidate_target_count = members
+                .iter()
+                .filter(|candidate| candidate.disposition == SaaqDisposition::Candidate)
+                .count() as u32;
+            let mean_readiness_score = members
+                .iter()
+                .map(|candidate| candidate.readiness_score)
+                .sum::<f64>()
+                / members.len() as f64;
+            let max_risk_score = members
+                .iter()
+                .map(|candidate| candidate.risk_score)
+                .fold(0.0, f64::max);
+
+            SaaqLayerReadiness {
+                block_index,
+                label,
+                routing_critical: routing_blocks.contains(&block_index),
+                candidate_target_count,
+                mean_readiness_score,
+                max_risk_score,
+            }
+        })
+        .collect()
+}
+
+fn build_saaq_notes(
+    candidate_targets: &[SaaqCandidate],
+    routing_critical_tensors: &[SaaqCandidate],
+    routing: &RoutingReport,
+) -> Vec<String> {
+    let mut notes = Vec::new();
+    if let Some(top) = candidate_targets.first() {
+        notes.push(format!(
+            "Top candidate target is `{}` with readiness {:.3}.",
+            top.structural_name, top.readiness_score
+        ));
+    }
+    if !routing_critical_tensors.is_empty() {
+        notes.push(format!(
+            "{} tensors are classified as routing-critical and should be handled cautiously.",
+            routing_critical_tensors.len()
+        ));
+    }
+    if !routing.grok_layout_notes.is_empty() {
+        notes.push(format!(
+            "Routing analysis notes: {}",
+            routing.grok_layout_notes.join(" ")
+        ));
+    }
+    notes
+}
+
+fn routing_tensor_set(routing: &RoutingReport) -> BTreeSet<(u32, u32)> {
+    routing
+        .candidate_tensors
+        .iter()
+        .map(|tensor| (tensor.shard_ordinal, tensor.in_shard_index))
+        .collect()
+}
+
+fn routing_block_set(routing: &RoutingReport) -> BTreeSet<Option<u32>> {
+    routing
+        .likely_routing_critical_blocks
+        .iter()
+        .map(|block| block.block_index)
+        .collect()
+}
+
+fn layer_label_for_tensor(tensor: &TensorStats) -> String {
+    match tensor.block_index {
+        Some(index) => format!("block_{index:03}"),
+        None if tensor.kind_label == "token_embedding" => "embedding".to_string(),
+        None if tensor.kind_label == "final_norm" => "final_norm".to_string(),
+        None => "unassigned".to_string(),
+    }
+}
+
+fn is_potential_compression_target(tensor: &TensorStats) -> bool {
+    tensor.dtype == TensorDType::F32
+        && tensor.kind_label != "router"
+        && tensor.kind_label != "block_norm"
+        && tensor.kind_label != "final_norm"
+}
+
+fn tensor_structural_name(tensor: &TensorInfo) -> String {
+    let slot = tensor
+        .block_slot
+        .map(|slot| format!("slot_{slot:02}"))
+        .unwrap_or_else(|| "slot_na".to_string());
+    match tensor.block_index {
+        Some(index) => format!("block_{index:03}.{slot}.{}", tensor.kind.short_label()),
+        None => match tensor.kind {
+            TensorKind::TokenEmbedding => "embedding.slot_00.token_embedding".to_string(),
+            TensorKind::FinalNorm => "final_norm.slot_00.final_norm".to_string(),
+            _ => format!(
+                "unassigned.shard_{:03}.idx_{:03}.{}",
+                tensor.shard_ordinal,
+                tensor.in_shard_index,
+                tensor.kind.short_label()
+            ),
+        },
+    }
+}
+
+fn clone_hyperparams(hp: &InferredHyperparams) -> InferredHyperparams {
+    InferredHyperparams {
+        vocab_size: hp.vocab_size,
+        d_model: hp.d_model,
+        n_experts: hp.n_experts,
+        d_ff: hp.d_ff,
+        n_blocks: hp.n_blocks,
+    }
+}
+
+fn clamp01(v: f64) -> f64 {
+    v.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::schema::{
+        BlockSummary, InferredHyperparams, InventoryTotals, KindCount, ModelInventory,
+        SaaqDisposition, SaaqRegionClass, TensorDType, TensorInfo, TensorKind, TensorRole,
+        TensorShape,
+    };
+
+    use super::{StatsConfig, build_saaq_readiness_report, build_stats_report};
+
+    #[test]
+    fn stats_report_profiles_tensor_values() {
+        let dir = temp_dir("stats_profile");
+        let shard = dir.join("tensor00000_000");
+        let mut bytes = Vec::new();
+        for value in [0.0f32, 1.0, -1.0, 10.0] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        fs::write(&shard, bytes).unwrap();
+
+        let inv = inventory(vec![tensor(
+            shard,
+            TensorDType::F32,
+            TensorRole::Tensor,
+            TensorKind::AttnProjF32,
+            vec![4],
+            None,
+            None,
+        )]);
+        let stats = build_stats_report(&inv, &StatsConfig::default()).unwrap();
+
+        assert_eq!(stats.tensors.len(), 1);
+        assert!((stats.tensors[0].mean - 2.5).abs() < 1e-6);
+        assert!(stats.tensors[0].max_abs >= 10.0);
+        assert!(stats.tensors[0].outlier_fraction >= 0.0);
+    }
+
+    #[test]
+    fn saaq_readiness_prefers_f32_attention_and_avoids_router() {
+        let dir = temp_dir("saaq_readiness");
+        let router_shard = dir.join("tensor00001_000");
+        let attn_shard = dir.join("tensor00002_000");
+
+        let mut router_bytes = Vec::new();
+        for value in [0.0f32, 1.0, 2.0, 3.0] {
+            router_bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        fs::write(&router_shard, router_bytes).unwrap();
+
+        let mut attn_bytes = Vec::new();
+        for value in [0.0f32, 0.0, 0.01, 0.02] {
+            attn_bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        fs::write(&attn_shard, attn_bytes).unwrap();
+
+        let inv = inventory(vec![
+            tensor(
+                router_shard,
+                TensorDType::F32,
+                TensorRole::Tensor,
+                TensorKind::Router,
+                vec![2, 2],
+                Some(0),
+                Some(0),
+            ),
+            tensor(
+                attn_shard,
+                TensorDType::F32,
+                TensorRole::Tensor,
+                TensorKind::AttnProjF32,
+                vec![2, 2],
+                Some(0),
+                Some(1),
+            ),
+        ]);
+        let stats = build_stats_report(&inv, &StatsConfig::default()).unwrap();
+        let readiness = build_saaq_readiness_report(&inv, &stats);
+
+        assert!(
+            readiness
+                .candidate_targets
+                .iter()
+                .any(|candidate| candidate.kind_label == "attn_proj_f32")
+        );
+        assert!(
+            readiness
+                .routing_critical_tensors
+                .iter()
+                .any(|candidate| candidate.region_class == SaaqRegionClass::RoutingCritical)
+        );
+        assert!(
+            readiness
+                .routing_critical_tensors
+                .iter()
+                .all(|candidate| candidate.disposition == SaaqDisposition::AvoidForNow)
+        );
+    }
+
+    fn inventory(tensors: Vec<TensorInfo>) -> ModelInventory {
+        ModelInventory {
+            model_family: "grok-1".to_string(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1"),
+            shard_count: tensors.len() as u32,
+            inferred: InferredHyperparams {
+                vocab_size: Some(131072),
+                d_model: Some(6144),
+                n_experts: Some(8),
+                d_ff: Some(32768),
+                n_blocks: Some(1),
+            },
+            tensors,
+            blocks: vec![BlockSummary {
+                block_index: Some(0),
+                label: "block_000".to_string(),
+                shard_range: None,
+                tensor_count: 2,
+                total_nbytes: 0,
+                dtypes: Vec::new(),
+                kinds: vec![KindCount {
+                    kind_label: "router".to_string(),
+                    count: 1,
+                    nbytes: 0,
+                }],
+            }],
+            totals: InventoryTotals {
+                tensors: 2,
+                quant_tensors: 0,
+                f32_tensors: 2,
+                i8_tensors: 0,
+                total_nbytes: 32,
+                total_elements: 8,
+            },
+            schema_version: 1,
+        }
+    }
+
+    fn tensor(
+        shard_path: PathBuf,
+        dtype: TensorDType,
+        role: TensorRole,
+        kind: TensorKind,
+        shape: Vec<u64>,
+        block_index: Option<u32>,
+        block_slot: Option<u32>,
+    ) -> TensorInfo {
+        TensorInfo {
+            shard_path,
+            shard_ordinal: block_slot.unwrap_or(0),
+            in_shard_index: 0,
+            role,
+            dtype,
+            shape: TensorShape::new(shape),
+            offset: 0,
+            nbytes: 16,
+            kind,
+            block_index,
+            block_slot,
+        }
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("xai_dissect_{label}_{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}


### PR DESCRIPTION
## **User description**
## What changed
- add a new `src/stats` module that samples tensor payload values for offline profiling
- add `stats` and `saaq-readiness` CLI commands
- add stats and SAAQ-readiness schema types plus JSON/Markdown export support
- add a machine-readable candidate manifest for future experiments
- update docs so the repo boundary stays accurate: offline profiling is in scope, runtime quantization and inference are still out of scope

## Why
`xai-dissect` could already describe checkpoint structure, experts, and routing, but it could not yet profile where future SAAQ-style experiments might be promising or risky. This change adds reconnaissance-oriented tensor statistics without turning the repo into a runtime or a quantization tool.

## Impact
- `cargo run -- stats <path>` now produces per-tensor and per-layer norm/variance/outlier/sparsity-ish summaries
- `cargo run -- saaq-readiness <path>` now ranks candidate tensors, flags routing-critical regions, and emits a manifest for downstream experimentation
- the implementation remains read-only and analysis-only: no weight mutation, no SAAQ application, no runtime quantization logic

## Validation
- `cargo test`
- `target/debug/xai-dissect stats /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 26 --json /tmp/grok1_stats.json --md /tmp/grok1_stats.md`
- `target/debug/xai-dissect saaq-readiness /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 26 --json /tmp/grok1_saaq.json --md /tmp/grok1_saaq.md --manifest /tmp/grok1_saaq_manifest.json`

## Notes
- the 26-shard Grok-1 smoke run surfaced the embedding as the best available candidate in that constrained slice and correctly marked the observed routers as routing-critical
- wider checkpoint sweeps should surface additional candidate targets once more of the checkpoint's f32 regions are included


___

## **CodeAnt-AI Description**
**Add offline tensor profiling and SAAQ-readiness reports**

### What Changed
- Added new `stats` and `saaq-readiness` commands that sample tensor values from checkpoints and print JSON or Markdown reports
- `stats` now shows per-tensor and per-layer metrics such as norm, variance, sparsity, and outlier summaries
- `saaq-readiness` now ranks likely experiment targets, marks routing-critical tensors, and can export a machine-readable candidate manifest
- Documentation now states that offline tensor sampling is allowed for profiling, while model execution and runtime quantization remain out of scope

### Impact
`✅ Clearer offline checkpoint profiling`
`✅ Faster SAAQ target screening`
`✅ Fewer false starts on routing-critical tensors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=MzO3Qinq8H5Nsck5cYlsOfn0Sj2UdCdgU4QzYMbBJZ4&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
