### PR TITLE
Fix Grok-1 router canonicalization

### DIFF
--- a/docs/tensor-schema.md
+++ b/docs/tensor-schema.md
@@ -127,13 +127,14 @@ Applied in order; the first matching rule wins.
 ## Block assignment
 
 Grok-1 emits one shard per top-level JAX leaf. The observed layout for
-`ckpt-0` is:
+`ckpt-0` is one token-embedding singleton, one norm singleton, and 64
+equal-sized transformer-block windows:
 
 ```
-  shard   0             : token embedding          (1 shard)
-  shards  1 .. 1+64*K-1 : 64 transformer blocks    (K = 12 shards / block)
-  shard   1 + 64*K      : final norm               (1 shard)
-                          total = 770
+  shard   0              : token embedding          (1 shard)
+  one edge singleton     : final/pre-head norm      (1 shard)
+  remaining 64*K shards  : 64 transformer blocks    (K = 12 shards / block)
+                           total = 770
 ```
 
 The inventory layer computes:
@@ -143,16 +144,22 @@ The inventory layer computes:
   if interior % 12 == 0 and shard_count >= 3:
       k_per_block = 12
       n_blocks    = interior / 12
-      block_index = (shard_ordinal - 1) / k_per_block
-      block_slot  = (shard_ordinal - 1) % k_per_block
+      choose the edge norm singleton from observed tensor kinds
+      block_index = (shard_ordinal - first_block_shard) / k_per_block
+      block_slot  = (shard_ordinal - first_block_shard) % k_per_block
 ```
 
 If the divisor check fails the assignment is skipped; `block_index` and
 `block_slot` remain `null` and downstream consumers should fall back to
 `shard_ordinal` and `kind`.
 
-The last shard's `BlockNorm` record is promoted to `FinalNorm` once block
-assignment succeeds.
+The norm singleton's `BlockNorm` record is promoted to `FinalNorm` once
+block assignment succeeds. For Grok-1 router canonicalization, the layout
+choice is conservative: if the norm singleton appears immediately after the
+embedding and the tail shard is router-shaped, the block window starts after
+that singleton so all 64 `(d_model, n_experts)` routers receive canonical
+`block_NNN.routing_slot_SS` names. If the evidence is insufficient, router
+candidates remain unassigned and the routing report records a layout note.
 
 ## What is *not* inferred here
 

--- a/src/experts/mod.rs
+++ b/src/experts/mod.rs
@@ -206,10 +206,8 @@ fn infer_expert_projection(
 ) -> Option<MoeProjection> {
     match &tensor.kind {
         TensorKind::MoeExpertProjection { projection } => return Some(*projection),
-        TensorKind::MoeScales => {
-            if tensor.shape.dims().first().copied() == expected_experts {
-                return Some(MoeProjection::Unresolved);
-            }
+        TensorKind::MoeScales if tensor.shape.dims().first().copied() == expected_experts => {
+            return Some(MoeProjection::Unresolved);
         }
         _ => {}
     }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -300,11 +300,15 @@ fn classify_tensor(t: &RawTensor, hp: &InferredHyperparams) -> TensorKind {
 
 /// Shard layout assumption for a well-formed Grok-1 checkpoint:
 ///
-///   shard 0            = token embedding         (1 shard)
-///   shards 1..=64*K    = 64 transformer blocks,  (K shards / block)
-///   shard (1 + 64*K)   = final norm              (1 shard)
+///   shard 0                  = token embedding         (1 shard)
+///   one edge norm singleton  = final/pre-head norm     (1 shard)
+///   remaining shards         = transformer blocks      (K shards / block)
 ///
 /// For Grok-1 `ckpt-0` observed in the wild: `K = 12`, total = 770.
+/// The norm singleton can appear either at the tail or immediately after
+/// the embedding depending on the sorted shard order. Pick the placement
+/// whose block window accounts for router-shaped tensors instead of leaving
+/// them unassigned.
 ///
 /// If the shard count does not fit this layout exactly, we leave
 /// `block_index` unset and the tail norm un-promoted; downstream consumers
@@ -328,7 +332,7 @@ fn assign_block_indices(tensors: &mut [TensorInfo], shard_count: usize) -> Optio
 
     let (k_per_block, n_blocks) = chosen?;
 
-    let last_shard = (shard_count - 1) as u32;
+    let layout = choose_grok_block_layout(tensors, shard_count, k_per_block, n_blocks)?;
 
     for t in tensors.iter_mut() {
         let ord = t.shard_ordinal as usize;
@@ -336,22 +340,102 @@ fn assign_block_indices(tensors: &mut [TensorInfo], shard_count: usize) -> Optio
             // Embedding: no block assignment.
             continue;
         }
-        if ord as u32 == last_shard {
-            // Final norm position. Promote a BlockNorm record to FinalNorm.
+        if ord == layout.norm_singleton_shard {
+            // Final/pre-head norm singleton. Promote a BlockNorm record to FinalNorm.
             if matches!(t.kind, TensorKind::BlockNorm) {
                 t.kind = TensorKind::FinalNorm;
             }
             continue;
         }
-        if ord >= 1 && ord <= shard_count - 2 {
-            let b = (ord - 1) / k_per_block;
-            let slot = (ord - 1) % k_per_block;
+        if ord >= layout.first_block_shard && ord <= layout.last_block_shard {
+            let b = (ord - layout.first_block_shard) / k_per_block;
+            let slot = (ord - layout.first_block_shard) % k_per_block;
             t.block_index = Some(b as u32);
             t.block_slot = Some(slot as u32);
         }
     }
 
     Some(n_blocks as u32)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct GrokBlockLayout {
+    first_block_shard: usize,
+    last_block_shard: usize,
+    norm_singleton_shard: usize,
+    assigned_routers: usize,
+    singleton_routers: usize,
+}
+
+fn choose_grok_block_layout(
+    tensors: &[TensorInfo],
+    shard_count: usize,
+    k_per_block: usize,
+    n_blocks: usize,
+) -> Option<GrokBlockLayout> {
+    let block_shards = k_per_block.checked_mul(n_blocks)?;
+    let last_shard = shard_count.checked_sub(1)?;
+    let tail_norm = grok_layout_candidate(tensors, 1, last_shard, block_shards);
+    let leading_norm = grok_layout_candidate(tensors, 2, 1, block_shards);
+
+    match (tail_norm, leading_norm) {
+        (Some(tail), Some(leading))
+            if leading.assigned_routers > tail.assigned_routers
+                && leading.singleton_routers < tail.singleton_routers =>
+        {
+            Some(leading)
+        }
+        (Some(tail), _) => Some(tail),
+        (None, Some(leading)) => Some(leading),
+        (None, None) => None,
+    }
+}
+
+fn grok_layout_candidate(
+    tensors: &[TensorInfo],
+    first_block_shard: usize,
+    norm_singleton_shard: usize,
+    block_shards: usize,
+) -> Option<GrokBlockLayout> {
+    let last_block_shard = first_block_shard
+        .checked_add(block_shards)?
+        .checked_sub(1)?;
+    let norm_is_plausible = tensors.iter().any(|tensor| {
+        tensor.shard_ordinal as usize == norm_singleton_shard
+            && matches!(tensor.kind, TensorKind::BlockNorm)
+    }) && !tensors.iter().any(|tensor| {
+        tensor.shard_ordinal as usize == norm_singleton_shard
+            && matches!(
+                tensor.kind,
+                TensorKind::Router | TensorKind::MoeExpertProjection { .. }
+            )
+    });
+    if !norm_is_plausible {
+        return None;
+    }
+
+    let assigned_routers = tensors
+        .iter()
+        .filter(|tensor| {
+            matches!(tensor.kind, TensorKind::Router)
+                && (first_block_shard..=last_block_shard).contains(&(tensor.shard_ordinal as usize))
+        })
+        .count();
+    let singleton_routers = tensors
+        .iter()
+        .filter(|tensor| {
+            matches!(tensor.kind, TensorKind::Router)
+                && tensor.shard_ordinal as usize == norm_singleton_shard
+        })
+        .count();
+
+    Some(GrokBlockLayout {
+        first_block_shard,
+        last_block_shard,
+        norm_singleton_shard,
+        assigned_routers,
+        singleton_routers,
+    })
 }
 
 // --- Block summaries -------------------------------------------------------
@@ -495,4 +579,194 @@ fn compute_totals(tensors: &[TensorInfo]) -> InventoryTotals {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::routing::build_routing_report;
+    use crate::schema::{TensorRole, TensorShape};
+
+    use super::*;
+
+    #[test]
+    fn shifted_grok_layout_assigns_all_sixty_four_routers_to_blocks() {
+        let mut tensors = shifted_grok_ckpt0_tensors();
+
+        let n_blocks = assign_block_indices(&mut tensors, 770);
+
+        assert_eq!(n_blocks, Some(64));
+        assert!(tensors.iter().any(|tensor| tensor.shard_ordinal == 1
+            && matches!(tensor.kind, TensorKind::FinalNorm)
+            && tensor.block_index.is_none()));
+
+        let routers = tensors
+            .iter()
+            .filter(|tensor| matches!(tensor.kind, TensorKind::Router))
+            .collect::<Vec<_>>();
+        assert_eq!(routers.len(), 64);
+        assert!(routers.iter().all(|tensor| tensor.block_index.is_some()));
+        assert!(routers.iter().any(|tensor| tensor.shard_ordinal == 13
+            && tensor.block_index == Some(0)
+            && tensor.block_slot == Some(11)));
+        assert!(routers.iter().any(|tensor| tensor.shard_ordinal == 769
+            && tensor.block_index == Some(63)
+            && tensor.block_slot == Some(11)));
+    }
+
+    #[test]
+    fn shifted_grok_layout_routing_report_has_no_unassigned_candidate() {
+        let mut tensors = shifted_grok_ckpt0_tensors();
+        assign_block_indices(&mut tensors, 770);
+        let inv = inventory(tensors, 770);
+
+        let report = build_routing_report(&inv);
+
+        assert_eq!(report.candidate_tensors.len(), 64);
+        assert_eq!(report.relevant_block_count, 64);
+        assert!(
+            report
+                .candidate_tensors
+                .iter()
+                .all(|tensor| tensor.block_index.is_some())
+        );
+        assert!(
+            report
+                .candidate_tensors
+                .iter()
+                .all(|tensor| !tensor.structural_name.starts_with("unassigned."))
+        );
+        assert!(
+            report
+                .candidate_tensors
+                .iter()
+                .any(|tensor| tensor.structural_name == "block_000.routing_slot_11")
+        );
+        assert!(
+            report
+                .candidate_tensors
+                .iter()
+                .any(|tensor| tensor.structural_name == "block_063.routing_slot_11")
+        );
+    }
+
+    fn shifted_grok_ckpt0_tensors() -> Vec<TensorInfo> {
+        let mut tensors = Vec::new();
+        tensors.push(tensor(
+            0,
+            TensorKind::TokenEmbedding,
+            TensorRole::Tensor,
+            TensorDType::F32,
+            vec![131_072, 6_144],
+        ));
+        tensors.push(tensor(
+            1,
+            TensorKind::BlockNorm,
+            TensorRole::Tensor,
+            TensorDType::F32,
+            vec![6_144],
+        ));
+
+        for block in 0..64u32 {
+            let start = 2 + block * 12;
+            for slot in 0..12u32 {
+                let shard = start + slot;
+                match slot {
+                    0..=3 => tensors.push(tensor(
+                        shard,
+                        TensorKind::BlockNorm,
+                        TensorRole::Tensor,
+                        TensorDType::F32,
+                        vec![6_144],
+                    )),
+                    4..=5 => tensors.push(tensor(
+                        shard,
+                        TensorKind::AttnProjF32,
+                        TensorRole::Tensor,
+                        TensorDType::F32,
+                        vec![6_144, 6_144],
+                    )),
+                    6..=7 => tensors.push(tensor(
+                        shard,
+                        TensorKind::MoeScales,
+                        TensorRole::QuantScales,
+                        TensorDType::F32,
+                        vec![8, 32_768],
+                    )),
+                    8 | 9 => tensors.push(tensor(
+                        shard,
+                        TensorKind::MoeExpertProjection {
+                            projection: MoeProjection::Unresolved,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6_144, 32_768],
+                    )),
+                    10 => tensors.push(tensor(
+                        shard,
+                        TensorKind::MoeExpertProjection {
+                            projection: MoeProjection::Down,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 32_768, 6_144],
+                    )),
+                    11 => tensors.push(tensor(
+                        shard,
+                        TensorKind::Router,
+                        TensorRole::Tensor,
+                        TensorDType::F32,
+                        vec![6_144, 8],
+                    )),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        tensors
+    }
+
+    fn inventory(tensors: Vec<TensorInfo>, shard_count: u32) -> ModelInventory {
+        let blocks = summarize_blocks(&tensors);
+        let totals = compute_totals(&tensors);
+        ModelInventory {
+            model_family: "grok-1".to_string(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1/ckpt-0"),
+            shard_count,
+            inferred: InferredHyperparams {
+                vocab_size: Some(131_072),
+                d_model: Some(6_144),
+                n_experts: Some(8),
+                d_ff: Some(32_768),
+                n_blocks: Some(64),
+            },
+            tensors,
+            blocks,
+            totals,
+            schema_version: SCHEMA_VERSION,
+        }
+    }
+
+    fn tensor(
+        shard_ordinal: u32,
+        kind: TensorKind,
+        role: TensorRole,
+        dtype: TensorDType,
+        shape: Vec<u64>,
+    ) -> TensorInfo {
+        TensorInfo {
+            shard_path: PathBuf::from(format!("/tmp/grok-1/ckpt-0/tensor{shard_ordinal:05}_000")),
+            shard_ordinal,
+            in_shard_index: 0,
+            role,
+            dtype,
+            shape: TensorShape::new(shape),
+            offset: 0,
+            nbytes: 0,
+            kind,
+            block_index: None,
+            block_slot: None,
+        }
+    }
 }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -311,7 +311,7 @@ fn classify_tensor(t: &RawTensor, hp: &InferredHyperparams) -> TensorKind {
 /// them unassigned.
 ///
 /// If the shard count does not fit this layout exactly, we leave
-/// `block_index` unset and the tail norm un-promoted; downstream consumers
+/// `block_index` unset and the norm singleton un-promoted; downstream consumers
 /// can still use `kind`, shape, and shard_ordinal directly.
 fn assign_block_indices(tensors: &mut [TensorInfo], shard_count: usize) -> Option<u32> {
     // Try to divide the interior shards into equally-sized blocks, preferring
@@ -364,7 +364,7 @@ struct GrokBlockLayout {
     last_block_shard: usize,
     norm_singleton_shard: usize,
     assigned_routers: usize,
-    singleton_routers: usize,
+    terminal_router_evidence: bool,
 }
 
 fn choose_grok_block_layout(
@@ -379,15 +379,13 @@ fn choose_grok_block_layout(
     let leading_norm = grok_layout_candidate(tensors, 2, 1, block_shards);
 
     match (tail_norm, leading_norm) {
-        (Some(tail), Some(leading))
-            if leading.assigned_routers > tail.assigned_routers
-                && leading.singleton_routers < tail.singleton_routers =>
-        {
+        (Some(tail), Some(leading)) if leading.assigned_routers > tail.assigned_routers => {
             Some(leading)
         }
         (Some(tail), _) => Some(tail),
-        (None, Some(leading)) => Some(leading),
+        (None, Some(leading)) if leading.terminal_router_evidence => Some(leading),
         (None, None) => None,
+        (None, Some(_)) => None,
     }
 }
 
@@ -421,20 +419,21 @@ fn grok_layout_candidate(
                 && (first_block_shard..=last_block_shard).contains(&(tensor.shard_ordinal as usize))
         })
         .count();
-    let singleton_routers = tensors
+    let terminal_router_evidence = tensors
         .iter()
         .filter(|tensor| {
             matches!(tensor.kind, TensorKind::Router)
-                && tensor.shard_ordinal as usize == norm_singleton_shard
+                && tensor.shard_ordinal as usize == last_block_shard
         })
-        .count();
+        .count()
+        > 0;
 
     Some(GrokBlockLayout {
         first_block_shard,
         last_block_shard,
         norm_singleton_shard,
         assigned_routers,
-        singleton_routers,
+        terminal_router_evidence,
     })
 }
 
@@ -651,6 +650,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn missing_tail_norm_does_not_force_shifted_layout() {
+        let mut tensors = normal_grok_ckpt0_tensors_without_tail_norm();
+
+        let n_blocks = assign_block_indices(&mut tensors, 770);
+
+        assert_eq!(n_blocks, None);
+        assert!(
+            tensors
+                .iter()
+                .filter(|tensor| matches!(tensor.kind, TensorKind::Router))
+                .all(|tensor| tensor.block_index.is_none() && tensor.block_slot.is_none())
+        );
+    }
+
     fn shifted_grok_ckpt0_tensors() -> Vec<TensorInfo> {
         let mut tensors = Vec::new();
         tensors.push(tensor(
@@ -668,8 +682,27 @@ mod tests {
             vec![6_144],
         ));
 
+        append_grok_blocks(&mut tensors, 2);
+
+        tensors
+    }
+
+    fn normal_grok_ckpt0_tensors_without_tail_norm() -> Vec<TensorInfo> {
+        let mut tensors = Vec::new();
+        tensors.push(tensor(
+            0,
+            TensorKind::TokenEmbedding,
+            TensorRole::Tensor,
+            TensorDType::F32,
+            vec![131_072, 6_144],
+        ));
+        append_grok_blocks(&mut tensors, 1);
+        tensors
+    }
+
+    fn append_grok_blocks(tensors: &mut Vec<TensorInfo>, first_block_shard: u32) {
         for block in 0..64u32 {
-            let start = 2 + block * 12;
+            let start = first_block_shard + block * 12;
             for slot in 0..12u32 {
                 let shard = start + slot;
                 match slot {
@@ -723,8 +756,6 @@ mod tests {
                 }
             }
         }
-
-        tensors
     }
 
     fn inventory(tensors: Vec<TensorInfo>, shard_count: u32) -> ModelInventory {

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,6 +496,7 @@ fn run_routing_report(
 
 // --- `stats` --------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn run_stats(
     path: &std::path::Path,
     prefix: &str,
@@ -542,6 +543,7 @@ fn run_stats(
 
 // --- `saaq-readiness` -----------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn run_saaq_readiness(
     path: &std::path::Path,
     prefix: &str,

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -86,6 +86,21 @@ pub fn build_routing_report(inv: &ModelInventory) -> RoutingReport {
             });
         }
 
+        if block_index.is_none() && !candidates.is_empty() {
+            for candidate in &candidates {
+                anomalies.push(RoutingIssue {
+                    severity: RoutingIssueSeverity::Warning,
+                    category: RoutingIssueCategory::LayoutNote,
+                    block_index,
+                    tensor: Some(locator_from_candidate(candidate)),
+                    message: format!(
+                        "routing candidate `{}` is unassigned because inventory block assignment did not have enough layout evidence to map it to a canonical block",
+                        candidate.structural_name
+                    ),
+                });
+            }
+        }
+
         if let Some(primary) = select_primary_candidate(&candidates) {
             if matches!(
                 primary.orientation,
@@ -600,6 +615,31 @@ mod tests {
                 .iter()
                 .any(|issue| issue.message.contains("no routing candidate"))
         );
+    }
+
+    #[test]
+    fn report_documents_unassigned_routing_candidate() {
+        let inv = inventory(vec![tensor(
+            769,
+            None,
+            None,
+            TensorRole::Tensor,
+            TensorDType::F32,
+            vec![6144, 8],
+            TensorKind::Router,
+        )]);
+
+        let report = build_routing_report(&inv);
+
+        assert_eq!(report.candidate_tensors.len(), 1);
+        assert_eq!(
+            report.candidate_tensors[0].structural_name,
+            "unassigned.routing_candidate_00"
+        );
+        assert!(report.anomalies.iter().any(|issue| {
+            issue.category == crate::schema::RoutingIssueCategory::LayoutNote
+                && issue.message.contains("is unassigned")
+        }));
     }
 
     fn inventory(tensors: Vec<TensorInfo>) -> ModelInventory {

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -643,10 +643,16 @@ mod tests {
     }
 
     fn inventory(tensors: Vec<TensorInfo>) -> ModelInventory {
+        let shard_count = tensors
+            .iter()
+            .map(|tensor| tensor.shard_ordinal)
+            .max()
+            .map(|max| max + 1)
+            .unwrap_or(0);
         ModelInventory {
             model_family: "grok-1".to_string(),
             checkpoint_path: PathBuf::from("/tmp/grok-1"),
-            shard_count: tensors.len() as u32,
+            shard_count,
             inferred: InferredHyperparams {
                 vocab_size: Some(131072),
                 d_model: Some(6144),

--- a/tests/fixtures/exports/stats.snap
+++ b/tests/fixtures/exports/stats.snap
@@ -146,7 +146,7 @@
   "norm_summary": {
     "mean_rms": 0.715266994375,
     "max_rms": {
-      "shard_ordinal": 0,
+      "shard_ordinal": 1,
       "in_shard_index": 0,
       "structural_name": "block_000.routing_slot_00",
       "kind_label": "router",
@@ -154,7 +154,7 @@
       "value": 1.11803398875
     },
     "max_l2": {
-      "shard_ordinal": 0,
+      "shard_ordinal": 1,
       "in_shard_index": 0,
       "structural_name": "block_000.routing_slot_00",
       "kind_label": "router",
@@ -163,7 +163,7 @@
     },
     "top_rms": [
       {
-        "shard_ordinal": 0,
+        "shard_ordinal": 1,
         "in_shard_index": 0,
         "structural_name": "block_000.routing_slot_00",
         "kind_label": "router",
@@ -181,7 +181,7 @@
     ],
     "top_l2": [
       {
-        "shard_ordinal": 0,
+        "shard_ordinal": 1,
         "in_shard_index": 0,
         "structural_name": "block_000.routing_slot_00",
         "kind_label": "router",
@@ -201,7 +201,7 @@
   "variance_summary": {
     "mean_variance": 0.65625,
     "max_variance": {
-      "shard_ordinal": 0,
+      "shard_ordinal": 1,
       "in_shard_index": 0,
       "structural_name": "block_000.routing_slot_00",
       "kind_label": "router",
@@ -218,7 +218,7 @@
     },
     "top_variance": [
       {
-        "shard_ordinal": 0,
+        "shard_ordinal": 1,
         "in_shard_index": 0,
         "structural_name": "block_000.routing_slot_00",
         "kind_label": "router",
@@ -244,7 +244,7 @@
         "value": 0.0625
       },
       {
-        "shard_ordinal": 0,
+        "shard_ordinal": 1,
         "in_shard_index": 0,
         "structural_name": "block_000.routing_slot_00",
         "kind_label": "router",
@@ -257,7 +257,7 @@
     "mean_outlier_fraction": 0.0625,
     "most_outlier_heavy": [
       {
-        "shard_ordinal": 0,
+        "shard_ordinal": 1,
         "in_shard_index": 0,
         "structural_name": "block_000.routing_slot_00",
         "kind_label": "router",
@@ -283,7 +283,7 @@
         "value": 2.4
       },
       {
-        "shard_ordinal": 0,
+        "shard_ordinal": 1,
         "in_shard_index": 0,
         "structural_name": "block_000.routing_slot_00",
         "kind_label": "router",

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -555,63 +555,27 @@ pub fn sample_stats_profile() -> StatsProfileReport {
         ],
         norm_summary: NormSummary {
             mean_rms: 0.715_266_994_375,
-            max_rms: Some(rank(
-                &router_stat,
-                "router",
-                1.118_033_988_75,
-            )),
-            max_l2: Some(rank(
-                &router_stat,
-                "router",
-                3.162_277_660_17,
-            )),
+            max_rms: Some(rank(&router_stat, "router", 1.118_033_988_75)),
+            max_l2: Some(rank(&router_stat, "router", 3.162_277_660_17)),
             top_rms: vec![
-                rank(
-                    &router_stat,
-                    "router",
-                    1.118_033_988_75,
-                ),
-                rank(
-                    &embedding_stat,
-                    "token_embedding",
-                    0.3125,
-                ),
+                rank(&router_stat, "router", 1.118_033_988_75),
+                rank(&embedding_stat, "token_embedding", 0.3125),
             ],
             top_l2: vec![
-                rank(
-                    &router_stat,
-                    "router",
-                    3.162_277_660_17,
-                ),
-                rank(
-                    &embedding_stat,
-                    "token_embedding",
-                    2.5,
-                ),
+                rank(&router_stat, "router", 3.162_277_660_17),
+                rank(&embedding_stat, "token_embedding", 2.5),
             ],
         },
         variance_summary: VarianceSummary {
             mean_variance: 0.65625,
             max_variance: Some(rank(&router_stat, "router", 1.25)),
-            min_variance: Some(rank(
-                &embedding_stat,
-                "token_embedding",
-                0.0625,
-            )),
+            min_variance: Some(rank(&embedding_stat, "token_embedding", 0.0625)),
             top_variance: vec![
                 rank(&router_stat, "router", 1.25),
-                rank(
-                    &embedding_stat,
-                    "token_embedding",
-                    0.0625,
-                ),
+                rank(&embedding_stat, "token_embedding", 0.0625),
             ],
             lowest_variance: vec![
-                rank(
-                    &embedding_stat,
-                    "token_embedding",
-                    0.0625,
-                ),
+                rank(&embedding_stat, "token_embedding", 0.0625),
                 rank(&router_stat, "router", 1.25),
             ],
         },
@@ -619,23 +583,11 @@ pub fn sample_stats_profile() -> StatsProfileReport {
             mean_outlier_fraction: 0.0625,
             most_outlier_heavy: vec![
                 rank(&router_stat, "router", 0.125),
-                rank(
-                    &embedding_stat,
-                    "token_embedding",
-                    0.0,
-                ),
+                rank(&embedding_stat, "token_embedding", 0.0),
             ],
             highest_peak_to_rms: vec![
-                rank(
-                    &embedding_stat,
-                    "token_embedding",
-                    2.4,
-                ),
-                rank(
-                    &router_stat,
-                    "router",
-                    1.788_854_381_99,
-                ),
+                rank(&embedding_stat, "token_embedding", 2.4),
+                rank(&router_stat, "router", 1.788_854_381_99),
             ],
         },
         schema_version: 1,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -556,96 +556,84 @@ pub fn sample_stats_profile() -> StatsProfileReport {
         norm_summary: NormSummary {
             mean_rms: 0.715_266_994_375,
             max_rms: Some(rank(
-                "block_000.routing_slot_00",
+                &router_stat,
                 "router",
-                Some(0),
                 1.118_033_988_75,
             )),
             max_l2: Some(rank(
-                "block_000.routing_slot_00",
+                &router_stat,
                 "router",
-                Some(0),
                 3.162_277_660_17,
             )),
             top_rms: vec![
                 rank(
-                    "block_000.routing_slot_00",
+                    &router_stat,
                     "router",
-                    Some(0),
                     1.118_033_988_75,
                 ),
                 rank(
-                    "embedding.slot_00.token_embedding",
+                    &embedding_stat,
                     "token_embedding",
-                    None,
                     0.3125,
                 ),
             ],
             top_l2: vec![
                 rank(
-                    "block_000.routing_slot_00",
+                    &router_stat,
                     "router",
-                    Some(0),
                     3.162_277_660_17,
                 ),
                 rank(
-                    "embedding.slot_00.token_embedding",
+                    &embedding_stat,
                     "token_embedding",
-                    None,
                     2.5,
                 ),
             ],
         },
         variance_summary: VarianceSummary {
             mean_variance: 0.65625,
-            max_variance: Some(rank("block_000.routing_slot_00", "router", Some(0), 1.25)),
+            max_variance: Some(rank(&router_stat, "router", 1.25)),
             min_variance: Some(rank(
-                "embedding.slot_00.token_embedding",
+                &embedding_stat,
                 "token_embedding",
-                None,
                 0.0625,
             )),
             top_variance: vec![
-                rank("block_000.routing_slot_00", "router", Some(0), 1.25),
+                rank(&router_stat, "router", 1.25),
                 rank(
-                    "embedding.slot_00.token_embedding",
+                    &embedding_stat,
                     "token_embedding",
-                    None,
                     0.0625,
                 ),
             ],
             lowest_variance: vec![
                 rank(
-                    "embedding.slot_00.token_embedding",
+                    &embedding_stat,
                     "token_embedding",
-                    None,
                     0.0625,
                 ),
-                rank("block_000.routing_slot_00", "router", Some(0), 1.25),
+                rank(&router_stat, "router", 1.25),
             ],
         },
         outlier_summary: OutlierSummary {
             mean_outlier_fraction: 0.0625,
             most_outlier_heavy: vec![
-                rank("block_000.routing_slot_00", "router", Some(0), 0.125),
+                rank(&router_stat, "router", 0.125),
                 rank(
-                    "embedding.slot_00.token_embedding",
+                    &embedding_stat,
                     "token_embedding",
-                    None,
                     0.0,
                 ),
             ],
             highest_peak_to_rms: vec![
                 rank(
-                    "embedding.slot_00.token_embedding",
+                    &embedding_stat,
                     "token_embedding",
-                    None,
                     2.4,
                 ),
                 rank(
-                    "block_000.routing_slot_00",
+                    &router_stat,
                     "router",
-                    Some(0),
                     1.788_854_381_99,
                 ),
             ],


### PR DESCRIPTION
## **User description**
## Summary
- canonicalize Grok-1 block assignment when the norm singleton appears immediately after the embedding, so all 64 router-shaped tensors can map to block-local routing slots
- add a routing layout-note anomaly for any router candidate that remains truly unassigned
- add regression coverage for the known 770-shard Grok-1 pattern and SAAQ/router protection path
- include the prior stats fixture compile/snapshot fix that is not yet on origin/main

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

No raw checkpoint shards or large output directories are included.


___

## **CodeAnt-AI Description**
**Handle Grok-1 router layouts where the norm singleton appears right after the embedding**

### What Changed
- Grok-1 router tensors are now assigned canonical block names in the shifted shard layout, so all 64 routers can be placed into block slots instead of being left unassigned
- When a router still cannot be matched to a block, the routing report now shows a layout note explaining that it was left unassigned
- Added regression coverage for the shifted `ckpt-0` layout, the unassigned-router report case, and the stats fixture helper update
- Updated the tensor layout docs to describe the shifted Grok-1 shard order and the router naming rule

### Impact
`✅ Fewer unassigned Grok-1 router tensors`
`✅ Clearer routing reports for shifted checkpoints`
`✅ Lower risk of router naming regressions`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=TyfBsHhhHF5UJhcj7H15VjXbPriGknn7gh0V5dBXdkc&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
