### PR TITLE
Issue 7: add unified reports and exports layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ here.
   quantized vs. unquantized byte budgets, shard-size histograms.
 - Exportable findings: stable, machine-readable artifacts (JSON / CSV /
   Markdown tables) suitable for downstream consumers.
+- Unified output conventions for reusable `reports/`, `exports/`, and
+  `manifests/` trees keyed by checkpoint slug.
 
 ## What this repo does NOT own
 
@@ -104,6 +106,10 @@ cargo build --release
 # Offline profiling for future SAAQ work.
 ./target/release/xai-dissect stats /path/to/grok-1/ckpt-0
 ./target/release/xai-dissect saaq-readiness /path/to/grok-1/ckpt-0
+
+# Write a predictable artifact tree for downstream tooling.
+./target/release/xai-dissect routing-report /path/to/grok-1/ckpt-0 \
+  --output-root out
 ```
 
 The parser-oriented commands memory-map each shard, validate the PROTO 4
@@ -113,7 +119,8 @@ reuse those offsets and sample tensor payload values for offline profiling;
 they still do not mutate weights or run inference.
 
 See `docs/architecture.md` for the intended layer breakdown and
-`docs/non_goals.md` for the full non-goals list.
+`docs/non_goals.md` for the full non-goals list. Unified artifact naming and
+directory conventions are documented in `docs/output-conventions.md`.
 
 ## Legal / ethical scope
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,8 +20,11 @@ testable against a single shard or a full checkpoint directory.
         +--> [ routing analysis ]  -> router / gate geometry
         +--> [ stats ]             -> offline tensor-value profiling
         |
+        +--> [ reports ]           -> human-readable Markdown
+        +--> [ exports ]           -> full JSON + findings summaries
+        |
         v
-  [ reports / exports ]  -> JSON, CSV, Markdown
+  [ manifests ]          -> focused machine-readable inventories
 ```
 
 ## Layers
@@ -96,12 +99,11 @@ quantization runtime, and no model execution.
 ### 7. reports / exports
 Emits stable, machine-readable artifacts:
 
-- `inventory.json` - full `TensorRecord` array
-- `architecture.md` - human-readable summary (layer count, d_model,
-  n_experts, head geometry, norm placement)
-- `experts.json` / `routing.json` - structured findings from (4) and (5)
-- `stats.json` / `saaq-readiness.json` - structured profiling outputs from (6)
-- `candidate-manifest.json` - ranked machine-readable target list for future experiments
+- `reports/<slug>/*.md` - human-readable summaries for inspection
+- `exports/<slug>/*.json` - full structured outputs plus compact findings summaries
+- `manifests/<slug>/*.json` - focused machine-readable lists such as:
+  checkpoint inventory snapshots, routing-critical tensors, and ranked SAAQ
+  target candidates
 
 Exports are the only supported integration surface for downstream repos
 (`corinth-canal`, `SAAQ-latent`, `Surrogate_Viz.jl`). No in-process API is
@@ -125,6 +127,8 @@ xai-dissect/
       mod.rs                 # TensorRecord, Role, Dtype
     inventory/
       mod.rs                 # checkpoint walk, dedup, verification
+    exports/
+      mod.rs                 # output-tree planning and manifest bundles
     analysis/
       mod.rs
       experts.rs             # MoE geometry from shapes

--- a/docs/output-conventions.md
+++ b/docs/output-conventions.md
@@ -1,0 +1,77 @@
+# Output Conventions
+
+`xai-dissect` supports two output modes:
+
+- explicit per-file flags such as `--json`, `--md`, and `--manifest`
+- a unified output tree via `--output-root <dir>`
+
+The unified tree exists so downstream tooling can consume artifacts from
+different analysis commands without guessing filenames or stitching together
+ad hoc directories.
+
+## Directory layout
+
+When `--output-root out` is provided, artifacts are written under:
+
+```text
+out/
+  reports/<checkpoint_slug>/
+  exports/<checkpoint_slug>/
+  manifests/<checkpoint_slug>/
+```
+
+`<checkpoint_slug>` is inferred from the checkpoint path by default using the
+last two path components, sanitized for filesystem safety. Example:
+
+```text
+/home/user/grok-1-official/ckpt-0
+-> grok-1-official__ckpt-0
+```
+
+Use `--checkpoint-slug <slug>` to override that value when a repo or
+pipeline needs a stable custom name.
+
+## Artifact conventions
+
+### `inventory`
+
+- `reports/<slug>/inventory.md`
+- `exports/<slug>/inventory.json`
+- `exports/<slug>/inventory-findings.json`
+- `manifests/<slug>/checkpoint-inventory-snapshot.json`
+
+### `experts`
+
+- `reports/<slug>/experts.md`
+- `exports/<slug>/experts.json`
+- `exports/<slug>/experts-findings.json`
+
+### `routing-report`
+
+- `reports/<slug>/routing-report.md`
+- `exports/<slug>/routing-report.json`
+- `exports/<slug>/routing-report-findings.json`
+- `manifests/<slug>/routing-critical-tensors.json`
+
+### `stats`
+
+- `reports/<slug>/stats.md`
+- `exports/<slug>/stats.json`
+- `exports/<slug>/stats-findings.json`
+
+### `saaq-readiness`
+
+- `reports/<slug>/saaq-readiness.md`
+- `exports/<slug>/saaq-readiness.json`
+- `exports/<slug>/saaq-readiness-findings.json`
+- `manifests/<slug>/candidate-saaq-targets.json`
+
+## Summary and manifest intent
+
+- `reports/`: human-readable Markdown meant for inspection and PR review
+- `exports/`: full JSON exports plus compact findings summaries for scripts
+- `manifests/`: focused machine-readable lists intended for downstream
+  selection, orchestration, and snapshot comparison
+
+The output tree is additive. Existing explicit file flags remain supported
+and are not replaced by the unified tree.

--- a/src/experts/mod.rs
+++ b/src/experts/mod.rs
@@ -646,14 +646,18 @@ mod tests {
 
         let atlas = build_expert_atlas(&inv);
 
-        assert!(atlas
-            .anomalies
-            .iter()
-            .any(|issue| issue.message.contains("canonical pattern")));
-        assert!(atlas
-            .naming_checks
-            .iter()
-            .any(|check| check.check == "expert_family_count_consistent" && !check.passed));
+        assert!(
+            atlas
+                .anomalies
+                .iter()
+                .any(|issue| issue.message.contains("canonical pattern"))
+        );
+        assert!(
+            atlas
+                .naming_checks
+                .iter()
+                .any(|check| check.check == "expert_family_count_consistent" && !check.passed)
+        );
     }
 
     fn inventory_with_blocks(blocks: Vec<Vec<TensorInfo>>) -> ModelInventory {

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -59,10 +59,13 @@ pub fn resolve_checkpoint_slug(
     checkpoint_path: &Path,
     slug_override: Option<&str>,
 ) -> Result<String> {
-    if let Some(slug) = slug_override {
-        let slug = sanitize_slug_component(slug);
+    if let Some(slug_override) = slug_override {
+        let slug = sanitize_slug_component(slug_override);
         if slug.is_empty() {
-            bail!("checkpoint slug override resolved to an empty value");
+            bail!(
+                "checkpoint slug override {:?} resolved to an empty value after sanitization; provide an override containing retained ASCII alphanumeric characters",
+                slug_override
+            );
         }
         return Ok(slug);
     }

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1,0 +1,826 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Unified output-tree planning and bundle writers. This layer keeps path
+// conventions and manifest generation out of the analyzers themselves.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::report;
+use crate::schema::{
+    CheckpointInventoryBlockSnapshot, CheckpointInventorySnapshot, ExpertAtlas, FindingsSeverity,
+    FindingsSummary, FindingsSummaryItem, ModelInventory, RoutingCriticalTensor,
+    RoutingCriticalTensorManifest, RoutingReport, SaaqReadinessReport, StatsProfileReport,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OutputLayout {
+    pub checkpoint_slug: String,
+    pub reports_dir: PathBuf,
+    pub exports_dir: PathBuf,
+    pub manifests_dir: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OutputBundle {
+    pub checkpoint_slug: String,
+    pub written_paths: Vec<PathBuf>,
+}
+
+pub fn prepare_output_layout(
+    root: &Path,
+    checkpoint_path: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputLayout> {
+    let checkpoint_slug = resolve_checkpoint_slug(checkpoint_path, slug_override)?;
+    let reports_dir = root.join("reports").join(&checkpoint_slug);
+    let exports_dir = root.join("exports").join(&checkpoint_slug);
+    let manifests_dir = root.join("manifests").join(&checkpoint_slug);
+
+    fs::create_dir_all(&reports_dir)
+        .with_context(|| format!("create {}", reports_dir.display()))?;
+    fs::create_dir_all(&exports_dir)
+        .with_context(|| format!("create {}", exports_dir.display()))?;
+    fs::create_dir_all(&manifests_dir)
+        .with_context(|| format!("create {}", manifests_dir.display()))?;
+
+    Ok(OutputLayout {
+        checkpoint_slug,
+        reports_dir,
+        exports_dir,
+        manifests_dir,
+    })
+}
+
+pub fn resolve_checkpoint_slug(
+    checkpoint_path: &Path,
+    slug_override: Option<&str>,
+) -> Result<String> {
+    if let Some(slug) = slug_override {
+        let slug = sanitize_slug_component(slug);
+        if slug.is_empty() {
+            bail!("checkpoint slug override resolved to an empty value");
+        }
+        return Ok(slug);
+    }
+
+    let parts = checkpoint_path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .map(sanitize_slug_component)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+
+    if parts.is_empty() {
+        bail!(
+            "unable to derive checkpoint slug from {}",
+            checkpoint_path.display()
+        );
+    }
+
+    let tail = if parts.len() >= 2 {
+        parts[parts.len() - 2..].to_vec()
+    } else {
+        vec![parts[parts.len() - 1].clone()]
+    };
+
+    Ok(tail.join("__"))
+}
+
+pub fn write_inventory_bundle(
+    inv: &ModelInventory,
+    root: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputBundle> {
+    let layout = prepare_output_layout(root, &inv.checkpoint_path, slug_override)?;
+    let mut bundle = OutputBundle {
+        checkpoint_slug: layout.checkpoint_slug.clone(),
+        written_paths: Vec::new(),
+    };
+
+    let json_path = layout.exports_dir.join("inventory.json");
+    report::write_json(inv, &json_path)?;
+    bundle.written_paths.push(json_path);
+
+    let md_path = layout.reports_dir.join("inventory.md");
+    report::write_markdown(inv, &md_path)?;
+    bundle.written_paths.push(md_path);
+
+    let findings = build_inventory_findings_summary(inv, &layout.checkpoint_slug);
+    let findings_path = layout.exports_dir.join("inventory-findings.json");
+    report::write_findings_summary_json(&findings, &findings_path)?;
+    bundle.written_paths.push(findings_path);
+
+    let snapshot = build_inventory_snapshot(inv);
+    let manifest_path = layout
+        .manifests_dir
+        .join("checkpoint-inventory-snapshot.json");
+    report::write_inventory_snapshot_manifest_json(&snapshot, &manifest_path)?;
+    bundle.written_paths.push(manifest_path);
+
+    Ok(bundle)
+}
+
+pub fn write_expert_bundle(
+    atlas: &ExpertAtlas,
+    root: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputBundle> {
+    let layout = prepare_output_layout(root, &atlas.checkpoint_path, slug_override)?;
+    let mut bundle = OutputBundle {
+        checkpoint_slug: layout.checkpoint_slug.clone(),
+        written_paths: Vec::new(),
+    };
+
+    let json_path = layout.exports_dir.join("experts.json");
+    report::write_expert_json(atlas, &json_path)?;
+    bundle.written_paths.push(json_path);
+
+    let md_path = layout.reports_dir.join("experts.md");
+    report::write_expert_markdown(atlas, &md_path)?;
+    bundle.written_paths.push(md_path);
+
+    let findings = build_expert_findings_summary(atlas, &layout.checkpoint_slug);
+    let findings_path = layout.exports_dir.join("experts-findings.json");
+    report::write_findings_summary_json(&findings, &findings_path)?;
+    bundle.written_paths.push(findings_path);
+
+    Ok(bundle)
+}
+
+pub fn write_routing_bundle(
+    report_doc: &RoutingReport,
+    root: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputBundle> {
+    let layout = prepare_output_layout(root, &report_doc.checkpoint_path, slug_override)?;
+    let mut bundle = OutputBundle {
+        checkpoint_slug: layout.checkpoint_slug.clone(),
+        written_paths: Vec::new(),
+    };
+
+    let json_path = layout.exports_dir.join("routing-report.json");
+    report::write_routing_json(report_doc, &json_path)?;
+    bundle.written_paths.push(json_path);
+
+    let md_path = layout.reports_dir.join("routing-report.md");
+    report::write_routing_markdown(report_doc, &md_path)?;
+    bundle.written_paths.push(md_path);
+
+    let findings = build_routing_findings_summary(report_doc, &layout.checkpoint_slug);
+    let findings_path = layout.exports_dir.join("routing-report-findings.json");
+    report::write_findings_summary_json(&findings, &findings_path)?;
+    bundle.written_paths.push(findings_path);
+
+    let manifest = build_routing_critical_manifest(report_doc);
+    let manifest_path = layout.manifests_dir.join("routing-critical-tensors.json");
+    report::write_routing_critical_manifest_json(&manifest, &manifest_path)?;
+    bundle.written_paths.push(manifest_path);
+
+    Ok(bundle)
+}
+
+pub fn write_stats_bundle(
+    report_doc: &StatsProfileReport,
+    root: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputBundle> {
+    let layout = prepare_output_layout(root, &report_doc.checkpoint_path, slug_override)?;
+    let mut bundle = OutputBundle {
+        checkpoint_slug: layout.checkpoint_slug.clone(),
+        written_paths: Vec::new(),
+    };
+
+    let json_path = layout.exports_dir.join("stats.json");
+    report::write_stats_json(report_doc, &json_path)?;
+    bundle.written_paths.push(json_path);
+
+    let md_path = layout.reports_dir.join("stats.md");
+    report::write_stats_markdown(report_doc, &md_path)?;
+    bundle.written_paths.push(md_path);
+
+    let findings = build_stats_findings_summary(report_doc, &layout.checkpoint_slug);
+    let findings_path = layout.exports_dir.join("stats-findings.json");
+    report::write_findings_summary_json(&findings, &findings_path)?;
+    bundle.written_paths.push(findings_path);
+
+    Ok(bundle)
+}
+
+pub fn write_saaq_bundle(
+    report_doc: &SaaqReadinessReport,
+    root: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputBundle> {
+    let layout = prepare_output_layout(root, &report_doc.checkpoint_path, slug_override)?;
+    let mut bundle = OutputBundle {
+        checkpoint_slug: layout.checkpoint_slug.clone(),
+        written_paths: Vec::new(),
+    };
+
+    let json_path = layout.exports_dir.join("saaq-readiness.json");
+    report::write_saaq_readiness_json(report_doc, &json_path)?;
+    bundle.written_paths.push(json_path);
+
+    let md_path = layout.reports_dir.join("saaq-readiness.md");
+    report::write_saaq_readiness_markdown(report_doc, &md_path)?;
+    bundle.written_paths.push(md_path);
+
+    let findings = build_saaq_findings_summary(report_doc, &layout.checkpoint_slug);
+    let findings_path = layout.exports_dir.join("saaq-readiness-findings.json");
+    report::write_findings_summary_json(&findings, &findings_path)?;
+    bundle.written_paths.push(findings_path);
+
+    let manifest_path = layout.manifests_dir.join("candidate-saaq-targets.json");
+    report::write_candidate_manifest_json(&report_doc.manifest, &manifest_path)?;
+    bundle.written_paths.push(manifest_path);
+
+    Ok(bundle)
+}
+
+pub fn build_inventory_snapshot(inv: &ModelInventory) -> CheckpointInventorySnapshot {
+    CheckpointInventorySnapshot {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        shard_count: inv.shard_count,
+        inferred: inv.inferred.clone(),
+        total_tensors: inv.totals.tensors,
+        total_nbytes: inv.totals.total_nbytes,
+        blocks: inv
+            .blocks
+            .iter()
+            .map(|block| CheckpointInventoryBlockSnapshot {
+                label: block.label.clone(),
+                block_index: block.block_index,
+                shard_range: block.shard_range,
+                tensor_count: block.tensor_count,
+                total_nbytes: block.total_nbytes,
+                kind_labels: block
+                    .kinds
+                    .iter()
+                    .map(|kind| kind.kind_label.clone())
+                    .collect(),
+            })
+            .collect(),
+        schema_version: inv.schema_version,
+    }
+}
+
+pub fn build_routing_critical_manifest(
+    report_doc: &RoutingReport,
+) -> RoutingCriticalTensorManifest {
+    let reasons = report_doc
+        .likely_routing_critical_blocks
+        .iter()
+        .map(|block| (block.block_index, block.reason.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    RoutingCriticalTensorManifest {
+        model_family: report_doc.model_family.clone(),
+        checkpoint_path: report_doc.checkpoint_path.clone(),
+        tensors: report_doc
+            .candidate_tensors
+            .iter()
+            .map(|tensor| RoutingCriticalTensor {
+                shard_ordinal: tensor.shard_ordinal,
+                in_shard_index: tensor.in_shard_index,
+                block_index: tensor.block_index,
+                block_slot: tensor.block_slot,
+                structural_name: tensor.structural_name.clone(),
+                kind_label: tensor.kind_label.clone(),
+                orientation: tensor.orientation,
+                linked_expert_count: tensor.linked_expert_count,
+                total_nbytes: tensor.gate_metrics.total_nbytes,
+                criticality_reason: reasons.get(&tensor.block_index).cloned(),
+            })
+            .collect(),
+        schema_version: report_doc.schema_version,
+    }
+}
+
+pub fn build_inventory_findings_summary(
+    inv: &ModelInventory,
+    checkpoint_slug: &str,
+) -> FindingsSummary {
+    let unknown_tensors = inv
+        .tensors
+        .iter()
+        .filter(|tensor| matches!(tensor.kind, crate::schema::TensorKind::Unknown { .. }))
+        .count();
+
+    let mut findings = vec![
+        info_finding(
+            "checkpoint_scale",
+            format!(
+                "{} shards, {} tensors, {} bytes",
+                inv.shard_count, inv.totals.tensors, inv.totals.total_nbytes
+            ),
+        ),
+        info_finding(
+            "block_structure",
+            format!(
+                "{} block summaries, inferred d_model {}, inferred experts {}",
+                inv.blocks.len(),
+                fmt_opt(inv.inferred.d_model),
+                fmt_opt(inv.inferred.n_experts)
+            ),
+        ),
+    ];
+
+    if inv.totals.quant_tensors > 0 {
+        findings.push(info_finding(
+            "quantization_layout",
+            format!(
+                "{} quantized tensors alongside {} f32 tensors",
+                inv.totals.quant_tensors, inv.totals.f32_tensors
+            ),
+        ));
+    }
+
+    if unknown_tensors > 0 {
+        findings.push(warn_finding(
+            "unknown_tensor_kinds",
+            format!("{unknown_tensors} tensors remained structurally unclassified"),
+        ));
+    }
+
+    FindingsSummary {
+        analysis: "inventory".into(),
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        checkpoint_slug: checkpoint_slug.to_string(),
+        headline: format!(
+            "{} tensors across {} shards",
+            inv.totals.tensors, inv.shard_count
+        ),
+        findings,
+        schema_version: inv.schema_version,
+    }
+}
+
+pub fn build_expert_findings_summary(
+    atlas: &ExpertAtlas,
+    checkpoint_slug: &str,
+) -> FindingsSummary {
+    let expert_counts = atlas
+        .blocks
+        .iter()
+        .filter_map(|block| block.expert_count)
+        .collect::<BTreeSet<_>>();
+    let failed_checks = atlas
+        .naming_checks
+        .iter()
+        .filter(|check| !check.passed)
+        .count();
+
+    let mut findings = vec![info_finding(
+        "expert_blocks",
+        format!(
+            "{} relevant blocks, expected experts per block {}",
+            atlas.relevant_block_count,
+            fmt_opt(atlas.expected_experts_per_block)
+        ),
+    )];
+
+    if expert_counts.len() <= 1 {
+        findings.push(info_finding(
+            "expert_count_consistency",
+            format!(
+                "expert count is structurally consistent at {}",
+                fmt_opt(expert_counts.iter().next().copied())
+            ),
+        ));
+    } else {
+        findings.push(warn_finding(
+            "expert_count_consistency",
+            format!(
+                "observed multiple expert counts across blocks: {}",
+                expert_counts
+                    .iter()
+                    .map(|count| count.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        ));
+    }
+
+    if failed_checks > 0 {
+        findings.push(warn_finding(
+            "naming_checks",
+            format!("{failed_checks} expert naming consistency checks failed"),
+        ));
+    }
+
+    if !atlas.anomalies.is_empty() {
+        findings.push(warn_finding(
+            "expert_anomalies",
+            format!("{} expert anomalies detected", atlas.anomalies.len()),
+        ));
+    }
+
+    FindingsSummary {
+        analysis: "experts".into(),
+        model_family: atlas.model_family.clone(),
+        checkpoint_path: atlas.checkpoint_path.clone(),
+        checkpoint_slug: checkpoint_slug.to_string(),
+        headline: format!("{} relevant expert blocks", atlas.relevant_block_count),
+        findings,
+        schema_version: atlas.schema_version,
+    }
+}
+
+pub fn build_routing_findings_summary(
+    report_doc: &RoutingReport,
+    checkpoint_slug: &str,
+) -> FindingsSummary {
+    let mut findings = vec![
+        info_finding(
+            "routing_candidates",
+            format!(
+                "{} routing candidates across {} relevant blocks",
+                report_doc.candidate_tensors.len(),
+                report_doc.relevant_block_count
+            ),
+        ),
+        info_finding(
+            "expert_linkage",
+            format!(
+                "expected experts per router {}",
+                fmt_opt(report_doc.expected_experts_per_router)
+            ),
+        ),
+    ];
+
+    if !report_doc.orientation_summaries.is_empty() {
+        findings.push(info_finding(
+            "orientations",
+            report_doc
+                .orientation_summaries
+                .iter()
+                .map(|summary| format!("{} x{}", summary.orientation.label(), summary.count))
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+
+    if !report_doc.likely_routing_critical_blocks.is_empty() {
+        findings.push(info_finding(
+            "routing_critical_blocks",
+            format!(
+                "{} blocks marked routing-critical",
+                report_doc.likely_routing_critical_blocks.len()
+            ),
+        ));
+    }
+
+    if !report_doc.anomalies.is_empty() {
+        findings.push(warn_finding(
+            "routing_anomalies",
+            format!("{} routing anomalies detected", report_doc.anomalies.len()),
+        ));
+    }
+
+    FindingsSummary {
+        analysis: "routing-report".into(),
+        model_family: report_doc.model_family.clone(),
+        checkpoint_path: report_doc.checkpoint_path.clone(),
+        checkpoint_slug: checkpoint_slug.to_string(),
+        headline: format!(
+            "{} routing candidates discovered",
+            report_doc.candidate_tensors.len()
+        ),
+        findings,
+        schema_version: report_doc.schema_version,
+    }
+}
+
+pub fn build_stats_findings_summary(
+    report_doc: &StatsProfileReport,
+    checkpoint_slug: &str,
+) -> FindingsSummary {
+    let mut findings = vec![info_finding(
+        "sampling",
+        format!(
+            "{} tensors profiled with up to {} sampled values each",
+            report_doc.tensors.len(),
+            report_doc.sampling.max_sample_values
+        ),
+    )];
+
+    if let Some(tensor) = &report_doc.norm_summary.max_rms {
+        findings.push(info_finding(
+            "highest_rms",
+            format!(
+                "highest RMS: {} ({:.6})",
+                tensor.structural_name, tensor.value
+            ),
+        ));
+    }
+    if let Some(tensor) = &report_doc.variance_summary.max_variance {
+        findings.push(info_finding(
+            "highest_variance",
+            format!(
+                "highest variance: {} ({:.6})",
+                tensor.structural_name, tensor.value
+            ),
+        ));
+    }
+    if let Some(tensor) = report_doc.outlier_summary.most_outlier_heavy.first() {
+        findings.push(info_finding(
+            "outlier_heavy",
+            format!(
+                "most outlier-heavy tensor: {} ({:.6})",
+                tensor.structural_name, tensor.value
+            ),
+        ));
+    }
+
+    FindingsSummary {
+        analysis: "stats".into(),
+        model_family: report_doc.model_family.clone(),
+        checkpoint_path: report_doc.checkpoint_path.clone(),
+        checkpoint_slug: checkpoint_slug.to_string(),
+        headline: format!("{} tensors profiled", report_doc.tensors.len()),
+        findings,
+        schema_version: report_doc.schema_version,
+    }
+}
+
+pub fn build_saaq_findings_summary(
+    report_doc: &SaaqReadinessReport,
+    checkpoint_slug: &str,
+) -> FindingsSummary {
+    let mut findings = vec![
+        info_finding(
+            "candidate_targets",
+            format!(
+                "{} candidate targets, {} routing-critical tensors",
+                report_doc.candidate_targets.len(),
+                report_doc.routing_critical_tensors.len()
+            ),
+        ),
+        info_finding(
+            "layer_readiness",
+            format!("{} layer readiness rows", report_doc.layer_readiness.len()),
+        ),
+    ];
+
+    if let Some(candidate) = report_doc.candidate_targets.first() {
+        findings.push(info_finding(
+            "top_candidate",
+            format!(
+                "top candidate {} with readiness {:.3} and risk {:.3}",
+                candidate.structural_name, candidate.readiness_score, candidate.risk_score
+            ),
+        ));
+    } else {
+        findings.push(warn_finding(
+            "top_candidate",
+            "no candidate tensors were promoted for the current checkpoint slice".into(),
+        ));
+    }
+
+    if let Some(candidate) = report_doc.risky_tensors.first() {
+        findings.push(warn_finding(
+            "highest_risk",
+            format!(
+                "highest-risk tensor {} at {:.3}",
+                candidate.structural_name, candidate.risk_score
+            ),
+        ));
+    }
+
+    FindingsSummary {
+        analysis: "saaq-readiness".into(),
+        model_family: report_doc.model_family.clone(),
+        checkpoint_path: report_doc.checkpoint_path.clone(),
+        checkpoint_slug: checkpoint_slug.to_string(),
+        headline: format!(
+            "{} SAAQ candidates ranked",
+            report_doc.candidate_targets.len()
+        ),
+        findings,
+        schema_version: report_doc.schema_version,
+    }
+}
+
+fn sanitize_slug_component(input: &str) -> String {
+    let mut slug = String::new();
+    let mut last_dash = false;
+
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+
+    slug.trim_matches('-').to_string()
+}
+
+fn info_finding(category: &str, detail: String) -> FindingsSummaryItem {
+    FindingsSummaryItem {
+        severity: FindingsSeverity::Info,
+        category: category.to_string(),
+        detail,
+    }
+}
+
+fn warn_finding(category: &str, detail: String) -> FindingsSummaryItem {
+    FindingsSummaryItem {
+        severity: FindingsSeverity::Warning,
+        category: category.to_string(),
+        detail,
+    }
+}
+
+fn fmt_opt(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::schema::{
+        BlockSummary, InferredHyperparams, InventoryTotals, KindCount, RoutingBlockReport,
+        RoutingCriticalBlock, RoutingGateMetrics, RoutingOrientation, RoutingOrientationSummary,
+        RoutingTensorLocator, RoutingTensorRef, ShardRange, TensorDType, TensorRole, TensorShape,
+    };
+
+    #[test]
+    fn resolves_checkpoint_slug_from_parent_and_leaf() {
+        let path = Path::new("/tmp/grok-1-official/ckpt-0");
+        let slug = resolve_checkpoint_slug(path, None).expect("slug");
+        assert_eq!(slug, "grok-1-official__ckpt-0");
+    }
+
+    #[test]
+    fn inventory_bundle_writes_standard_tree() {
+        let root = unique_test_root("inventory_bundle");
+        let inv = sample_inventory();
+
+        let bundle = write_inventory_bundle(&inv, &root, None).expect("write inventory bundle");
+
+        assert_eq!(bundle.checkpoint_slug, "grok-1-official__ckpt-0");
+        assert!(
+            root.join("reports/grok-1-official__ckpt-0/inventory.md")
+                .exists()
+        );
+        assert!(
+            root.join("exports/grok-1-official__ckpt-0/inventory.json")
+                .exists()
+        );
+        assert!(
+            root.join("exports/grok-1-official__ckpt-0/inventory-findings.json")
+                .exists()
+        );
+        assert!(
+            root.join("manifests/grok-1-official__ckpt-0/checkpoint-inventory-snapshot.json")
+                .exists()
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn routing_manifest_carries_block_reason() {
+        let report_doc = sample_routing_report();
+        let manifest = build_routing_critical_manifest(&report_doc);
+
+        assert_eq!(manifest.tensors.len(), 1);
+        assert_eq!(
+            manifest.tensors[0].criticality_reason.as_deref(),
+            Some("primary router present")
+        );
+    }
+
+    fn unique_test_root(prefix: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("xai-dissect-{prefix}-{stamp}"))
+    }
+
+    fn sample_inventory() -> ModelInventory {
+        ModelInventory {
+            model_family: "grok-1".into(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+            shard_count: 2,
+            inferred: InferredHyperparams {
+                d_model: Some(6144),
+                n_experts: Some(8),
+                n_blocks: Some(1),
+                ..Default::default()
+            },
+            tensors: Vec::new(),
+            blocks: vec![BlockSummary {
+                block_index: Some(0),
+                label: "block_000".into(),
+                shard_range: Some(ShardRange {
+                    start: 0,
+                    end_inclusive: 1,
+                }),
+                tensor_count: 3,
+                total_nbytes: 1024,
+                dtypes: vec![TensorDType::F32, TensorDType::I8],
+                kinds: vec![KindCount {
+                    kind_label: "router".into(),
+                    count: 1,
+                    nbytes: 128,
+                }],
+            }],
+            totals: InventoryTotals {
+                tensors: 3,
+                quant_tensors: 1,
+                f32_tensors: 2,
+                i8_tensors: 1,
+                total_nbytes: 1024,
+                total_elements: 256,
+            },
+            schema_version: 1,
+        }
+    }
+
+    fn sample_routing_report() -> RoutingReport {
+        RoutingReport {
+            model_family: "grok-1".into(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+            shard_count: 2,
+            inferred: InferredHyperparams {
+                d_model: Some(6144),
+                n_experts: Some(8),
+                ..Default::default()
+            },
+            relevant_block_count: 1,
+            expected_experts_per_router: Some(8),
+            candidate_tensors: vec![RoutingTensorRef {
+                shard_ordinal: 1,
+                in_shard_index: 0,
+                block_index: Some(0),
+                block_slot: Some(4),
+                role: TensorRole::Tensor,
+                dtype: TensorDType::F32,
+                shape: TensorShape::new(vec![6144, 8]),
+                kind_label: "router".into(),
+                orientation: RoutingOrientation::DModelToExperts,
+                expert_axis: Some(1),
+                linked_expert_count: Some(8),
+                matches_inferred_expert_count: true,
+                structural_name: "block_000.slot_04.router".into(),
+                gate_metrics: RoutingGateMetrics {
+                    total_elements: 49_152,
+                    total_nbytes: 196_608,
+                    input_width: Some(6144),
+                    output_width: Some(8),
+                    expert_count: Some(8),
+                    logits_per_input: Some(8),
+                },
+            }],
+            blocks: vec![RoutingBlockReport {
+                block_index: Some(0),
+                label: "block_000".into(),
+                shard_range: Some(ShardRange {
+                    start: 0,
+                    end_inclusive: 1,
+                }),
+                local_expert_count: Some(8),
+                primary_candidate: Some(RoutingTensorLocator {
+                    shard_ordinal: 1,
+                    in_shard_index: 0,
+                    block_slot: Some(4),
+                }),
+                candidates: Vec::new(),
+            }],
+            orientation_summaries: vec![RoutingOrientationSummary {
+                orientation: RoutingOrientation::DModelToExperts,
+                count: 1,
+                observed_shapes: vec![TensorShape::new(vec![6144, 8])],
+                observed_blocks: 1,
+            }],
+            likely_routing_critical_blocks: vec![RoutingCriticalBlock {
+                block_index: Some(0),
+                label: "block_000".into(),
+                reason: "primary router present".into(),
+                primary_candidate: Some(RoutingTensorLocator {
+                    shard_ordinal: 1,
+                    in_shard_index: 0,
+                    block_slot: Some(4),
+                }),
+            }],
+            grok_layout_notes: Vec::new(),
+            anomalies: Vec::new(),
+            schema_version: 1,
+        }
+    }
+}

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::parser::{self, RawTensor};
 use crate::schema::{
@@ -316,7 +316,7 @@ fn assign_block_indices(tensors: &mut [TensorInfo], shard_count: usize) -> Optio
         return None;
     }
     let interior = shard_count - 2; // drop embedding + final-norm singletons
-                                    // Candidate block sizes we try, in priority order.
+    // Candidate block sizes we try, in priority order.
     let candidates = [12usize];
     let mut chosen: Option<(usize, usize)> = None; // (k_per_block, n_blocks)
     for &k in &candidates {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@
 //
 // Library entry point. The binary (src/main.rs) is a thin CLI on top of
 // this crate; external consumers should depend on the library and the
-// stable export schema produced by `xai_dissect::report`.
+// stable export schema and output conventions produced by the export layer.
 
 pub mod experts;
+pub mod exports;
 pub mod inventory;
 pub mod parser;
 pub mod report;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct OutputTreeArgs {
     output_root: Option<PathBuf>,
     /// Optional override for the checkpoint slug used under the unified
     /// output tree. If unset, the slug is inferred from the checkpoint path.
-    #[arg(long)]
+    #[arg(long, requires = "output_root")]
     checkpoint_slug: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,11 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use comfy_table::{Cell, ContentArrangement, Table, presets::UTF8_FULL};
 
 use xai_dissect::experts::build_expert_atlas;
+use xai_dissect::exports;
 use xai_dissect::inventory::{InventoryConfig, build_inventory};
 use xai_dissect::parser;
 use xai_dissect::report;
@@ -30,6 +31,18 @@ use xai_dissect::stats::{StatsConfig, build_saaq_readiness_report, build_stats_r
 struct Cli {
     #[command(subcommand)]
     command: Command,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+struct OutputTreeArgs {
+    /// If set, also write artifacts into
+    /// `<root>/{reports,exports,manifests}/<checkpoint-slug>/...`.
+    #[arg(long)]
+    output_root: Option<PathBuf>,
+    /// Optional override for the checkpoint slug used under the unified
+    /// output tree. If unset, the slug is inferred from the checkpoint path.
+    #[arg(long)]
+    checkpoint_slug: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -68,6 +81,8 @@ enum Command {
         /// Markdown summary is printed to stdout.
         #[arg(long)]
         md: Option<PathBuf>,
+        #[command(flatten)]
+        output_tree: OutputTreeArgs,
     },
     /// Build an expert-level atlas of a checkpoint directory: discover
     /// expert-stacked tensors, map blocks to expert counts, and optionally
@@ -92,6 +107,8 @@ enum Command {
         /// unset, the Markdown report is printed to stdout.
         #[arg(long)]
         md: Option<PathBuf>,
+        #[command(flatten)]
+        output_tree: OutputTreeArgs,
     },
     /// Build a routing-structure report for a checkpoint directory:
     /// identify likely router tensors, summarize their geometry, and
@@ -116,6 +133,8 @@ enum Command {
         /// unset, the Markdown report is printed to stdout.
         #[arg(long)]
         md: Option<PathBuf>,
+        #[command(flatten)]
+        output_tree: OutputTreeArgs,
     },
     /// Profile tensor payload statistics for offline analysis.
     Stats {
@@ -141,6 +160,8 @@ enum Command {
         /// the Markdown report is printed to stdout.
         #[arg(long)]
         md: Option<PathBuf>,
+        #[command(flatten)]
+        output_tree: OutputTreeArgs,
     },
     /// Rank likely SAAQ experiment targets without applying SAAQ itself.
     SaaqReadiness {
@@ -169,6 +190,8 @@ enum Command {
         /// If set, write the machine-readable candidate manifest as pretty JSON.
         #[arg(long)]
         manifest: Option<PathBuf>,
+        #[command(flatten)]
+        output_tree: OutputTreeArgs,
     },
 }
 
@@ -187,6 +210,7 @@ fn main() -> Result<()> {
             family,
             json,
             md,
+            output_tree,
         } => run_inventory(
             &path,
             &prefix,
@@ -194,6 +218,7 @@ fn main() -> Result<()> {
             &family,
             json.as_deref(),
             md.as_deref(),
+            &output_tree,
         ),
         Command::Experts {
             path,
@@ -202,6 +227,7 @@ fn main() -> Result<()> {
             family,
             json,
             md,
+            output_tree,
         } => run_experts(
             &path,
             &prefix,
@@ -209,6 +235,7 @@ fn main() -> Result<()> {
             &family,
             json.as_deref(),
             md.as_deref(),
+            &output_tree,
         ),
         Command::RoutingReport {
             path,
@@ -217,6 +244,7 @@ fn main() -> Result<()> {
             family,
             json,
             md,
+            output_tree,
         } => run_routing_report(
             &path,
             &prefix,
@@ -224,6 +252,7 @@ fn main() -> Result<()> {
             &family,
             json.as_deref(),
             md.as_deref(),
+            &output_tree,
         ),
         Command::Stats {
             path,
@@ -233,6 +262,7 @@ fn main() -> Result<()> {
             sample_values,
             json,
             md,
+            output_tree,
         } => run_stats(
             &path,
             &prefix,
@@ -241,6 +271,7 @@ fn main() -> Result<()> {
             sample_values,
             json.as_deref(),
             md.as_deref(),
+            &output_tree,
         ),
         Command::SaaqReadiness {
             path,
@@ -251,6 +282,7 @@ fn main() -> Result<()> {
             json,
             md,
             manifest,
+            output_tree,
         } => run_saaq_readiness(
             &path,
             &prefix,
@@ -260,6 +292,7 @@ fn main() -> Result<()> {
             json.as_deref(),
             md.as_deref(),
             manifest.as_deref(),
+            &output_tree,
         ),
     }
 }
@@ -336,6 +369,7 @@ fn run_inventory(
     family: &str,
     json_out: Option<&std::path::Path>,
     md_out: Option<&std::path::Path>,
+    output_tree: &OutputTreeArgs,
 ) -> Result<()> {
     let cfg = InventoryConfig {
         prefix: prefix.to_string(),
@@ -360,6 +394,11 @@ fn run_inventory(
         println!();
         println!("{}", report::render_markdown(&inv));
     }
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle =
+            exports::write_inventory_bundle(&inv, root, output_tree.checkpoint_slug.as_deref())?;
+        print_output_bundle("inventory bundle", root, &bundle);
+    }
 
     Ok(())
 }
@@ -373,6 +412,7 @@ fn run_experts(
     family: &str,
     json_out: Option<&std::path::Path>,
     md_out: Option<&std::path::Path>,
+    output_tree: &OutputTreeArgs,
 ) -> Result<()> {
     let cfg = InventoryConfig {
         prefix: prefix.to_string(),
@@ -395,6 +435,11 @@ fn run_experts(
         println!();
         println!("{}", report::render_expert_markdown(&atlas));
     }
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle =
+            exports::write_expert_bundle(&atlas, root, output_tree.checkpoint_slug.as_deref())?;
+        print_output_bundle("expert bundle", root, &bundle);
+    }
 
     Ok(())
 }
@@ -408,6 +453,7 @@ fn run_routing_report(
     family: &str,
     json_out: Option<&std::path::Path>,
     md_out: Option<&std::path::Path>,
+    output_tree: &OutputTreeArgs,
 ) -> Result<()> {
     let cfg = InventoryConfig {
         prefix: prefix.to_string(),
@@ -430,6 +476,14 @@ fn run_routing_report(
         println!();
         println!("{}", report::render_routing_markdown(&report_doc));
     }
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle = exports::write_routing_bundle(
+            &report_doc,
+            root,
+            output_tree.checkpoint_slug.as_deref(),
+        )?;
+        print_output_bundle("routing bundle", root, &bundle);
+    }
 
     Ok(())
 }
@@ -444,6 +498,7 @@ fn run_stats(
     sample_values: usize,
     json_out: Option<&std::path::Path>,
     md_out: Option<&std::path::Path>,
+    output_tree: &OutputTreeArgs,
 ) -> Result<()> {
     let cfg = InventoryConfig {
         prefix: prefix.to_string(),
@@ -470,6 +525,11 @@ fn run_stats(
         println!();
         println!("{}", report::render_stats_markdown(&report_doc));
     }
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle =
+            exports::write_stats_bundle(&report_doc, root, output_tree.checkpoint_slug.as_deref())?;
+        print_output_bundle("stats bundle", root, &bundle);
+    }
 
     Ok(())
 }
@@ -485,6 +545,7 @@ fn run_saaq_readiness(
     json_out: Option<&std::path::Path>,
     md_out: Option<&std::path::Path>,
     manifest_out: Option<&std::path::Path>,
+    output_tree: &OutputTreeArgs,
 ) -> Result<()> {
     let cfg = InventoryConfig {
         prefix: prefix.to_string(),
@@ -516,8 +577,21 @@ fn run_saaq_readiness(
         report::write_candidate_manifest_json(&readiness.manifest, p)?;
         eprintln!("wrote candidate manifest -> {}", p.display());
     }
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle =
+            exports::write_saaq_bundle(&readiness, root, output_tree.checkpoint_slug.as_deref())?;
+        print_output_bundle("saaq bundle", root, &bundle);
+    }
 
     Ok(())
+}
+
+fn print_output_bundle(label: &str, root: &std::path::Path, bundle: &exports::OutputBundle) {
+    eprintln!(
+        "wrote {label} -> {}/{{reports,exports,manifests}}/{}/...",
+        root.display(),
+        bundle.checkpoint_slug
+    );
 }
 
 fn print_console_summary(inv: &ModelInventory) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,7 +22,7 @@ use std::cmp::min;
 use std::fs::File;
 use std::path::Path;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use memchr::memmem;
 use memmap2::Mmap;
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -10,9 +10,11 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 
 use crate::schema::{
-    BlockSummary, CandidateTensorManifest, ExpertAtlas, ExpertIssueCategory, ModelInventory,
+    BlockSummary, CandidateTensorManifest, CheckpointInventorySnapshot, ExpertAtlas,
+    ExpertIssueCategory, FindingsSummary, ModelInventory, RoutingCriticalTensorManifest,
     RoutingIssueCategory, RoutingReport, SaaqDisposition, SaaqReadinessReport, StatsProfileReport,
 };
 
@@ -20,46 +22,57 @@ use crate::schema::{
 /// `ModelInventory` struct rendered via serde; its schema version is carried
 /// in the `schema_version` field.
 pub fn write_json(inv: &ModelInventory, out: &Path) -> Result<()> {
-    let s = serde_json::to_string_pretty(inv).context("serialize inventory to json")?;
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_pretty_json(inv, "serialize inventory to json", out)
 }
 
 /// Write the full expert atlas as pretty-printed JSON.
 pub fn write_expert_json(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
-    let s = serde_json::to_string_pretty(atlas).context("serialize expert atlas to json")?;
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_pretty_json(atlas, "serialize expert atlas to json", out)
 }
 
 /// Write the full routing report as pretty-printed JSON.
 pub fn write_routing_json(report_doc: &RoutingReport, out: &Path) -> Result<()> {
-    let s = serde_json::to_string_pretty(report_doc).context("serialize routing report to json")?;
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_pretty_json(report_doc, "serialize routing report to json", out)
 }
 
 /// Write the full stats profile as pretty-printed JSON.
 pub fn write_stats_json(report_doc: &StatsProfileReport, out: &Path) -> Result<()> {
-    let s = serde_json::to_string_pretty(report_doc).context("serialize stats report to json")?;
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_pretty_json(report_doc, "serialize stats report to json", out)
 }
 
 /// Write the full SAAQ-readiness report as pretty-printed JSON.
 pub fn write_saaq_readiness_json(report_doc: &SaaqReadinessReport, out: &Path) -> Result<()> {
-    let s = serde_json::to_string_pretty(report_doc)
-        .context("serialize saaq-readiness report to json")?;
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_pretty_json(report_doc, "serialize saaq-readiness report to json", out)
 }
 
 /// Write the candidate manifest as pretty-printed JSON.
 pub fn write_candidate_manifest_json(manifest: &CandidateTensorManifest, out: &Path) -> Result<()> {
-    let s =
-        serde_json::to_string_pretty(manifest).context("serialize candidate manifest to json")?;
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_pretty_json(manifest, "serialize candidate manifest to json", out)
+}
+
+/// Write the inventory snapshot manifest as pretty-printed JSON.
+pub fn write_inventory_snapshot_manifest_json(
+    manifest: &CheckpointInventorySnapshot,
+    out: &Path,
+) -> Result<()> {
+    write_pretty_json(
+        manifest,
+        "serialize inventory snapshot manifest to json",
+        out,
+    )
+}
+
+/// Write the routing-critical tensor manifest as pretty-printed JSON.
+pub fn write_routing_critical_manifest_json(
+    manifest: &RoutingCriticalTensorManifest,
+    out: &Path,
+) -> Result<()> {
+    write_pretty_json(manifest, "serialize routing-critical manifest to json", out)
+}
+
+/// Write the compact findings summary as pretty-printed JSON.
+pub fn write_findings_summary_json(summary: &FindingsSummary, out: &Path) -> Result<()> {
+    write_pretty_json(summary, "serialize findings summary to json", out)
 }
 
 /// Render a Markdown summary report for humans. Intentionally small and
@@ -182,8 +195,7 @@ pub fn render_markdown(inv: &ModelInventory) -> String {
 /// Write the Markdown summary to `out`.
 pub fn write_markdown(inv: &ModelInventory, out: &Path) -> Result<()> {
     let s = render_markdown(inv);
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_text(&s, out)
 }
 
 /// Render a Markdown summary report for humans from an expert atlas.
@@ -355,8 +367,7 @@ pub fn render_expert_markdown(atlas: &ExpertAtlas) -> String {
 /// Write the expert atlas Markdown summary to `out`.
 pub fn write_expert_markdown(atlas: &ExpertAtlas, out: &Path) -> Result<()> {
     let s = render_expert_markdown(atlas);
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_text(&s, out)
 }
 
 /// Render a Markdown summary report for humans from a routing report.
@@ -578,8 +589,7 @@ pub fn render_routing_markdown(report_doc: &RoutingReport) -> String {
 /// Write the routing Markdown summary to `out`.
 pub fn write_routing_markdown(report_doc: &RoutingReport, out: &Path) -> Result<()> {
     let s = render_routing_markdown(report_doc);
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_text(&s, out)
 }
 
 /// Render a Markdown summary report for humans from a stats profile.
@@ -713,8 +723,7 @@ pub fn render_stats_markdown(report_doc: &StatsProfileReport) -> String {
 /// Write the stats Markdown summary to `out`.
 pub fn write_stats_markdown(report_doc: &StatsProfileReport, out: &Path) -> Result<()> {
     let s = render_stats_markdown(report_doc);
-    fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
-    Ok(())
+    write_text(&s, out)
 }
 
 /// Render a Markdown summary report for humans from a SAAQ-readiness report.
@@ -849,11 +858,30 @@ pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> Strin
 /// Write the SAAQ-readiness Markdown summary to `out`.
 pub fn write_saaq_readiness_markdown(report_doc: &SaaqReadinessReport, out: &Path) -> Result<()> {
     let s = render_saaq_readiness_markdown(report_doc);
+    write_text(&s, out)
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+fn write_pretty_json<T: Serialize>(value: &T, context: &str, out: &Path) -> Result<()> {
+    let s = serde_json::to_string_pretty(value).with_context(|| context.to_string())?;
+    write_text(&s, out)
+}
+
+fn write_text(s: &str, out: &Path) -> Result<()> {
+    ensure_parent_dir(out)?;
     fs::write(out, s).with_context(|| format!("write {}", out.display()))?;
     Ok(())
 }
 
-// --- Helpers ---------------------------------------------------------------
+fn ensure_parent_dir(out: &Path) -> Result<()> {
+    if let Some(parent) = out.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
 
 fn render_kinds(b: &BlockSummary) -> String {
     if b.kinds.is_empty() {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -629,6 +629,82 @@ pub struct CandidateTensorManifest {
     pub schema_version: u32,
 }
 
+/// Compact checkpoint snapshot manifest for downstream tooling that needs
+/// inventory-level counts without the full tensor table payload.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointInventorySnapshot {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub shard_count: u32,
+    pub inferred: InferredHyperparams,
+    pub total_tensors: u64,
+    pub total_nbytes: u64,
+    pub blocks: Vec<CheckpointInventoryBlockSnapshot>,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointInventoryBlockSnapshot {
+    pub label: String,
+    pub block_index: Option<u32>,
+    pub shard_range: Option<ShardRange>,
+    pub tensor_count: u32,
+    pub total_nbytes: u64,
+    pub kind_labels: Vec<String>,
+}
+
+/// Machine-readable routing-critical tensor list for downstream
+/// compression / orchestration tooling.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingCriticalTensorManifest {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub tensors: Vec<RoutingCriticalTensor>,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoutingCriticalTensor {
+    pub shard_ordinal: u32,
+    pub in_shard_index: u32,
+    pub block_index: Option<u32>,
+    pub block_slot: Option<u32>,
+    pub structural_name: String,
+    pub kind_label: String,
+    pub orientation: RoutingOrientation,
+    pub linked_expert_count: Option<u64>,
+    pub total_nbytes: u64,
+    pub criticality_reason: Option<String>,
+}
+
+/// Small machine-readable summary of the main findings from a single
+/// analysis artifact.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FindingsSummary {
+    pub analysis: String,
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub checkpoint_slug: String,
+    pub headline: String,
+    pub findings: Vec<FindingsSummaryItem>,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FindingsSummaryItem {
+    pub severity: FindingsSeverity,
+    pub category: String,
+    pub detail: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingsSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SaaqCandidate {
     pub rank: u32,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -114,9 +114,10 @@ pub fn build_saaq_readiness_report(
         }) {
             let mut fallback = fallback.clone();
             fallback.disposition = SaaqDisposition::Candidate;
-            fallback
-                .reasons
-                .push("promoted as the best available non-routing target in a constrained sample".to_string());
+            fallback.reasons.push(
+                "promoted as the best available non-routing target in a constrained sample"
+                    .to_string(),
+            );
             candidate_targets.push(fallback);
         }
     }


### PR DESCRIPTION
## **User description**
## Summary
- add a dedicated exports layer for checkpoint-slugged reports/exports/manifests bundles
- add findings summaries plus routing-critical and inventory snapshot manifests
- wire inventory, experts, routing-report, stats, and saaq-readiness to --output-root / --checkpoint-slug

## Validation
- cargo test
- cargo build
- target/debug/xai-dissect inventory /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 1 --md /tmp/issue7-inventory.md --output-root /tmp/xai-dissect-issue7-jAjryE
- target/debug/xai-dissect experts /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 14 --md /tmp/issue7-experts.md --output-root /tmp/xai-dissect-issue7-jAjryE
- target/debug/xai-dissect routing-report /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 26 --md /tmp/issue7-routing.md --output-root /tmp/xai-dissect-issue7-jAjryE
- target/debug/xai-dissect stats /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 26 --md /tmp/issue7-stats.md --output-root /tmp/xai-dissect-issue7-jAjryE
- target/debug/xai-dissect saaq-readiness /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 --limit 26 --md /tmp/issue7-saaq.md --output-root /tmp/xai-dissect-issue7-jAjryE


___

## **CodeAnt-AI Description**
**Add a unified output tree for reports, exports, and manifests**

### What Changed
- Analysis commands can now write their results into a predictable `reports/`, `exports/`, and `manifests/` folder layout under a chosen output root.
- Inventory, experts, routing, stats, and SAAQ-readiness runs now save matching Markdown and JSON artifacts, plus compact findings summaries; inventory and routing also emit focused machine-readable manifests for downstream use.
- If no slug is provided, the checkpoint name is inferred from the path and sanitized so the output folders stay consistent and filesystem-safe.

### Impact
`✅ Easier downstream automation`
`✅ Consistent artifact locations across commands`
`✅ Faster checkpoint review and handoff`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=MscabsO7osHV-ejEYMc__cdfGSJJXL8w9ryuSYsrvZo&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
