### PR TITLE
Define xai-dissect export contract for grok-ozempic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Main commands:
 - `experts`: expert atlas for MoE block structure
 - `routing-report`: routing/gating structure inspection
 - `stats`: offline tensor-statistics profiling
-- `saaq-readiness`: candidate scouting for future SAAQ experiments
+- `saaq-readiness`: candidate scouting for future SAAQ work
+- `quant-plan`: deterministic Grok-1 conversion and policy-planning artifacts
 
 ## Usage Examples
 
@@ -102,6 +103,22 @@ All examples assume a checkpoint directory such as
   --manifest out/candidate-saaq-targets.json
 ```
 
+### Quant Plan
+
+```bash
+./target/release/xai-dissect quant-plan /path/to/grok-1/ckpt-0 \
+  --sample-values 65536 \
+  --json out/quant-plan.json \
+  --md out/quant-plan.md \
+  --conversion-manifest out/conversion-manifest.json
+```
+
+This command requires the clean Grok-1 structural baseline and emits:
+
+- a named baseline gate via `grok1-coverage.json` with profile `grok1-map-v1-clean`
+- a per-tensor `conversion-manifest.json` for downstream conversion / packing work
+- a family-level `quant-plan.json` for pilot quantization policy selection
+
 ### Unified Output Tree
 
 ```bash
@@ -135,7 +152,8 @@ Examples:
 
 - `inventory` writes a checkpoint inventory plus an inventory snapshot manifest
 - `routing-report` writes a routing report plus a routing-critical tensor list
-- `saaq-readiness` writes a readiness report plus a ranked candidate manifest
+- `saaq-readiness` writes a grouped readiness report plus a ranked candidate manifest
+- `quant-plan` writes a conversion manifest plus a deterministic family-level quant plan
 
 ## Stability Notes
 
@@ -192,6 +210,9 @@ upstream of that work: it tells you what you are touching before any
 compression-oriented repo starts changing representation or execution.
 `grok-ozempic` is still under construction for further upgrades, and the
 "ozempic" part of the name is meant to make that repo's purpose obvious.
+The current Grok-1 downstream handoff contract is documented in
+[`docs/export-contracts.md`](docs/export-contracts.md) and intentionally keeps
+the required ingest surface smaller than the full export tree.
 
 ### Surrogate_Viz.jl
 

--- a/docs/export-contracts.md
+++ b/docs/export-contracts.md
@@ -4,9 +4,11 @@
 surface for downstream repos. The in-process Rust API is intentionally smaller
 and may evolve faster than the CLI artifact layer.
 
-Every top-level JSON document includes a `schema_version` field. Consumers
-should key compatibility checks off that field, not off incidental ordering or
-internal module layout.
+Every top-level JSON document includes a `schema_version` field. Some
+documents, such as `grok1-coverage.json`, also carry a second
+document-specific version field. Consumers should key compatibility checks off
+the documented version fields, not off incidental ordering or internal module
+layout.
 
 ## Unified Output Tree
 
@@ -22,6 +24,71 @@ When `--output-root <dir>` is provided, artifacts are written under:
 `docs/output-conventions.md` defines the directory and filename conventions.
 This document defines the schema contracts behind those files.
 
+## grok-ozempic Handoff Contract
+
+Issue `#21` defines a smaller contract profile than the full export surface.
+For the `grok-ozempic` handoff, `xai-dissect` must produce a complete Grok-1
+bundle for one `<checkpoint_slug>`, and downstream ingest must key that bundle
+off the directory slug plus tensor locators, not off the host-local
+`checkpoint_path`.
+
+### Required Machine-Ingest Artifacts
+
+| Path | Purpose in `grok-ozempic` | Contract | Version expectation | Checksum expectation |
+| --- | --- | --- | --- | --- |
+| `exports/<slug>/inventory.json` | Canonical tensor catalog for deciding what exists, where it lives, and how big it is before any packing or quantization step. | `schema::ModelInventory` | `schema_version = 2` | No embedded checksum in v1. Require the sibling `grok1-coverage.json` gate for complete Grok-1 handoff bundles. |
+| `exports/<slug>/experts.json` | Canonical MoE mapping for expanding expert families into resolved `gate` / `down` / `up` slices without re-inferring layout from shape alone. | `schema::ExpertAtlas` | `schema_version = 1` | No embedded checksum in v1. Must agree with the same-slug `inventory.json` locators and dimensions. |
+| `manifests/<slug>/routing-critical-tensors.json` | Compact routing guardrail list for tensors that downstream compression or packing logic must treat as routing-sensitive. | `schema::RoutingCriticalTensorManifest` | `schema_version = 1` | No embedded checksum in v1. Must agree with the same-slug inventory and coverage facts. |
+| `manifests/<slug>/grok1-coverage.json` | Fail-closed completeness and integrity proof that the bundle came from a recognized complete Grok-1 parse. | `schema::Grok1CoverageManifest` | `schema_version = 2`, `coverage_schema_version = 1`, and `baseline_profile = grok1-map-v1-clean` | Embedded `checksum` field is required. Downstream should reject bundles whose coverage validation is not `pass`. |
+
+### Bundle Rules
+
+- All required files must exist under the same `<checkpoint_slug>` across
+  `exports/` and `manifests/`.
+- `model_family` must be `"grok-1"` in every required JSON document for this
+  handoff profile.
+- `inventory.json` is the canonical tensor table. Downstream tensor identity is
+  `shard_ordinal` plus `in_shard_index`; `kind`, `shape`, `role`,
+  `block_index`, and `block_slot` are the stable classification helpers.
+- `experts.json` is the canonical expert layout map. For MoE packing plans,
+  downstream must use the resolved `projection` values and `source_*` locator
+  fields rather than re-deriving projection identity from shape alone.
+- `routing-critical-tensors.json` is a guardrail list, not the source of truth
+  for the whole checkpoint. `criticality_reason` is explanatory; the stable
+  ingest fields are tensor identity, `structural_name`, `orientation`,
+  `linked_expert_count`, `block_index`, and `block_slot`.
+- `grok1-coverage.json` is a fail-closed gate. Downstream should require
+  `validation = "pass"`, `expected == discovered`, and `unknown_slots = []`
+  before treating the bundle as complete enough for `grok-ozempic` ingestion.
+- `checkpoint_path` is informative and machine-local. `grok-ozempic` should
+  not use it as a cache key, artifact identifier, or portability boundary.
+
+### Optional Companion Artifacts
+
+- `manifests/<slug>/checkpoint-inventory-snapshot.json`: compact summary for
+  dashboards or quick sanity checks. It is not sufficient by itself for
+  ingestion because it omits the full tensor table and expert slice mapping.
+- `exports/<slug>/routing-report.json`: richer routing analysis companion for
+  review and debugging. It is not required for ingest because the normative
+  routing guardrail list lives in `routing-critical-tensors.json`.
+- `reports/<slug>/*.md` and `exports/<slug>/*-findings.json`: human-review and
+  summary outputs only, not machine-ingest inputs.
+- `exports/<slug>/stats.json`, `exports/<slug>/saaq-readiness.json`, and
+  `manifests/<slug>/candidate-saaq-targets.json`: exploratory analysis outputs
+  intentionally left out of the v1 `grok-ozempic` contract so downstream work
+  does not depend on sampling heuristics or SAAQ-oriented scoring.
+
+### Validated Example
+
+This handoff contract was checked against the real output tree under
+`out/grok1_run2_after_fixes_20260525T002904Z` with
+`<checkpoint_slug> = grok-1-official__ckpt-0`. The coverage manifest for that
+run recorded `schema_version = 2`, `coverage_schema_version = 1`,
+`validation = "pass"`, `expected.tensors = discovered.tensors = 770`, and
+checksum `fnv1a64:de5a1c978121c62c`. This change also standardizes the clean
+baseline label `baseline_profile = grok1-map-v1-clean` for newly emitted
+coverage manifests and downstream planning artifacts.
+
 ## Inventory
 
 Current schema version: **2**.
@@ -34,6 +101,8 @@ Current schema version: **2**.
   Contract: `schema::FindingsSummary` with `analysis = "inventory"`
 - `manifests/<slug>/checkpoint-inventory-snapshot.json`
   Contract: `schema::CheckpointInventorySnapshot`
+- `manifests/<slug>/grok1-coverage.json`
+  Contract: `schema::Grok1CoverageManifest` for complete Grok-1 inventories
 
 ## Experts
 
@@ -74,6 +143,21 @@ Current schema version: **2**.
   Contract: `schema::FindingsSummary` with `analysis = "saaq-readiness"`
 - `manifests/<slug>/candidate-saaq-targets.json`
   Contract: `schema::CandidateTensorManifest`
+
+## Quant Planning
+
+- `manifests/<slug>/conversion-manifest.json`
+  Contract: `schema::ConversionManifest`
+- `manifests/<slug>/quant-plan.json`
+  Contract: `schema::QuantPlan`
+- `reports/<slug>/quant-plan.md`
+  Contract: `report::render_quant_plan_markdown`
+
+These planning artifacts are downstream of the core Grok-1 handoff contract.
+They depend on the clean baseline profile `grok1-map-v1-clean`, the resolved
+expert layout, and the grouped readiness buckets. They are meant to drive
+policy selection and pilot-scoping work without widening `xai-dissect` into a
+runtime or checkpoint-mutation tool.
 
 ## Stability Rules
 

--- a/docs/export-contracts.md
+++ b/docs/export-contracts.md
@@ -39,7 +39,7 @@ off the directory slug plus tensor locators, not off the host-local
 | `exports/<slug>/inventory.json` | Canonical tensor catalog for deciding what exists, where it lives, and how big it is before any packing or quantization step. | `schema::ModelInventory` | `schema_version = 2` | No embedded checksum in v1. Require the sibling `grok1-coverage.json` gate for complete Grok-1 handoff bundles. |
 | `exports/<slug>/experts.json` | Canonical MoE mapping for expanding expert families into resolved `gate` / `down` / `up` slices without re-inferring layout from shape alone. | `schema::ExpertAtlas` | `schema_version = 1` | No embedded checksum in v1. Must agree with the same-slug `inventory.json` locators and dimensions. |
 | `manifests/<slug>/routing-critical-tensors.json` | Compact routing guardrail list for tensors that downstream compression or packing logic must treat as routing-sensitive. | `schema::RoutingCriticalTensorManifest` | `schema_version = 1` | No embedded checksum in v1. Must agree with the same-slug inventory and coverage facts. |
-| `manifests/<slug>/grok1-coverage.json` | Fail-closed completeness and integrity proof that the bundle came from a recognized complete Grok-1 parse. | `schema::Grok1CoverageManifest` | `schema_version = 2`, `coverage_schema_version = 1`, and `baseline_profile = grok1-map-v1-clean` | Embedded `checksum` field is required. Downstream should reject bundles whose coverage validation is not `pass`. |
+| `manifests/<slug>/grok1-coverage.json` | Fail-closed completeness and integrity proof that the bundle came from a recognized complete Grok-1 parse. | `schema::Grok1CoverageManifest` | `schema_version = 2`, `coverage_schema_version = 2`, and `baseline_profile = grok1-map-v1-clean` | Embedded `checksum` field is required. Downstream should reject bundles whose coverage validation is not `pass`. |
 
 ### Bundle Rules
 
@@ -83,11 +83,11 @@ off the directory slug plus tensor locators, not off the host-local
 This handoff contract was checked against the real output tree under
 `out/grok1_run2_after_fixes_20260525T002904Z` with
 `<checkpoint_slug> = grok-1-official__ckpt-0`. The coverage manifest for that
-run recorded `schema_version = 2`, `coverage_schema_version = 1`,
-`validation = "pass"`, `expected.tensors = discovered.tensors = 770`, and
-checksum `fnv1a64:de5a1c978121c62c`. This change also standardizes the clean
-baseline label `baseline_profile = grok1-map-v1-clean` for newly emitted
-coverage manifests and downstream planning artifacts.
+run recorded `validation = "pass"`, `expected.tensors = discovered.tensors =
+770`, and checksum `fnv1a64:de5a1c978121c62c`. Newly emitted coverage manifests
+from this contract carry `coverage_schema_version = 2` and the clean baseline
+label `baseline_profile = grok1-map-v1-clean` so downstream parsers can branch
+cleanly on the versioned payload shape.
 
 ## Inventory
 

--- a/docs/output-conventions.md
+++ b/docs/output-conventions.md
@@ -39,6 +39,7 @@ pipeline needs a stable custom name.
 - `exports/<slug>/inventory.json`
 - `exports/<slug>/inventory-findings.json`
 - `manifests/<slug>/checkpoint-inventory-snapshot.json`
+- `manifests/<slug>/grok1-coverage.json` for complete Grok-1 inventories
 
 ### `experts`
 
@@ -66,6 +67,12 @@ pipeline needs a stable custom name.
 - `exports/<slug>/saaq-readiness-findings.json`
 - `manifests/<slug>/candidate-saaq-targets.json`
 
+### `quant-plan`
+
+- `reports/<slug>/quant-plan.md`
+- `manifests/<slug>/conversion-manifest.json`
+- `manifests/<slug>/quant-plan.json`
+
 ## Summary and manifest intent
 
 - `reports/`: human-readable Markdown meant for inspection and PR review
@@ -75,6 +82,24 @@ pipeline needs a stable custom name.
 
 The output tree is additive. Existing explicit file flags remain supported
 and are not replaced by the unified tree.
+
+## Contract Profiles
+
+### `grok-ozempic` handoff v1
+
+- Required machine-ingest files are:
+  - `exports/<slug>/inventory.json`
+  - `exports/<slug>/experts.json`
+  - `manifests/<slug>/routing-critical-tensors.json`
+  - `manifests/<slug>/grok1-coverage.json`
+- These files must be emitted for the same `<checkpoint_slug>`.
+- `reports/` is never a machine-ingest surface for this profile.
+- `checkpoint_path` fields inside the JSON documents remain informative only;
+  downstream bundle identity is the parent `<checkpoint_slug>` plus tensor
+  locators inside the documents.
+- `stats`, `saaq-readiness`, `candidate-saaq-targets`, `conversion-manifest`, and
+  `quant-plan` remain optional planning/analysis outputs and are not part of this
+  minimal ingest profile.
 
 See `docs/export-contracts.md` for the stable schema types behind each
 artifact.

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -12,9 +12,10 @@ use anyhow::{Context, Result, bail};
 use crate::inventory;
 use crate::report;
 use crate::schema::{
-    CheckpointInventoryBlockSnapshot, CheckpointInventorySnapshot, ExpertAtlas, FindingsSeverity,
-    FindingsSummary, FindingsSummaryItem, ModelInventory, RoutingCriticalTensor,
-    RoutingCriticalTensorManifest, RoutingReport, SaaqReadinessReport, StatsProfileReport,
+    CheckpointInventoryBlockSnapshot, CheckpointInventorySnapshot, ConversionManifest, ExpertAtlas,
+    FindingsSeverity, FindingsSummary, FindingsSummaryItem, ModelInventory, QuantPlan,
+    RoutingCriticalTensor, RoutingCriticalTensorManifest, RoutingReport, SaaqReadinessReport,
+    StatsProfileReport,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -259,6 +260,33 @@ pub fn write_saaq_bundle(
     let manifest_path = layout.manifests_dir.join("candidate-saaq-targets.json");
     report::write_candidate_manifest_json(&report_doc.manifest, &manifest_path)?;
     bundle.written_paths.push(manifest_path);
+
+    Ok(bundle)
+}
+
+pub fn write_quant_plan_bundle(
+    conversion_manifest: &ConversionManifest,
+    quant_plan: &QuantPlan,
+    root: &Path,
+    slug_override: Option<&str>,
+) -> Result<OutputBundle> {
+    let layout = prepare_output_layout(root, &quant_plan.checkpoint_path, slug_override)?;
+    let mut bundle = OutputBundle {
+        checkpoint_slug: layout.checkpoint_slug.clone(),
+        written_paths: Vec::new(),
+    };
+
+    let conversion_path = layout.manifests_dir.join("conversion-manifest.json");
+    report::write_conversion_manifest_json(conversion_manifest, &conversion_path)?;
+    bundle.written_paths.push(conversion_path);
+
+    let plan_path = layout.manifests_dir.join("quant-plan.json");
+    report::write_quant_plan_json(quant_plan, &plan_path)?;
+    bundle.written_paths.push(plan_path);
+
+    let md_path = layout.reports_dir.join("quant-plan.md");
+    report::write_quant_plan_markdown(quant_plan, &md_path)?;
+    bundle.written_paths.push(md_path);
 
     Ok(bundle)
 }

--- a/src/inventory/grok1_coverage.rs
+++ b/src/inventory/grok1_coverage.rs
@@ -9,14 +9,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Result, bail};
 
 use crate::schema::{
-    Grok1CoverageCounts, Grok1CoverageManifest, Grok1UnknownSlot, ModelInventory, MoeProjection,
-    QuantizedAttentionWidth, TensorDType, TensorInfo, TensorKind, TensorRole,
+    GROK1_BASELINE_PROFILE, Grok1CoverageCounts, Grok1CoverageManifest, Grok1UnknownSlot,
+    ModelInventory, MoeProjection, QuantizedAttentionWidth, TensorDType, TensorInfo, TensorKind,
+    TensorRole,
 };
 
 use super::SCHEMA_VERSION;
 
-pub const GROK1_COVERAGE_SCHEMA_VERSION: u32 = 1;
-pub const GROK1_BASELINE_PROFILE: &str = "grok1-map-v1-clean";
+pub const GROK1_COVERAGE_SCHEMA_VERSION: u32 = 2;
 
 const GROK1_EXPECTED_BLOCKS: u32 = 64;
 const GROK1_EXPECTED_TENSORS: u64 = 770;

--- a/src/inventory/grok1_coverage.rs
+++ b/src/inventory/grok1_coverage.rs
@@ -16,6 +16,7 @@ use crate::schema::{
 use super::SCHEMA_VERSION;
 
 pub const GROK1_COVERAGE_SCHEMA_VERSION: u32 = 1;
+pub const GROK1_BASELINE_PROFILE: &str = "grok1-map-v1-clean";
 
 const GROK1_EXPECTED_BLOCKS: u32 = 64;
 const GROK1_EXPECTED_TENSORS: u64 = 770;
@@ -94,6 +95,7 @@ pub fn validate_grok1_complete_manifest(inv: &ModelInventory) -> Result<Grok1Cov
     let checksum = grok1_checksum(inv, &discovered, &unknown_slots);
     Ok(Grok1CoverageManifest {
         model_family: inv.model_family.clone(),
+        baseline_profile: GROK1_BASELINE_PROFILE.to_string(),
         schema_version: inv.schema_version,
         coverage_schema_version: GROK1_COVERAGE_SCHEMA_VERSION,
         validation: "pass".to_string(),
@@ -590,6 +592,7 @@ mod tests {
         assert_eq!(manifest.discovered.routers, 64);
         assert_eq!(manifest.expected.expert_families, 192);
         assert_eq!(manifest.discovered.expert_families, 192);
+        assert_eq!(manifest.baseline_profile, GROK1_BASELINE_PROFILE);
         assert!(manifest.unknown_slots.is_empty());
         assert_eq!(manifest.checksum, "fnv1a64:de5a1c978121c62c");
     }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -24,9 +24,8 @@ use crate::schema::{
 
 mod grok1_coverage;
 
-pub use grok1_coverage::{
-    GROK1_BASELINE_PROFILE, should_validate_grok1_coverage, validate_grok1_complete_manifest,
-};
+pub use crate::schema::GROK1_BASELINE_PROFILE;
+pub use grok1_coverage::{should_validate_grok1_coverage, validate_grok1_complete_manifest};
 
 pub const SCHEMA_VERSION: u32 = 2;
 

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -24,7 +24,9 @@ use crate::schema::{
 
 mod grok1_coverage;
 
-pub use grok1_coverage::{should_validate_grok1_coverage, validate_grok1_complete_manifest};
+pub use grok1_coverage::{
+    GROK1_BASELINE_PROFILE, should_validate_grok1_coverage, validate_grok1_complete_manifest,
+};
 
 pub const SCHEMA_VERSION: u32 = 2;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod experts;
 pub mod exports;
 pub mod inventory;
 pub mod parser;
+pub mod planning;
 pub mod report;
 pub mod routing;
 pub mod schema;

--- a/src/main.rs
+++ b/src/main.rs
@@ -780,6 +780,7 @@ fn run_quant_plan(
     conversion_manifest_out: Option<&std::path::Path>,
     output_tree: &OutputTreeArgs,
 ) -> Result<()> {
+    validate_quant_plan_inventory_scope(prefix, limit)?;
     let cfg = InventoryConfig {
         prefix: prefix.to_string(),
         limit,
@@ -827,6 +828,21 @@ fn run_quant_plan(
     Ok(())
 }
 
+fn validate_quant_plan_inventory_scope(prefix: &str, limit: Option<usize>) -> Result<()> {
+    if prefix != "tensor" {
+        bail!(
+            "quant-plan requires a complete Grok-1 inventory; `--prefix {}` is not supported",
+            prefix
+        );
+    }
+    if let Some(limit) = limit {
+        bail!(
+            "quant-plan requires a complete Grok-1 inventory; `--limit {limit}` is not supported"
+        );
+    }
+    Ok(())
+}
+
 fn print_quant_plan_console_summary(
     quant_plan: &xai_dissect::schema::QuantPlan,
     conversion_manifest: &xai_dissect::schema::ConversionManifest,
@@ -857,6 +873,23 @@ fn print_output_bundle(label: &str, root: &std::path::Path, bundle: &exports::Ou
         root.display(),
         bundle.checkpoint_slug
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_quant_plan_inventory_scope;
+
+    #[test]
+    fn quant_plan_rejects_non_default_prefix() {
+        let err = validate_quant_plan_inventory_scope("tensor-shard", None).unwrap_err();
+        assert!(format!("{err:#}").contains("--prefix tensor-shard"));
+    }
+
+    #[test]
+    fn quant_plan_rejects_limited_inventory() {
+        let err = validate_quant_plan_inventory_scope("tensor", Some(4)).unwrap_err();
+        assert!(format!("{err:#}").contains("--limit 4"));
+    }
 }
 
 fn print_console_summary(inv: &ModelInventory) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use xai_dissect::experts::build_expert_atlas;
 use xai_dissect::exports;
 use xai_dissect::inventory::{InventoryConfig, build_inventory};
 use xai_dissect::parser;
+use xai_dissect::planning::build_grok1_planning_artifacts;
 use xai_dissect::report;
 use xai_dissect::routing::build_routing_report;
 use xai_dissect::schema::{
@@ -202,6 +203,36 @@ enum Command {
         #[command(flatten)]
         output_tree: OutputTreeArgs,
     },
+    /// Emit deterministic Grok-1 conversion and quant-planning artifacts.
+    QuantPlan {
+        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+        path: PathBuf,
+        /// Filename prefix filter.
+        #[arg(long, default_value = "tensor")]
+        prefix: String,
+        /// Only process the first N shards (sorted by filename).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Model family tag written into the export header. Only `grok-1`
+        /// is officially supported today.
+        #[arg(long, default_value = "grok-1")]
+        family: String,
+        /// Maximum sampled values per tensor when computing readiness.
+        #[arg(long, default_value_t = 65_536)]
+        sample_values: usize,
+        /// If set, write the deterministic quant-plan JSON to this path.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// If set, write the quant-plan Markdown summary to this path. If
+        /// unset, the Markdown report is printed to stdout.
+        #[arg(long)]
+        md: Option<PathBuf>,
+        /// If set, write the conversion-ready manifest JSON to this path.
+        #[arg(long)]
+        conversion_manifest: Option<PathBuf>,
+        #[command(flatten)]
+        output_tree: OutputTreeArgs,
+    },
 }
 
 struct CommandFields {
@@ -220,6 +251,7 @@ impl Command {
             Command::RoutingReport { .. } => "routing-report",
             Command::Stats { .. } => "stats",
             Command::SaaqReadiness { .. } => "saaq-readiness",
+            Command::QuantPlan { .. } => "quant-plan",
         }
     }
 
@@ -262,6 +294,13 @@ impl Command {
                 ..
             }
             | Command::SaaqReadiness {
+                limit,
+                prefix,
+                family,
+                sample_values,
+                ..
+            }
+            | Command::QuantPlan {
                 limit,
                 prefix,
                 family,
@@ -396,6 +435,27 @@ fn main() -> Result<()> {
             json.as_deref(),
             md.as_deref(),
             manifest.as_deref(),
+            &output_tree,
+        ),
+        Command::QuantPlan {
+            path,
+            prefix,
+            limit,
+            family,
+            sample_values,
+            json,
+            md,
+            conversion_manifest,
+            output_tree,
+        } => run_quant_plan(
+            &path,
+            &prefix,
+            limit,
+            &family,
+            sample_values,
+            json.as_deref(),
+            md.as_deref(),
+            conversion_manifest.as_deref(),
             &output_tree,
         ),
     };
@@ -704,6 +764,91 @@ fn run_saaq_readiness(
     }
 
     Ok(())
+}
+
+// --- `quant-plan` ---------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn run_quant_plan(
+    path: &std::path::Path,
+    prefix: &str,
+    limit: Option<usize>,
+    family: &str,
+    sample_values: usize,
+    json_out: Option<&std::path::Path>,
+    md_out: Option<&std::path::Path>,
+    conversion_manifest_out: Option<&std::path::Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let cfg = InventoryConfig {
+        prefix: prefix.to_string(),
+        limit,
+        model_family: family.to_string(),
+    };
+    let inv = build_inventory(path, &cfg)?;
+    let atlas = build_expert_atlas(&inv);
+    let routing = build_routing_report(&inv);
+    let stats_cfg = StatsConfig {
+        max_sample_values: sample_values,
+        ..Default::default()
+    };
+    let stats = build_stats_report(&inv, &stats_cfg)?;
+    let readiness = build_saaq_readiness_report(&inv, &stats);
+    let (conversion_manifest, quant_plan) =
+        build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness)?;
+
+    print_quant_plan_console_summary(&quant_plan, &conversion_manifest);
+
+    if let Some(p) = conversion_manifest_out {
+        report::write_conversion_manifest_json(&conversion_manifest, p)?;
+        eprintln!("wrote conversion manifest -> {}", p.display());
+    }
+    if let Some(p) = json_out {
+        report::write_quant_plan_json(&quant_plan, p)?;
+        eprintln!("wrote JSON quant plan -> {}", p.display());
+    }
+    if let Some(p) = md_out {
+        report::write_quant_plan_markdown(&quant_plan, p)?;
+        eprintln!("wrote Markdown quant plan -> {}", p.display());
+    } else {
+        println!();
+        println!("{}", report::render_quant_plan_markdown(&quant_plan));
+    }
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle = exports::write_quant_plan_bundle(
+            &conversion_manifest,
+            &quant_plan,
+            root,
+            output_tree.checkpoint_slug.as_deref(),
+        )?;
+        print_output_bundle("quant-plan bundle", root, &bundle);
+    }
+
+    Ok(())
+}
+
+fn print_quant_plan_console_summary(
+    quant_plan: &xai_dissect::schema::QuantPlan,
+    conversion_manifest: &xai_dissect::schema::ConversionManifest,
+) {
+    eprintln!(
+        "checkpoint: {}  baseline: {}  tensors: {}",
+        quant_plan.checkpoint_path.display(),
+        quant_plan.baseline,
+        conversion_manifest.tensors.len(),
+    );
+    eprintln!(
+        "keep_fp32: {}  pilot_quantize: {}  defer: {}",
+        quant_plan.keep_fp32.len(),
+        quant_plan.pilot_quantize.len(),
+        quant_plan.defer.len(),
+    );
+    if !conversion_manifest.warnings.is_empty() {
+        eprintln!(
+            "warn: conversion manifest emitted {} warning categories",
+            conversion_manifest.warnings.len()
+        );
+    }
 }
 
 fn print_output_bundle(label: &str, root: &std::path::Path, bundle: &exports::OutputBundle) {

--- a/src/planning/mod.rs
+++ b/src/planning/mod.rs
@@ -8,16 +8,15 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Result, bail};
 
-use crate::inventory::validate_grok1_complete_manifest;
+use crate::inventory::{GROK1_BASELINE_PROFILE, validate_grok1_complete_manifest};
 use crate::schema::{
     ConversionManifest, ConversionManifestTensor, ExpertAtlas, Grok1CoverageManifest,
     ModelInventory, MoeProjection, QuantPlan, QuantPolicy, RoutingOrientation, RoutingReport,
-    SaaqReadinessReport, SaaqRegionClass, TensorInfo, TensorKind,
+    SaaqCandidate, SaaqReadinessReport, SaaqRegionClass, TensorInfo, TensorKind,
 };
 
 pub const CONVERSION_MANIFEST_SCHEMA_VERSION: u32 = 1;
 pub const QUANT_PLAN_SCHEMA_VERSION: u32 = 1;
-pub const GROK1_BASELINE_PROFILE: &str = "grok1-map-v1-clean";
 
 const GROK1_EXPECTED_EXPERTS_PER_BLOCK: u64 = 8;
 const GROK1_EXPECTED_EXPERT_FAMILIES_PER_BLOCK: u32 = 3;
@@ -49,8 +48,14 @@ pub fn build_grok1_planning_artifacts(
 }
 
 pub fn validate_grok1_clean_baseline(inv: &ModelInventory) -> Result<Grok1CoverageManifest> {
-    let mut coverage = validate_grok1_complete_manifest(inv)?;
-    coverage.baseline_profile = GROK1_BASELINE_PROFILE.to_string();
+    let coverage = validate_grok1_complete_manifest(inv)?;
+    if coverage.baseline_profile != GROK1_BASELINE_PROFILE {
+        bail!(
+            "coverage baseline_profile {} != expected {}",
+            coverage.baseline_profile,
+            GROK1_BASELINE_PROFILE
+        );
+    }
     Ok(coverage)
 }
 
@@ -143,6 +148,16 @@ fn validate_routing_report(
 }
 
 fn validate_readiness_groups(inv: &ModelInventory, readiness: &SaaqReadinessReport) -> Result<()> {
+    let inventory_keys = inv
+        .tensors
+        .iter()
+        .map(|tensor| {
+            (
+                (tensor.shard_ordinal, tensor.in_shard_index),
+                tensor_identity_name(tensor),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
     let mut seen: BTreeMap<(u32, u32), &'static str> = BTreeMap::new();
     for (label, tensors) in [
         (
@@ -173,18 +188,31 @@ fn validate_readiness_groups(inv: &ModelInventory, readiness: &SaaqReadinessRepo
         }
     }
 
-    if seen.len() != inv.tensors.len() {
-        let missing = inv
-            .tensors
-            .iter()
-            .filter(|tensor| !seen.contains_key(&(tensor.shard_ordinal, tensor.in_shard_index)))
-            .map(tensor_identity_name)
-            .collect::<Vec<_>>();
+    let missing = inventory_keys
+        .iter()
+        .filter(|(key, _)| !seen.contains_key(key))
+        .map(|(_, name)| name.clone())
+        .collect::<Vec<_>>();
+    let extra = seen
+        .iter()
+        .filter(|(key, _)| !inventory_keys.contains_key(key))
+        .map(|((shard, index), label)| format!("shard={shard} idx={index} in {label}"))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() || !extra.is_empty() {
         bail!(
-            "readiness groups cover {} tensors but inventory has {}; missing: {}",
+            "readiness groups cover {} tensors but inventory has {}; missing: {}; extra: {}",
             seen.len(),
             inv.tensors.len(),
-            missing.join(", ")
+            if missing.is_empty() {
+                "none".to_string()
+            } else {
+                missing.join(", ")
+            },
+            if extra.is_empty() {
+                "none".to_string()
+            } else {
+                extra.join(", ")
+            }
         );
     }
 
@@ -213,13 +241,13 @@ fn build_conversion_manifest(
         .tensors
         .iter()
         .map(|tensor| {
-            let group = groups
+            let membership = groups
                 .get(&(tensor.shard_ordinal, tensor.in_shard_index))
                 .copied()
-                .unwrap_or(ReadinessGroup::Deferred);
-            let region = group.region();
+                .expect("validated readiness membership missing");
+            let region = membership.region;
             let (quant_policy, protected_reason, entry_warnings) =
-                quant_policy_for_tensor(tensor, group);
+                quant_policy_for_tensor(tensor, membership.group);
             for warning in &entry_warnings {
                 warnings.insert(warning.clone());
             }
@@ -337,44 +365,47 @@ enum ReadinessGroup {
     Deferred,
 }
 
-impl ReadinessGroup {
-    fn region(self) -> SaaqRegionClass {
-        match self {
-            ReadinessGroup::QuantizationCandidate => SaaqRegionClass::PotentialCompressionTarget,
-            ReadinessGroup::RoutingCritical => SaaqRegionClass::RoutingCritical,
-            ReadinessGroup::PrecisionSensitive => SaaqRegionClass::NormalizationSensitive,
-            ReadinessGroup::Deferred => SaaqRegionClass::EmbeddingHeavy,
-        }
-    }
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct ReadinessMembership {
+    group: ReadinessGroup,
+    region: SaaqRegionClass,
 }
 
-fn readiness_group_map(readiness: &SaaqReadinessReport) -> BTreeMap<(u32, u32), ReadinessGroup> {
+fn readiness_group_map(
+    readiness: &SaaqReadinessReport,
+) -> BTreeMap<(u32, u32), ReadinessMembership> {
     let mut groups = BTreeMap::new();
     for candidate in &readiness.quantization_candidates {
-        groups.insert(
-            (candidate.shard_ordinal, candidate.in_shard_index),
+        insert_readiness_membership(
+            &mut groups,
+            candidate,
             ReadinessGroup::QuantizationCandidate,
         );
     }
     for candidate in &readiness.routing_critical_tensors {
-        groups.insert(
-            (candidate.shard_ordinal, candidate.in_shard_index),
-            ReadinessGroup::RoutingCritical,
-        );
+        insert_readiness_membership(&mut groups, candidate, ReadinessGroup::RoutingCritical);
     }
     for candidate in &readiness.precision_sensitive_tensors {
-        groups.insert(
-            (candidate.shard_ordinal, candidate.in_shard_index),
-            ReadinessGroup::PrecisionSensitive,
-        );
+        insert_readiness_membership(&mut groups, candidate, ReadinessGroup::PrecisionSensitive);
     }
     for candidate in &readiness.deferred_tensors {
-        groups.insert(
-            (candidate.shard_ordinal, candidate.in_shard_index),
-            ReadinessGroup::Deferred,
-        );
+        insert_readiness_membership(&mut groups, candidate, ReadinessGroup::Deferred);
     }
     groups
+}
+
+fn insert_readiness_membership(
+    groups: &mut BTreeMap<(u32, u32), ReadinessMembership>,
+    candidate: &SaaqCandidate,
+    group: ReadinessGroup,
+) {
+    groups.insert(
+        (candidate.shard_ordinal, candidate.in_shard_index),
+        ReadinessMembership {
+            group,
+            region: candidate.region_class,
+        },
+    );
 }
 
 fn quant_policy_for_tensor(
@@ -502,9 +533,10 @@ mod tests {
         SaaqRegionClass, ShardRange, TensorDType, TensorInfo, TensorKind, TensorRole, TensorShape,
     };
 
+    use crate::inventory::GROK1_BASELINE_PROFILE;
+
     use super::{
-        GROK1_BASELINE_PROFILE, QUANT_PLAN_SCHEMA_VERSION, ReadinessGroup,
-        build_grok1_planning_artifacts, tensor_descriptor_hash,
+        QUANT_PLAN_SCHEMA_VERSION, build_grok1_planning_artifacts, tensor_descriptor_hash,
     };
 
     #[test]
@@ -595,14 +627,52 @@ mod tests {
         let first = tensor_descriptor_hash(
             &tensor,
             crate::schema::QuantPolicy::PassthroughF32Router,
-            ReadinessGroup::RoutingCritical.region(),
+            SaaqRegionClass::RoutingCritical,
         );
         let second = tensor_descriptor_hash(
             &tensor,
             crate::schema::QuantPolicy::PassthroughF32Router,
-            ReadinessGroup::RoutingCritical.region(),
+            SaaqRegionClass::RoutingCritical,
         );
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn validate_readiness_groups_reports_extra_tensor_keys() {
+        let (inv, atlas, routing, mut readiness) = complete_inputs();
+        readiness.deferred_tensors.push(candidate(
+            9_999,
+            7,
+            None,
+            None,
+            "unassigned.shard_9999.idx_007.unknown",
+            "unknown",
+            TensorDType::F32,
+            vec![1],
+            SaaqRegionClass::Unknown,
+            SaaqDisposition::ObserveOnly,
+            0.01,
+        ));
+
+        let err = build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness).unwrap_err();
+
+        assert!(format!("{err:#}").contains("extra: shard=9999 idx=7 in deferred_tensors"));
+    }
+
+    #[test]
+    fn conversion_manifest_preserves_deferred_region_class() {
+        let (inv, atlas, routing, mut readiness) = complete_inputs();
+        readiness.deferred_tensors[0].region_class = SaaqRegionClass::Unknown;
+
+        let (conversion, _) = build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness)
+            .expect("planning artifacts");
+
+        let embedding = conversion
+            .tensors
+            .iter()
+            .find(|tensor| tensor.kind == "token_embedding")
+            .expect("token embedding entry");
+        assert_eq!(embedding.region, SaaqRegionClass::Unknown);
     }
 
     fn complete_inputs() -> (
@@ -1103,7 +1173,7 @@ mod tests {
                 candidates: quantization_candidates,
                 schema_version: 1,
             },
-            schema_version: 1,
+            schema_version: 2,
         }
     }
 

--- a/src/planning/mod.rs
+++ b/src/planning/mod.rs
@@ -1,0 +1,1190 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Static planning artifacts that bridge validated Grok-1 structure into
+// downstream conversion / quantization repos without executing or mutating the
+// checkpoint.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Result, bail};
+
+use crate::inventory::validate_grok1_complete_manifest;
+use crate::schema::{
+    ConversionManifest, ConversionManifestTensor, ExpertAtlas, Grok1CoverageManifest,
+    ModelInventory, MoeProjection, QuantPlan, QuantPolicy, RoutingOrientation, RoutingReport,
+    SaaqReadinessReport, SaaqRegionClass, TensorInfo, TensorKind,
+};
+
+pub const CONVERSION_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub const QUANT_PLAN_SCHEMA_VERSION: u32 = 1;
+pub const GROK1_BASELINE_PROFILE: &str = "grok1-map-v1-clean";
+
+const GROK1_EXPECTED_EXPERTS_PER_BLOCK: u64 = 8;
+const GROK1_EXPECTED_EXPERT_FAMILIES_PER_BLOCK: u32 = 3;
+const GROK1_EXPECTED_ROUTER_SHAPE: [u64; 2] = [6_144, 8];
+const GROK1_KEEP_FP32_ORDER: &[&str] = &["router", "block_norm", "final_norm"];
+const GROK1_PILOT_QUANTIZE_ORDER: &[&str] = &[
+    "attn_proj_i8.model_width",
+    "attn_proj_i8.narrow",
+    "moe_expert.gate",
+    "moe_expert.up",
+    "moe_expert.down",
+];
+const GROK1_DEFER_ORDER: &[&str] = &["token_embedding"];
+
+pub fn build_grok1_planning_artifacts(
+    inv: &ModelInventory,
+    atlas: &ExpertAtlas,
+    routing: &RoutingReport,
+    readiness: &SaaqReadinessReport,
+) -> Result<(ConversionManifest, QuantPlan)> {
+    let coverage = validate_grok1_clean_baseline(inv)?;
+    validate_expert_atlas(atlas, &coverage)?;
+    validate_routing_report(routing, &coverage)?;
+    validate_readiness_groups(inv, readiness)?;
+
+    let conversion = build_conversion_manifest(inv, atlas, routing, readiness, &coverage)?;
+    let quant_plan = build_quant_plan(inv, readiness, &coverage);
+    Ok((conversion, quant_plan))
+}
+
+pub fn validate_grok1_clean_baseline(inv: &ModelInventory) -> Result<Grok1CoverageManifest> {
+    let mut coverage = validate_grok1_complete_manifest(inv)?;
+    coverage.baseline_profile = GROK1_BASELINE_PROFILE.to_string();
+    Ok(coverage)
+}
+
+fn validate_expert_atlas(atlas: &ExpertAtlas, coverage: &Grok1CoverageManifest) -> Result<()> {
+    if atlas.relevant_block_count != coverage.discovered.blocks {
+        bail!(
+            "expert atlas relevant_block_count {} != baseline blocks {}",
+            atlas.relevant_block_count,
+            coverage.discovered.blocks
+        );
+    }
+    if atlas.expected_experts_per_block != Some(GROK1_EXPECTED_EXPERTS_PER_BLOCK) {
+        bail!(
+            "expert atlas expected_experts_per_block {:?} != expected {}",
+            atlas.expected_experts_per_block,
+            GROK1_EXPECTED_EXPERTS_PER_BLOCK
+        );
+    }
+    for block in &atlas.blocks {
+        if block.expert_count != Some(GROK1_EXPECTED_EXPERTS_PER_BLOCK) {
+            bail!(
+                "expert atlas block_{:03} expert_count {:?} != expected {}",
+                block.block_index,
+                block.expert_count,
+                GROK1_EXPECTED_EXPERTS_PER_BLOCK
+            );
+        }
+        if block.tensors.len() != GROK1_EXPECTED_EXPERT_FAMILIES_PER_BLOCK as usize {
+            bail!(
+                "expert atlas block_{:03} exposes {} tensor families, expected {}",
+                block.block_index,
+                block.tensors.len(),
+                GROK1_EXPECTED_EXPERT_FAMILIES_PER_BLOCK
+            );
+        }
+        if block.experts.len() != GROK1_EXPECTED_EXPERTS_PER_BLOCK as usize {
+            bail!(
+                "expert atlas block_{:03} exposes {} expert slices, expected {}",
+                block.block_index,
+                block.experts.len(),
+                GROK1_EXPECTED_EXPERTS_PER_BLOCK
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_routing_report(
+    routing: &RoutingReport,
+    coverage: &Grok1CoverageManifest,
+) -> Result<()> {
+    if routing.relevant_block_count != coverage.discovered.blocks {
+        bail!(
+            "routing relevant_block_count {} != baseline blocks {}",
+            routing.relevant_block_count,
+            coverage.discovered.blocks
+        );
+    }
+    if routing.expected_experts_per_router != Some(GROK1_EXPECTED_EXPERTS_PER_BLOCK) {
+        bail!(
+            "routing expected_experts_per_router {:?} != expected {}",
+            routing.expected_experts_per_router,
+            GROK1_EXPECTED_EXPERTS_PER_BLOCK
+        );
+    }
+    if routing.candidate_tensors.len() as u64 != coverage.discovered.routers {
+        bail!(
+            "routing candidate count {} != baseline routers {}",
+            routing.candidate_tensors.len(),
+            coverage.discovered.routers
+        );
+    }
+    for tensor in &routing.candidate_tensors {
+        if tensor.orientation != RoutingOrientation::DModelToExperts {
+            bail!(
+                "routing tensor {} has orientation {}, expected d_model_to_experts",
+                tensor.structural_name,
+                tensor.orientation.label()
+            );
+        }
+        if tensor.shape.dims() != GROK1_EXPECTED_ROUTER_SHAPE {
+            bail!(
+                "routing tensor {} has shape {}, expected (6144, 8)",
+                tensor.structural_name,
+                tensor.shape.render()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_readiness_groups(inv: &ModelInventory, readiness: &SaaqReadinessReport) -> Result<()> {
+    let mut seen: BTreeMap<(u32, u32), &'static str> = BTreeMap::new();
+    for (label, tensors) in [
+        (
+            "quantization_candidates",
+            &readiness.quantization_candidates,
+        ),
+        (
+            "routing_critical_tensors",
+            &readiness.routing_critical_tensors,
+        ),
+        (
+            "precision_sensitive_tensors",
+            &readiness.precision_sensitive_tensors,
+        ),
+        ("deferred_tensors", &readiness.deferred_tensors),
+    ] {
+        for tensor in tensors {
+            let key = (tensor.shard_ordinal, tensor.in_shard_index);
+            if let Some(prev) = seen.insert(key, label) {
+                bail!(
+                    "tensor shard={} idx={} appears in both {} and {}",
+                    tensor.shard_ordinal,
+                    tensor.in_shard_index,
+                    prev,
+                    label
+                );
+            }
+        }
+    }
+
+    if seen.len() != inv.tensors.len() {
+        let missing = inv
+            .tensors
+            .iter()
+            .filter(|tensor| !seen.contains_key(&(tensor.shard_ordinal, tensor.in_shard_index)))
+            .map(tensor_identity_name)
+            .collect::<Vec<_>>();
+        bail!(
+            "readiness groups cover {} tensors but inventory has {}; missing: {}",
+            seen.len(),
+            inv.tensors.len(),
+            missing.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+fn build_conversion_manifest(
+    inv: &ModelInventory,
+    atlas: &ExpertAtlas,
+    routing: &RoutingReport,
+    readiness: &SaaqReadinessReport,
+    coverage: &Grok1CoverageManifest,
+) -> Result<ConversionManifest> {
+    let groups = readiness_group_map(readiness);
+    let router_shape = routing
+        .candidate_tensors
+        .first()
+        .map(|tensor| tensor.shape.clone());
+    let router_orientation = routing
+        .candidate_tensors
+        .first()
+        .map(|tensor| tensor.orientation);
+
+    let mut warnings = BTreeSet::new();
+    let tensors = inv
+        .tensors
+        .iter()
+        .map(|tensor| {
+            let group = groups
+                .get(&(tensor.shard_ordinal, tensor.in_shard_index))
+                .copied()
+                .unwrap_or(ReadinessGroup::Deferred);
+            let region = group.region();
+            let (quant_policy, protected_reason, entry_warnings) =
+                quant_policy_for_tensor(tensor, group);
+            for warning in &entry_warnings {
+                warnings.insert(warning.clone());
+            }
+            ConversionManifestTensor {
+                tensor_name: tensor_identity_name(tensor),
+                structural_name: structural_name(tensor),
+                model_family: inv.model_family.clone(),
+                block: tensor.block_index,
+                slot: tensor.block_slot,
+                kind: tensor.kind.short_label(),
+                region,
+                dtype: tensor.dtype,
+                shape: tensor.shape.clone(),
+                numel: tensor.shape.numel(),
+                byte_len: tensor.nbytes,
+                shard_index: tensor.shard_ordinal,
+                source_shard_path: tensor.shard_path.clone(),
+                source_in_shard_index: tensor.in_shard_index,
+                quant_policy,
+                protected_reason,
+                deterministic_hash: tensor_descriptor_hash(tensor, quant_policy, region),
+                warnings: entry_warnings,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ConversionManifest {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        baseline_profile: coverage.baseline_profile.clone(),
+        required_validation: coverage.expected.clone(),
+        discovered_validation: coverage.discovered.clone(),
+        relevant_block_count: atlas.relevant_block_count,
+        expected_experts_per_block: atlas.expected_experts_per_block,
+        expert_tensor_families_per_block: Some(GROK1_EXPECTED_EXPERT_FAMILIES_PER_BLOCK),
+        router_orientation,
+        router_shape,
+        tensors,
+        warnings: warnings.into_iter().collect(),
+        schema_version: CONVERSION_MANIFEST_SCHEMA_VERSION,
+    })
+}
+
+fn build_quant_plan(
+    inv: &ModelInventory,
+    readiness: &SaaqReadinessReport,
+    coverage: &Grok1CoverageManifest,
+) -> QuantPlan {
+    let candidate_kinds = readiness
+        .quantization_candidates
+        .iter()
+        .map(|candidate| candidate.kind_label.as_str())
+        .collect::<BTreeSet<_>>();
+    let deferred_kinds = readiness
+        .deferred_tensors
+        .iter()
+        .map(|candidate| candidate.kind_label.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let keep_fp32 = GROK1_KEEP_FP32_ORDER
+        .iter()
+        .map(|kind| (*kind).to_string())
+        .collect::<Vec<_>>();
+    let pilot_quantize = GROK1_PILOT_QUANTIZE_ORDER
+        .iter()
+        .filter(|kind| candidate_kinds.contains(**kind))
+        .map(|kind| (*kind).to_string())
+        .collect::<Vec<_>>();
+    let mut defer = GROK1_DEFER_ORDER
+        .iter()
+        .filter(|kind| deferred_kinds.contains(**kind))
+        .map(|kind| (*kind).to_string())
+        .collect::<Vec<_>>();
+    let remaining_defer = deferred_kinds
+        .into_iter()
+        .filter(|kind| !GROK1_DEFER_ORDER.contains(kind))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    defer.extend(remaining_defer);
+
+    let mut notes = vec![format!(
+        "{} tensors partition into {} quantization candidates, {} routing-critical, {} precision-sensitive, and {} deferred entries.",
+        inv.tensors.len(),
+        readiness.quantization_candidates.len(),
+        readiness.routing_critical_tensors.len(),
+        readiness.precision_sensitive_tensors.len(),
+        readiness.deferred_tensors.len()
+    )];
+    if let Some(top) = readiness.quantization_candidates.first() {
+        notes.push(format!(
+            "Top quantization candidate is `{}` with readiness {:.3}.",
+            top.structural_name, top.readiness_score
+        ));
+    }
+
+    QuantPlan {
+        model_family: inv.model_family.clone(),
+        checkpoint_path: inv.checkpoint_path.clone(),
+        baseline: coverage.baseline_profile.clone(),
+        required_validation: coverage.expected.clone(),
+        discovered_validation: coverage.discovered.clone(),
+        keep_fp32,
+        pilot_quantize,
+        defer,
+        notes,
+        schema_version: QUANT_PLAN_SCHEMA_VERSION,
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ReadinessGroup {
+    QuantizationCandidate,
+    RoutingCritical,
+    PrecisionSensitive,
+    Deferred,
+}
+
+impl ReadinessGroup {
+    fn region(self) -> SaaqRegionClass {
+        match self {
+            ReadinessGroup::QuantizationCandidate => SaaqRegionClass::PotentialCompressionTarget,
+            ReadinessGroup::RoutingCritical => SaaqRegionClass::RoutingCritical,
+            ReadinessGroup::PrecisionSensitive => SaaqRegionClass::NormalizationSensitive,
+            ReadinessGroup::Deferred => SaaqRegionClass::EmbeddingHeavy,
+        }
+    }
+}
+
+fn readiness_group_map(readiness: &SaaqReadinessReport) -> BTreeMap<(u32, u32), ReadinessGroup> {
+    let mut groups = BTreeMap::new();
+    for candidate in &readiness.quantization_candidates {
+        groups.insert(
+            (candidate.shard_ordinal, candidate.in_shard_index),
+            ReadinessGroup::QuantizationCandidate,
+        );
+    }
+    for candidate in &readiness.routing_critical_tensors {
+        groups.insert(
+            (candidate.shard_ordinal, candidate.in_shard_index),
+            ReadinessGroup::RoutingCritical,
+        );
+    }
+    for candidate in &readiness.precision_sensitive_tensors {
+        groups.insert(
+            (candidate.shard_ordinal, candidate.in_shard_index),
+            ReadinessGroup::PrecisionSensitive,
+        );
+    }
+    for candidate in &readiness.deferred_tensors {
+        groups.insert(
+            (candidate.shard_ordinal, candidate.in_shard_index),
+            ReadinessGroup::Deferred,
+        );
+    }
+    groups
+}
+
+fn quant_policy_for_tensor(
+    tensor: &TensorInfo,
+    group: ReadinessGroup,
+) -> (QuantPolicy, Option<String>, Vec<String>) {
+    let mut warnings = Vec::new();
+    let (policy, protected_reason) = match &tensor.kind {
+        TensorKind::Router => (
+            QuantPolicy::PassthroughF32Router,
+            Some("protected router tensor; keep f32 to preserve expert selection".to_string()),
+        ),
+        TensorKind::BlockNorm | TensorKind::FinalNorm => (
+            QuantPolicy::PassthroughF32Norm,
+            Some("protected normalization tensor; keep f32 in first-pass planning".to_string()),
+        ),
+        TensorKind::TokenEmbedding => (QuantPolicy::CandidateSaaqEmbedding, None),
+        TensorKind::MoeExpertProjection { projection } => {
+            if *projection == MoeProjection::Unresolved {
+                warnings.push(
+                    "expert projection label remains unresolved; wrapping existing int8 tensor without projection-specific renaming"
+                        .to_string(),
+                );
+            }
+            (QuantPolicy::WrapExistingInt8Expert, None)
+        }
+        TensorKind::QuantizedAttentionProjection { .. } => {
+            (QuantPolicy::WrapExistingInt8Unknown, None)
+        }
+        TensorKind::Unknown { reason } => {
+            warnings.push(format!("unknown tensor classification: {reason}"));
+            (QuantPolicy::UnknownPassthroughOrWarn, None)
+        }
+        TensorKind::MoeScales | TensorKind::AttnProjF32 => {
+            warnings.push(format!(
+                "{} is outside the first-pass Grok-1 conversion policy set",
+                tensor.kind.short_label()
+            ));
+            (QuantPolicy::UnknownPassthroughOrWarn, None)
+        }
+    };
+
+    if matches!(group, ReadinessGroup::Deferred)
+        && !matches!(tensor.kind, TensorKind::TokenEmbedding)
+    {
+        warnings.push("tensor was deferred by readiness grouping".to_string());
+    }
+
+    (policy, protected_reason, warnings)
+}
+
+fn tensor_identity_name(tensor: &TensorInfo) -> String {
+    let file_name = tensor
+        .shard_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("tensor");
+    format!("{file_name}#{}", tensor.in_shard_index)
+}
+
+fn structural_name(tensor: &TensorInfo) -> String {
+    let slot = tensor
+        .block_slot
+        .map(|slot| format!("slot_{slot:02}"))
+        .unwrap_or_else(|| "slot_na".to_string());
+    match tensor.block_index {
+        Some(index) => format!("block_{index:03}.{slot}.{}", tensor.kind.short_label()),
+        None => match tensor.kind {
+            TensorKind::TokenEmbedding => "embedding.slot_00.token_embedding".to_string(),
+            TensorKind::FinalNorm => "final_norm.slot_00.final_norm".to_string(),
+            _ => format!(
+                "unassigned.shard_{:03}.idx_{:03}.{}",
+                tensor.shard_ordinal,
+                tensor.in_shard_index,
+                tensor.kind.short_label()
+            ),
+        },
+    }
+}
+
+fn tensor_descriptor_hash(
+    tensor: &TensorInfo,
+    policy: QuantPolicy,
+    region: SaaqRegionClass,
+) -> String {
+    let mut parts = vec![
+        format!("shard={}", tensor.shard_ordinal),
+        format!("index={}", tensor.in_shard_index),
+        format!("role={}", tensor.role.label()),
+        format!("dtype={}", tensor.dtype.label()),
+        format!("shape={}", tensor.shape.render()),
+        format!("nbytes={}", tensor.nbytes),
+        format!("kind={}", tensor.kind.short_label()),
+        format!("policy={:?}", policy),
+        format!("region={:?}", region),
+    ];
+    if let Some(block) = tensor.block_index {
+        parts.push(format!("block={block}"));
+    }
+    if let Some(slot) = tensor.block_slot {
+        parts.push(format!("slot={slot}"));
+    }
+    fnv1a64(&parts.join("|"))
+}
+
+fn fnv1a64(input: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+
+    use crate::schema::{
+        CandidateTensorManifest, ExpertAtlas, ExpertBlock, InferredHyperparams, ModelInventory,
+        MoeProjection, RoutingBlockReport, RoutingCriticalBlock, RoutingGateMetrics,
+        RoutingOrientation, RoutingOrientationSummary, RoutingReport, RoutingTensorLocator,
+        RoutingTensorRef, SaaqCandidate, SaaqDisposition, SaaqLayerReadiness, SaaqReadinessReport,
+        SaaqRegionClass, ShardRange, TensorDType, TensorInfo, TensorKind, TensorRole, TensorShape,
+    };
+
+    use super::{
+        GROK1_BASELINE_PROFILE, QUANT_PLAN_SCHEMA_VERSION, ReadinessGroup,
+        build_grok1_planning_artifacts, tensor_descriptor_hash,
+    };
+
+    #[test]
+    fn planning_artifacts_use_named_grok1_baseline() {
+        let (inv, atlas, routing, readiness) = complete_inputs();
+        let (conversion, plan) = build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness)
+            .expect("planning artifacts");
+
+        assert_eq!(conversion.baseline_profile, GROK1_BASELINE_PROFILE);
+        assert_eq!(plan.baseline, GROK1_BASELINE_PROFILE);
+        assert_eq!(conversion.tensors.len(), 770);
+        assert_eq!(plan.schema_version, QUANT_PLAN_SCHEMA_VERSION);
+        assert_eq!(plan.keep_fp32, vec!["router", "block_norm", "final_norm"]);
+        assert_eq!(
+            plan.pilot_quantize,
+            vec![
+                "attn_proj_i8.model_width",
+                "attn_proj_i8.narrow",
+                "moe_expert.gate",
+                "moe_expert.up",
+                "moe_expert.down",
+            ]
+        );
+        assert_eq!(plan.defer, vec!["token_embedding"]);
+    }
+
+    #[test]
+    fn conversion_manifest_policies_cover_all_primary_grok1_families() {
+        let (inv, atlas, routing, readiness) = complete_inputs();
+        let (conversion, _plan) =
+            build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness)
+                .expect("planning artifacts");
+
+        let mut seen = BTreeSet::new();
+        for tensor in &conversion.tensors {
+            seen.insert((tensor.kind.clone(), format!("{:?}", tensor.quant_policy)));
+        }
+        assert!(seen.contains(&(String::from("router"), String::from("PassthroughF32Router"))));
+        assert!(seen.contains(&(
+            String::from("block_norm"),
+            String::from("PassthroughF32Norm")
+        )));
+        assert!(seen.contains(&(
+            String::from("final_norm"),
+            String::from("PassthroughF32Norm")
+        )));
+        assert!(seen.contains(&(
+            String::from("token_embedding"),
+            String::from("CandidateSaaqEmbedding")
+        )));
+        assert!(seen.contains(&(
+            String::from("moe_expert.gate"),
+            String::from("WrapExistingInt8Expert")
+        )));
+        assert!(seen.contains(&(
+            String::from("moe_expert.down"),
+            String::from("WrapExistingInt8Expert")
+        )));
+        assert!(seen.contains(&(
+            String::from("moe_expert.up"),
+            String::from("WrapExistingInt8Expert")
+        )));
+        assert!(seen.contains(&(
+            String::from("attn_proj_i8.model_width"),
+            String::from("WrapExistingInt8Unknown")
+        )));
+        assert!(seen.contains(&(
+            String::from("attn_proj_i8.narrow"),
+            String::from("WrapExistingInt8Unknown")
+        )));
+    }
+
+    #[test]
+    fn tensor_hash_is_deterministic() {
+        let tensor = TensorInfo {
+            shard_path: PathBuf::from("/tmp/grok-1/ckpt-0/tensor00013_000"),
+            shard_ordinal: 13,
+            in_shard_index: 0,
+            role: TensorRole::Tensor,
+            dtype: TensorDType::F32,
+            shape: TensorShape::new(vec![6144, 8]),
+            offset: 0,
+            nbytes: 196_608,
+            kind: TensorKind::Router,
+            block_index: Some(0),
+            block_slot: Some(11),
+        };
+        let first = tensor_descriptor_hash(
+            &tensor,
+            crate::schema::QuantPolicy::PassthroughF32Router,
+            ReadinessGroup::RoutingCritical.region(),
+        );
+        let second = tensor_descriptor_hash(
+            &tensor,
+            crate::schema::QuantPolicy::PassthroughF32Router,
+            ReadinessGroup::RoutingCritical.region(),
+        );
+        assert_eq!(first, second);
+    }
+
+    fn complete_inputs() -> (
+        ModelInventory,
+        ExpertAtlas,
+        RoutingReport,
+        SaaqReadinessReport,
+    ) {
+        let inv = complete_inventory();
+        let atlas = complete_expert_atlas();
+        let routing = complete_routing_report();
+        let readiness = complete_readiness();
+        (inv, atlas, routing, readiness)
+    }
+
+    fn complete_inventory() -> ModelInventory {
+        let mut tensors = vec![tensor(
+            0,
+            0,
+            None,
+            None,
+            TensorKind::TokenEmbedding,
+            TensorRole::Tensor,
+            TensorDType::F32,
+            vec![131_072, 6_144],
+        )];
+        tensors.push(tensor(
+            1,
+            0,
+            None,
+            None,
+            TensorKind::FinalNorm,
+            TensorRole::Tensor,
+            TensorDType::F32,
+            vec![6_144],
+        ));
+        for block in 0..64u32 {
+            for slot in 0..12u32 {
+                let shard = 2 + block * 12 + slot;
+                let (kind, role, dtype, shape) = match slot {
+                    0 => (
+                        TensorKind::MoeExpertProjection {
+                            projection: MoeProjection::Gate,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6_144, 32_768],
+                    ),
+                    1 => (
+                        TensorKind::MoeExpertProjection {
+                            projection: MoeProjection::Down,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 32_768, 6_144],
+                    ),
+                    2 => (
+                        TensorKind::MoeExpertProjection {
+                            projection: MoeProjection::Up,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![8, 6_144, 32_768],
+                    ),
+                    3 | 6 => (
+                        TensorKind::QuantizedAttentionProjection {
+                            width: crate::schema::QuantizedAttentionWidth::Narrow,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![6_144, 1_024],
+                    ),
+                    4 | 5 => (
+                        TensorKind::QuantizedAttentionProjection {
+                            width: crate::schema::QuantizedAttentionWidth::ModelWidth,
+                        },
+                        TensorRole::QuantWeight,
+                        TensorDType::I8,
+                        vec![6_144, 6_144],
+                    ),
+                    7..=10 => (
+                        TensorKind::BlockNorm,
+                        TensorRole::Tensor,
+                        TensorDType::F32,
+                        vec![6_144],
+                    ),
+                    11 => (
+                        TensorKind::Router,
+                        TensorRole::Tensor,
+                        TensorDType::F32,
+                        vec![6_144, 8],
+                    ),
+                    _ => unreachable!(),
+                };
+                tensors.push(tensor(
+                    shard,
+                    0,
+                    Some(block),
+                    Some(slot),
+                    kind,
+                    role,
+                    dtype,
+                    shape,
+                ));
+            }
+        }
+        let blocks = crate::inventory::summarize_blocks(&tensors);
+        let totals = compute_totals(&tensors);
+        ModelInventory {
+            model_family: "grok-1".into(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+            shard_count: 770,
+            inferred: InferredHyperparams {
+                vocab_size: Some(131_072),
+                d_model: Some(6_144),
+                n_experts: Some(8),
+                d_ff: Some(32_768),
+                n_blocks: Some(64),
+            },
+            tensors,
+            blocks,
+            totals,
+            schema_version: crate::inventory::SCHEMA_VERSION,
+        }
+    }
+
+    fn complete_expert_atlas() -> ExpertAtlas {
+        let blocks = (0..64u32)
+            .map(|block| ExpertBlock {
+                block_index: block,
+                shard_range: Some(ShardRange {
+                    start: 2 + block * 12,
+                    end_inclusive: 4 + block * 12,
+                }),
+                expert_count: Some(8),
+                tensors: vec![
+                    crate::schema::ExpertTensorRef {
+                        shard_ordinal: 2 + block * 12,
+                        in_shard_index: 0,
+                        block_slot: Some(0),
+                        role: TensorRole::QuantWeight,
+                        dtype: TensorDType::I8,
+                        shape: TensorShape::new(vec![8, 6_144, 32_768]),
+                        kind_label: "moe_expert.gate".into(),
+                        projection: MoeProjection::Gate,
+                        expert_axis: Some(0),
+                        expert_count: Some(8),
+                        family_label: "expert_slot_00".into(),
+                        structural_name: format!("block_{block:03}.expert_slot_00"),
+                    },
+                    crate::schema::ExpertTensorRef {
+                        shard_ordinal: 3 + block * 12,
+                        in_shard_index: 0,
+                        block_slot: Some(1),
+                        role: TensorRole::QuantWeight,
+                        dtype: TensorDType::I8,
+                        shape: TensorShape::new(vec![8, 32_768, 6_144]),
+                        kind_label: "moe_expert.down".into(),
+                        projection: MoeProjection::Down,
+                        expert_axis: Some(0),
+                        expert_count: Some(8),
+                        family_label: "expert_slot_01".into(),
+                        structural_name: format!("block_{block:03}.expert_slot_01"),
+                    },
+                    crate::schema::ExpertTensorRef {
+                        shard_ordinal: 4 + block * 12,
+                        in_shard_index: 0,
+                        block_slot: Some(2),
+                        role: TensorRole::QuantWeight,
+                        dtype: TensorDType::I8,
+                        shape: TensorShape::new(vec![8, 6_144, 32_768]),
+                        kind_label: "moe_expert.up".into(),
+                        projection: MoeProjection::Up,
+                        expert_axis: Some(0),
+                        expert_count: Some(8),
+                        family_label: "expert_slot_02".into(),
+                        structural_name: format!("block_{block:03}.expert_slot_02"),
+                    },
+                ],
+                experts: (0..8u32)
+                    .map(|expert| crate::schema::ExpertSlice {
+                        expert_index: expert,
+                        tensors: vec![
+                            crate::schema::ExpertSliceTensor {
+                                family_label: "expert_slot_00".into(),
+                                structural_name: format!(
+                                    "block_{block:03}.expert_slot_00.expert_{expert:02}"
+                                ),
+                                source_shard_ordinal: 2 + block * 12,
+                                source_in_shard_index: 0,
+                                source_block_slot: Some(0),
+                                projection: MoeProjection::Gate,
+                                dtype: TensorDType::I8,
+                                slice_shape: TensorShape::new(vec![6_144, 32_768]),
+                            },
+                            crate::schema::ExpertSliceTensor {
+                                family_label: "expert_slot_01".into(),
+                                structural_name: format!(
+                                    "block_{block:03}.expert_slot_01.expert_{expert:02}"
+                                ),
+                                source_shard_ordinal: 3 + block * 12,
+                                source_in_shard_index: 0,
+                                source_block_slot: Some(1),
+                                projection: MoeProjection::Down,
+                                dtype: TensorDType::I8,
+                                slice_shape: TensorShape::new(vec![32_768, 6_144]),
+                            },
+                            crate::schema::ExpertSliceTensor {
+                                family_label: "expert_slot_02".into(),
+                                structural_name: format!(
+                                    "block_{block:03}.expert_slot_02.expert_{expert:02}"
+                                ),
+                                source_shard_ordinal: 4 + block * 12,
+                                source_in_shard_index: 0,
+                                source_block_slot: Some(2),
+                                projection: MoeProjection::Up,
+                                dtype: TensorDType::I8,
+                                slice_shape: TensorShape::new(vec![6_144, 32_768]),
+                            },
+                        ],
+                    })
+                    .collect(),
+            })
+            .collect();
+        ExpertAtlas {
+            model_family: "grok-1".into(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+            shard_count: 770,
+            inferred: InferredHyperparams {
+                d_model: Some(6_144),
+                n_experts: Some(8),
+                d_ff: Some(32_768),
+                n_blocks: Some(64),
+                ..Default::default()
+            },
+            relevant_block_count: 64,
+            expected_experts_per_block: Some(8),
+            blocks,
+            naming_patterns: Vec::new(),
+            naming_checks: Vec::new(),
+            anomalies: Vec::new(),
+            schema_version: 1,
+        }
+    }
+
+    fn complete_routing_report() -> RoutingReport {
+        let candidates = (0..64u32)
+            .map(|block| RoutingTensorRef {
+                shard_ordinal: 13 + block * 12,
+                in_shard_index: 0,
+                block_index: Some(block),
+                block_slot: Some(11),
+                role: TensorRole::Tensor,
+                dtype: TensorDType::F32,
+                shape: TensorShape::new(vec![6_144, 8]),
+                kind_label: "router".into(),
+                orientation: RoutingOrientation::DModelToExperts,
+                expert_axis: Some(1),
+                linked_expert_count: Some(8),
+                matches_inferred_expert_count: true,
+                structural_name: format!("block_{block:03}.routing_slot_11"),
+                gate_metrics: RoutingGateMetrics {
+                    total_elements: 49_152,
+                    total_nbytes: 196_608,
+                    input_width: Some(6_144),
+                    output_width: Some(8),
+                    expert_count: Some(8),
+                    logits_per_input: Some(8),
+                },
+            })
+            .collect::<Vec<_>>();
+        RoutingReport {
+            model_family: "grok-1".into(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+            shard_count: 770,
+            inferred: InferredHyperparams {
+                d_model: Some(6_144),
+                n_experts: Some(8),
+                n_blocks: Some(64),
+                ..Default::default()
+            },
+            relevant_block_count: 64,
+            expected_experts_per_router: Some(8),
+            candidate_tensors: candidates.clone(),
+            blocks: (0..64u32)
+                .map(|block| RoutingBlockReport {
+                    block_index: Some(block),
+                    label: format!("block_{block:03}"),
+                    shard_range: Some(ShardRange {
+                        start: 2 + block * 12,
+                        end_inclusive: 13 + block * 12,
+                    }),
+                    local_expert_count: Some(8),
+                    primary_candidate: Some(RoutingTensorLocator {
+                        shard_ordinal: 13 + block * 12,
+                        in_shard_index: 0,
+                        block_slot: Some(11),
+                    }),
+                    candidates: vec![candidates[block as usize].clone()],
+                })
+                .collect(),
+            orientation_summaries: vec![RoutingOrientationSummary {
+                orientation: RoutingOrientation::DModelToExperts,
+                count: 64,
+                observed_shapes: vec![TensorShape::new(vec![6_144, 8])],
+                observed_blocks: 64,
+            }],
+            likely_routing_critical_blocks: (0..64u32)
+                .map(|block| RoutingCriticalBlock {
+                    block_index: Some(block),
+                    label: format!("block_{block:03}"),
+                    reason: "primary router present".into(),
+                    primary_candidate: Some(RoutingTensorLocator {
+                        shard_ordinal: 13 + block * 12,
+                        in_shard_index: 0,
+                        block_slot: Some(11),
+                    }),
+                })
+                .collect(),
+            grok_layout_notes: Vec::new(),
+            anomalies: Vec::new(),
+            schema_version: 1,
+        }
+    }
+
+    fn complete_readiness() -> SaaqReadinessReport {
+        let mut quantization_candidates = Vec::new();
+        let mut routing_critical_tensors = Vec::new();
+        let mut precision_sensitive_tensors = Vec::new();
+        let mut deferred_tensors = vec![candidate(
+            0,
+            0,
+            None,
+            None,
+            "embedding.slot_00.token_embedding",
+            "token_embedding",
+            TensorDType::F32,
+            vec![131_072, 6_144],
+            SaaqRegionClass::EmbeddingHeavy,
+            SaaqDisposition::ObserveOnly,
+            0.08,
+        )];
+        for block in 0..64u32 {
+            for (slot, kind, dtype, shape, readiness_score) in [
+                (
+                    0,
+                    "moe_expert.gate",
+                    TensorDType::I8,
+                    vec![8, 6_144, 32_768],
+                    0.82,
+                ),
+                (
+                    1,
+                    "moe_expert.down",
+                    TensorDType::I8,
+                    vec![8, 32_768, 6_144],
+                    0.79,
+                ),
+                (
+                    2,
+                    "moe_expert.up",
+                    TensorDType::I8,
+                    vec![8, 6_144, 32_768],
+                    0.81,
+                ),
+                (
+                    3,
+                    "attn_proj_i8.narrow",
+                    TensorDType::I8,
+                    vec![6_144, 1_024],
+                    0.55,
+                ),
+                (
+                    4,
+                    "attn_proj_i8.model_width",
+                    TensorDType::I8,
+                    vec![6_144, 6_144],
+                    0.63,
+                ),
+                (
+                    5,
+                    "attn_proj_i8.model_width",
+                    TensorDType::I8,
+                    vec![6_144, 6_144],
+                    0.61,
+                ),
+                (
+                    6,
+                    "attn_proj_i8.narrow",
+                    TensorDType::I8,
+                    vec![6_144, 1_024],
+                    0.54,
+                ),
+            ] {
+                quantization_candidates.push(candidate(
+                    2 + block * 12 + slot,
+                    0,
+                    Some(block),
+                    Some(slot),
+                    &format!("block_{block:03}.slot_{slot:02}.{kind}"),
+                    kind,
+                    dtype,
+                    shape,
+                    SaaqRegionClass::PotentialCompressionTarget,
+                    SaaqDisposition::Candidate,
+                    readiness_score,
+                ));
+            }
+            for slot in 7..=10u32 {
+                precision_sensitive_tensors.push(candidate(
+                    2 + block * 12 + slot,
+                    0,
+                    Some(block),
+                    Some(slot),
+                    &format!("block_{block:03}.slot_{slot:02}.block_norm"),
+                    "block_norm",
+                    TensorDType::F32,
+                    vec![6_144],
+                    SaaqRegionClass::NormalizationSensitive,
+                    SaaqDisposition::AvoidForNow,
+                    0.04,
+                ));
+            }
+            routing_critical_tensors.push(candidate(
+                13 + block * 12,
+                0,
+                Some(block),
+                Some(11),
+                &format!("block_{block:03}.slot_11.router"),
+                "router",
+                TensorDType::F32,
+                vec![6_144, 8],
+                SaaqRegionClass::RoutingCritical,
+                SaaqDisposition::AvoidForNow,
+                0.03,
+            ));
+        }
+        precision_sensitive_tensors.push(candidate(
+            1,
+            0,
+            None,
+            None,
+            "final_norm.slot_00.final_norm",
+            "final_norm",
+            TensorDType::F32,
+            vec![6_144],
+            SaaqRegionClass::NormalizationSensitive,
+            SaaqDisposition::AvoidForNow,
+            0.02,
+        ));
+
+        quantization_candidates.sort_by(|a, b| b.readiness_score.total_cmp(&a.readiness_score));
+        for (idx, candidate) in quantization_candidates.iter_mut().enumerate() {
+            candidate.rank = (idx + 1) as u32;
+        }
+        for (idx, candidate) in routing_critical_tensors.iter_mut().enumerate() {
+            candidate.rank = (idx + 1) as u32;
+        }
+        for (idx, candidate) in precision_sensitive_tensors.iter_mut().enumerate() {
+            candidate.rank = (idx + 1) as u32;
+        }
+        for (idx, candidate) in deferred_tensors.iter_mut().enumerate() {
+            candidate.rank = (idx + 1) as u32;
+        }
+
+        SaaqReadinessReport {
+            model_family: "grok-1".into(),
+            checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+            shard_count: 770,
+            inferred: InferredHyperparams {
+                d_model: Some(6_144),
+                n_experts: Some(8),
+                d_ff: Some(32_768),
+                n_blocks: Some(64),
+                ..Default::default()
+            },
+            candidate_targets: quantization_candidates.clone(),
+            quantization_candidates: quantization_candidates.clone(),
+            routing_critical_tensors: routing_critical_tensors.clone(),
+            precision_sensitive_tensors: precision_sensitive_tensors.clone(),
+            deferred_tensors: deferred_tensors.clone(),
+            risky_tensors: routing_critical_tensors.iter().take(10).cloned().collect(),
+            layer_readiness: vec![SaaqLayerReadiness {
+                block_index: Some(0),
+                label: "block_000".into(),
+                routing_critical: true,
+                candidate_target_count: 7,
+                mean_readiness_score: 0.46,
+                max_risk_score: 0.93,
+            }],
+            notes: vec![
+                "Top candidate target is `block_000.slot_00.moe_expert.gate` with readiness 0.820."
+                    .into(),
+            ],
+            manifest: CandidateTensorManifest {
+                model_family: "grok-1".into(),
+                checkpoint_path: PathBuf::from("/tmp/grok-1-official/ckpt-0"),
+                candidates: quantization_candidates,
+                schema_version: 1,
+            },
+            schema_version: 1,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn candidate(
+        shard_ordinal: u32,
+        in_shard_index: u32,
+        block_index: Option<u32>,
+        block_slot: Option<u32>,
+        structural_name: &str,
+        kind_label: &str,
+        dtype: TensorDType,
+        shape: Vec<u64>,
+        region_class: SaaqRegionClass,
+        disposition: SaaqDisposition,
+        readiness_score: f64,
+    ) -> SaaqCandidate {
+        SaaqCandidate {
+            rank: 0,
+            shard_ordinal,
+            in_shard_index,
+            block_index,
+            block_slot,
+            structural_name: structural_name.into(),
+            kind_label: kind_label.into(),
+            dtype,
+            shape: TensorShape::new(shape),
+            region_class,
+            disposition,
+            readiness_score,
+            opportunity_score: readiness_score,
+            risk_score: 1.0 - readiness_score,
+            reasons: vec!["synthetic planning fixture".into()],
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn tensor(
+        shard_ordinal: u32,
+        in_shard_index: u32,
+        block_index: Option<u32>,
+        block_slot: Option<u32>,
+        kind: TensorKind,
+        role: TensorRole,
+        dtype: TensorDType,
+        shape: Vec<u64>,
+    ) -> TensorInfo {
+        TensorInfo {
+            shard_path: PathBuf::from(format!(
+                "/tmp/grok-1-official/ckpt-0/tensor{shard_ordinal:05}_000"
+            )),
+            shard_ordinal,
+            in_shard_index,
+            role,
+            dtype,
+            shape: TensorShape::new(shape.clone()),
+            offset: 0,
+            nbytes: dtype.itemsize() as u64 * shape.iter().product::<u64>(),
+            kind,
+            block_index,
+            block_slot,
+        }
+    }
+
+    fn compute_totals(tensors: &[TensorInfo]) -> crate::schema::InventoryTotals {
+        let mut totals = crate::schema::InventoryTotals {
+            tensors: tensors.len() as u64,
+            ..Default::default()
+        };
+        for tensor in tensors {
+            totals.total_nbytes += tensor.nbytes;
+            totals.total_elements += tensor.shape.numel();
+            match tensor.dtype {
+                TensorDType::F32 => totals.f32_tensors += 1,
+                TensorDType::I8 => totals.i8_tensors += 1,
+            }
+            match tensor.role {
+                TensorRole::QuantWeight | TensorRole::QuantScales => totals.quant_tensors += 1,
+                TensorRole::Tensor => {}
+            }
+        }
+        totals
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -13,9 +13,9 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::schema::{
-    BlockSummary, CandidateTensorManifest, CheckpointInventorySnapshot, ExpertAtlas,
-    ExpertIssueCategory, FindingsSummary, Grok1CoverageManifest, ModelInventory,
-    RoutingCriticalTensorManifest, RoutingIssueCategory, RoutingReport, SaaqDisposition,
+    BlockSummary, CandidateTensorManifest, CheckpointInventorySnapshot, ConversionManifest,
+    ExpertAtlas, ExpertIssueCategory, FindingsSummary, Grok1CoverageManifest, ModelInventory,
+    QuantPlan, RoutingCriticalTensorManifest, RoutingIssueCategory, RoutingReport, SaaqDisposition,
     SaaqReadinessReport, StatsProfileReport,
 };
 
@@ -49,6 +49,16 @@ pub fn write_saaq_readiness_json(report_doc: &SaaqReadinessReport, out: &Path) -
 /// Write the candidate manifest as pretty-printed JSON.
 pub fn write_candidate_manifest_json(manifest: &CandidateTensorManifest, out: &Path) -> Result<()> {
     write_pretty_json(manifest, "serialize candidate manifest to json", out)
+}
+
+/// Write the conversion-ready manifest as pretty-printed JSON.
+pub fn write_conversion_manifest_json(manifest: &ConversionManifest, out: &Path) -> Result<()> {
+    write_pretty_json(manifest, "serialize conversion manifest to json", out)
+}
+
+/// Write the deterministic quant plan as pretty-printed JSON.
+pub fn write_quant_plan_json(plan: &QuantPlan, out: &Path) -> Result<()> {
+    write_pretty_json(plan, "serialize quant plan to json", out)
 }
 
 /// Write the inventory snapshot manifest as pretty-printed JSON.
@@ -756,8 +766,18 @@ pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> Strin
     let _ = writeln!(md, "- **shards**: {}", report_doc.shard_count);
     let _ = writeln!(
         md,
-        "- **candidate_targets**: {}",
-        report_doc.candidate_targets.len()
+        "- **quantization_candidates**: {}",
+        report_doc.quantization_candidates.len()
+    );
+    let _ = writeln!(
+        md,
+        "- **precision_sensitive_tensors**: {}",
+        report_doc.precision_sensitive_tensors.len()
+    );
+    let _ = writeln!(
+        md,
+        "- **deferred_tensors**: {}",
+        report_doc.deferred_tensors.len()
     );
     let _ = writeln!(
         md,
@@ -767,7 +787,7 @@ pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> Strin
     let _ = writeln!(md, "- **schema_version**: {}", report_doc.schema_version);
 
     let _ = writeln!(md);
-    let _ = writeln!(md, "## Candidate target tensors");
+    let _ = writeln!(md, "## Quantization candidates");
     let _ = writeln!(md);
     let _ = writeln!(
         md,
@@ -777,7 +797,7 @@ pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> Strin
         md,
         "| ---: | ------ | ---- | ------ | --------: | ----------: | ---: | ----------- |"
     );
-    for candidate in &report_doc.candidate_targets {
+    for candidate in &report_doc.quantization_candidates {
         let _ = writeln!(
             md,
             "| {} | `{}` | {} | {} | {:.3} | {:.3} | {:.3} | {} |",
@@ -807,6 +827,45 @@ pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> Strin
                 candidate.structural_name,
                 candidate.readiness_score,
                 candidate.risk_score,
+                candidate.reasons.join("<br>")
+            );
+        }
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Precision-sensitive tensors");
+    let _ = writeln!(md);
+    if report_doc.precision_sensitive_tensors.is_empty() {
+        let _ = writeln!(md, "None detected.");
+    } else {
+        let _ = writeln!(md, "| Tensor | Risk | Reasons |");
+        let _ = writeln!(md, "| ------ | ---: | ------- |");
+        for candidate in &report_doc.precision_sensitive_tensors {
+            let _ = writeln!(
+                md,
+                "| `{}` | {:.3} | {} |",
+                candidate.structural_name,
+                candidate.risk_score,
+                candidate.reasons.join("<br>")
+            );
+        }
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Deferred tensors");
+    let _ = writeln!(md);
+    if report_doc.deferred_tensors.is_empty() {
+        let _ = writeln!(md, "None detected.");
+    } else {
+        let _ = writeln!(md, "| Tensor | Kind | Disposition | Reasons |");
+        let _ = writeln!(md, "| ------ | ---- | ----------- | ------- |");
+        for candidate in &report_doc.deferred_tensors {
+            let _ = writeln!(
+                md,
+                "| `{}` | {} | {} | {} |",
+                candidate.structural_name,
+                candidate.kind_label,
+                saaq_disposition_label(candidate.disposition),
                 candidate.reasons.join("<br>")
             );
         }
@@ -873,6 +932,88 @@ pub fn render_saaq_readiness_markdown(report_doc: &SaaqReadinessReport) -> Strin
 /// Write the SAAQ-readiness Markdown summary to `out`.
 pub fn write_saaq_readiness_markdown(report_doc: &SaaqReadinessReport, out: &Path) -> Result<()> {
     let s = render_saaq_readiness_markdown(report_doc);
+    write_text(&s, out)
+}
+
+/// Render a Markdown summary for the deterministic Grok-1 quant plan.
+pub fn render_quant_plan_markdown(plan: &QuantPlan) -> String {
+    let mut md = String::new();
+
+    let _ = writeln!(md, "# xai-dissect quant plan");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "- **model_family**: `{}`", plan.model_family);
+    let _ = writeln!(md, "- **checkpoint**: `{}`", plan.checkpoint_path.display());
+    let _ = writeln!(md, "- **baseline**: `{}`", plan.baseline);
+    let _ = writeln!(md, "- **schema_version**: {}", plan.schema_version);
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Required validation");
+    let _ = writeln!(md);
+    let _ = writeln!(md, "| Metric | Required | Discovered |");
+    let _ = writeln!(md, "| ------ | -------: | ---------: |");
+    let _ = writeln!(
+        md,
+        "| blocks | {} | {} |",
+        plan.required_validation.blocks, plan.discovered_validation.blocks
+    );
+    let _ = writeln!(
+        md,
+        "| tensors | {} | {} |",
+        plan.required_validation.tensors, plan.discovered_validation.tensors
+    );
+    let _ = writeln!(
+        md,
+        "| routers | {} | {} |",
+        plan.required_validation.routers, plan.discovered_validation.routers
+    );
+    let _ = writeln!(
+        md,
+        "| expert_families | {} | {} |",
+        plan.required_validation.expert_families, plan.discovered_validation.expert_families
+    );
+    let _ = writeln!(
+        md,
+        "| unknown_tensors | {} | {} |",
+        plan.required_validation.unknown_tensors, plan.discovered_validation.unknown_tensors
+    );
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Keep fp32");
+    let _ = writeln!(md);
+    for kind in &plan.keep_fp32 {
+        let _ = writeln!(md, "- `{kind}`");
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Pilot quantize");
+    let _ = writeln!(md);
+    for kind in &plan.pilot_quantize {
+        let _ = writeln!(md, "- `{kind}`");
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Defer");
+    let _ = writeln!(md);
+    for kind in &plan.defer {
+        let _ = writeln!(md, "- `{kind}`");
+    }
+
+    let _ = writeln!(md);
+    let _ = writeln!(md, "## Notes");
+    let _ = writeln!(md);
+    if plan.notes.is_empty() {
+        let _ = writeln!(md, "None.");
+    } else {
+        for note in &plan.notes {
+            let _ = writeln!(md, "- {}", note);
+        }
+    }
+
+    md
+}
+
+/// Write the quant-plan Markdown summary to `out`.
+pub fn write_quant_plan_markdown(plan: &QuantPlan, out: &Path) -> Result<()> {
+    let s = render_quant_plan_markdown(plan);
     write_text(&s, out)
 }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+pub const GROK1_BASELINE_PROFILE: &str = "grok1-map-v1-clean";
+
 /// Numpy-style dtype of a tensor as it lives on disk. The set is intentionally
 /// narrow: Grok-1 shards only contain `float32` and `int8`. New dtypes are
 /// added only when a supported checkpoint actually requires them.
@@ -634,13 +636,21 @@ pub struct SaaqReadinessReport {
     pub shard_count: u32,
     pub inferred: InferredHyperparams,
     /// Backward-compatible alias for the actionable quantization-candidate set.
+    #[serde(default)]
     pub candidate_targets: Vec<SaaqCandidate>,
+    #[serde(default)]
     pub quantization_candidates: Vec<SaaqCandidate>,
+    #[serde(default)]
     pub routing_critical_tensors: Vec<SaaqCandidate>,
+    #[serde(default)]
     pub precision_sensitive_tensors: Vec<SaaqCandidate>,
+    #[serde(default)]
     pub deferred_tensors: Vec<SaaqCandidate>,
+    #[serde(default)]
     pub risky_tensors: Vec<SaaqCandidate>,
+    #[serde(default)]
     pub layer_readiness: Vec<SaaqLayerReadiness>,
+    #[serde(default)]
     pub notes: Vec<String>,
     pub manifest: CandidateTensorManifest,
     pub schema_version: u32,
@@ -684,6 +694,7 @@ pub struct CheckpointInventoryBlockSnapshot {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Grok1CoverageManifest {
     pub model_family: String,
+    #[serde(default = "default_grok1_baseline_profile")]
     pub baseline_profile: String,
     pub schema_version: u32,
     pub coverage_schema_version: u32,
@@ -710,6 +721,10 @@ pub struct Grok1UnknownSlot {
     pub block_slot: Option<u32>,
     pub shape: TensorShape,
     pub reason: String,
+}
+
+fn default_grok1_baseline_profile() -> String {
+    GROK1_BASELINE_PROFILE.to_string()
 }
 
 /// Machine-readable routing-critical tensor list for downstream

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -638,7 +638,7 @@ pub struct SaaqReadinessReport {
     /// Backward-compatible alias for the actionable quantization-candidate set.
     #[serde(default)]
     pub candidate_targets: Vec<SaaqCandidate>,
-    #[serde(default)]
+    #[serde(default, alias = "candidate_targets")]
     pub quantization_candidates: Vec<SaaqCandidate>,
     #[serde(default)]
     pub routing_critical_tensors: Vec<SaaqCandidate>,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -636,7 +636,8 @@ pub struct SaaqReadinessReport {
     pub shard_count: u32,
     pub inferred: InferredHyperparams,
     /// Backward-compatible alias for the actionable quantization-candidate set.
-    #[serde(default)]
+    /// Skips deserialization so the legacy key can be aliased into quantization_candidates.
+    #[serde(default, skip_deserializing)]
     pub candidate_targets: Vec<SaaqCandidate>,
     #[serde(default, alias = "candidate_targets")]
     pub quantization_candidates: Vec<SaaqCandidate>,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -633,8 +633,12 @@ pub struct SaaqReadinessReport {
     pub checkpoint_path: PathBuf,
     pub shard_count: u32,
     pub inferred: InferredHyperparams,
+    /// Backward-compatible alias for the actionable quantization-candidate set.
     pub candidate_targets: Vec<SaaqCandidate>,
+    pub quantization_candidates: Vec<SaaqCandidate>,
     pub routing_critical_tensors: Vec<SaaqCandidate>,
+    pub precision_sensitive_tensors: Vec<SaaqCandidate>,
+    pub deferred_tensors: Vec<SaaqCandidate>,
     pub risky_tensors: Vec<SaaqCandidate>,
     pub layer_readiness: Vec<SaaqLayerReadiness>,
     pub notes: Vec<String>,
@@ -680,6 +684,7 @@ pub struct CheckpointInventoryBlockSnapshot {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Grok1CoverageManifest {
     pub model_family: String,
+    pub baseline_profile: String,
     pub schema_version: u32,
     pub coverage_schema_version: u32,
     pub validation: String,
@@ -729,6 +734,73 @@ pub struct RoutingCriticalTensor {
     pub linked_expert_count: Option<u64>,
     pub total_nbytes: u64,
     pub criticality_reason: Option<String>,
+}
+
+/// Conversion-ready tensor-by-tensor handoff manifest for downstream
+/// packing or quantization tooling.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConversionManifest {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub baseline_profile: String,
+    pub required_validation: Grok1CoverageCounts,
+    pub discovered_validation: Grok1CoverageCounts,
+    pub relevant_block_count: u32,
+    pub expected_experts_per_block: Option<u64>,
+    pub expert_tensor_families_per_block: Option<u32>,
+    pub router_orientation: Option<RoutingOrientation>,
+    pub router_shape: Option<TensorShape>,
+    pub tensors: Vec<ConversionManifestTensor>,
+    pub warnings: Vec<String>,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConversionManifestTensor {
+    pub tensor_name: String,
+    pub structural_name: String,
+    pub model_family: String,
+    pub block: Option<u32>,
+    pub slot: Option<u32>,
+    pub kind: String,
+    pub region: SaaqRegionClass,
+    pub dtype: TensorDType,
+    pub shape: TensorShape,
+    pub numel: u64,
+    pub byte_len: u64,
+    pub shard_index: u32,
+    pub source_shard_path: PathBuf,
+    pub source_in_shard_index: u32,
+    pub quant_policy: QuantPolicy,
+    pub protected_reason: Option<String>,
+    pub deterministic_hash: String,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuantPolicy {
+    PassthroughF32Router,
+    PassthroughF32Norm,
+    CandidateSaaqEmbedding,
+    WrapExistingInt8Expert,
+    WrapExistingInt8Unknown,
+    UnknownPassthroughOrWarn,
+}
+
+/// Deterministic family-level quantization plan for downstream pilot work.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QuantPlan {
+    pub model_family: String,
+    pub checkpoint_path: PathBuf,
+    pub baseline: String,
+    pub required_validation: Grok1CoverageCounts,
+    pub discovered_validation: Grok1CoverageCounts,
+    pub keep_fp32: Vec<String>,
+    pub pilot_quantize: Vec<String>,
+    pub defer: Vec<String>,
+    pub notes: Vec<String>,
+    pub schema_version: u32,
 }
 
 /// Small machine-readable summary of the main findings from a single

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -98,18 +98,19 @@ pub fn build_saaq_readiness_report(
         candidate.rank = (index + 1) as u32;
     }
 
-    let mut candidate_targets = scored
+    let mut quantization_candidates = scored
         .iter()
         .filter(|candidate| candidate.disposition == SaaqDisposition::Candidate)
         .cloned()
         .collect::<Vec<_>>();
-    if candidate_targets.is_empty() {
+    if quantization_candidates.is_empty() {
         if let Some(fallback_index) = scored.iter().position(|candidate| {
             !matches!(
                 candidate.region_class,
                 SaaqRegionClass::RoutingCritical
                     | SaaqRegionClass::NormalizationSensitive
                     | SaaqRegionClass::AlreadyCompressed
+                    | SaaqRegionClass::EmbeddingHeavy
             )
         }) {
             scored[fallback_index].disposition = SaaqDisposition::Candidate;
@@ -117,15 +118,28 @@ pub fn build_saaq_readiness_report(
                 "promoted as the best available non-routing target in a constrained sample"
                     .to_string(),
             );
-            candidate_targets.push(scored[fallback_index].clone());
+            quantization_candidates.push(scored[fallback_index].clone());
         }
     }
-    for (index, candidate) in candidate_targets.iter_mut().enumerate() {
+    for (index, candidate) in quantization_candidates.iter_mut().enumerate() {
         candidate.rank = (index + 1) as u32;
     }
     let routing_critical_tensors = scored
         .iter()
         .filter(|candidate| candidate.region_class == SaaqRegionClass::RoutingCritical)
+        .cloned()
+        .collect::<Vec<_>>();
+    let precision_sensitive_tensors = scored
+        .iter()
+        .filter(|candidate| candidate.region_class == SaaqRegionClass::NormalizationSensitive)
+        .cloned()
+        .collect::<Vec<_>>();
+    let deferred_tensors = scored
+        .iter()
+        .filter(|candidate| {
+            candidate.region_class == SaaqRegionClass::EmbeddingHeavy
+                || candidate.disposition == SaaqDisposition::ObserveOnly
+        })
         .cloned()
         .collect::<Vec<_>>();
     let mut risky_tensors = scored
@@ -136,11 +150,15 @@ pub fn build_saaq_readiness_report(
     risky_tensors.sort_by(|a, b| b.risk_score.total_cmp(&a.risk_score));
     risky_tensors.truncate(25);
     let layer_readiness = summarize_layer_readiness(&scored, &routing_blocks);
-    let notes = build_saaq_notes(&candidate_targets, &routing_critical_tensors, &routing);
+    let notes = build_saaq_notes(
+        &quantization_candidates,
+        &routing_critical_tensors,
+        &routing,
+    );
     let manifest = CandidateTensorManifest {
         model_family: inv.model_family.clone(),
         checkpoint_path: inv.checkpoint_path.clone(),
-        candidates: candidate_targets.clone(),
+        candidates: quantization_candidates.clone(),
         schema_version: SAAQ_READINESS_SCHEMA_VERSION,
     };
 
@@ -149,8 +167,11 @@ pub fn build_saaq_readiness_report(
         checkpoint_path: inv.checkpoint_path.clone(),
         shard_count: inv.shard_count,
         inferred: clone_hyperparams(&inv.inferred),
-        candidate_targets,
+        candidate_targets: quantization_candidates.clone(),
+        quantization_candidates,
         routing_critical_tensors,
+        precision_sensitive_tensors,
+        deferred_tensors,
         risky_tensors,
         layer_readiness,
         notes,
@@ -569,10 +590,10 @@ fn score_tensor(
     let structural_penalty = match region_class {
         SaaqRegionClass::RoutingCritical => 0.95,
         SaaqRegionClass::NormalizationSensitive => 0.85,
-        SaaqRegionClass::AlreadyCompressed => 0.9,
-        SaaqRegionClass::EmbeddingHeavy => 0.55,
+        SaaqRegionClass::AlreadyCompressed => 0.7,
+        SaaqRegionClass::EmbeddingHeavy => 0.7,
         SaaqRegionClass::PotentialCompressionTarget => 0.2,
-        SaaqRegionClass::Unknown => 0.4,
+        SaaqRegionClass::Unknown => 0.45,
     };
     let risk_score = clamp01(structural_penalty * 0.65 + outlier_penalty * 0.35);
     let readiness_score = clamp01(opportunity_score * (1.0 - structural_penalty * 0.85));
@@ -580,10 +601,10 @@ fn score_tensor(
         SaaqRegionClass::PotentialCompressionTarget if readiness_score >= 0.15 => {
             SaaqDisposition::Candidate
         }
-        SaaqRegionClass::EmbeddingHeavy if readiness_score >= 0.12 => SaaqDisposition::Candidate,
         SaaqRegionClass::RoutingCritical
         | SaaqRegionClass::NormalizationSensitive
         | SaaqRegionClass::AlreadyCompressed => SaaqDisposition::AvoidForNow,
+        SaaqRegionClass::EmbeddingHeavy | SaaqRegionClass::Unknown => SaaqDisposition::ObserveOnly,
         _ => SaaqDisposition::ObserveOnly,
     };
 
@@ -644,19 +665,21 @@ fn classify_region(
     if tensor.kind_label == "block_norm" || tensor.kind_label == "final_norm" {
         return SaaqRegionClass::NormalizationSensitive;
     }
-    if tensor.dtype == TensorDType::I8
-        || tensor.kind_label.starts_with("moe_scales")
-        || tensor.kind_label.starts_with("moe_expert.")
-    {
-        return SaaqRegionClass::AlreadyCompressed;
-    }
     if tensor.kind_label == "token_embedding" {
         return SaaqRegionClass::EmbeddingHeavy;
     }
+    if tensor.kind_label.starts_with("moe_scales") {
+        return SaaqRegionClass::AlreadyCompressed;
+    }
+    if tensor.kind_label.starts_with("moe_expert.")
+        || tensor.kind_label.starts_with("attn_proj_i8.")
+        || tensor.kind_label == "attn_proj_f32"
+    {
+        return SaaqRegionClass::PotentialCompressionTarget;
+    }
     if tensor.dtype == TensorDType::F32
-        && (tensor.kind_label == "attn_proj_f32"
-            || tensor.kind_label == "unknown"
-            || routing_blocks.contains(&tensor.block_index))
+        && tensor.kind_label == "unknown"
+        && routing_blocks.contains(&tensor.block_index)
     {
         return SaaqRegionClass::PotentialCompressionTarget;
     }
@@ -716,7 +739,7 @@ fn build_saaq_notes(
     let mut notes = Vec::new();
     if let Some(top) = candidate_targets.first() {
         notes.push(format!(
-            "Top candidate target is `{}` with readiness {:.3}.",
+            "Top quantization candidate is `{}` with readiness {:.3}.",
             top.structural_name, top.readiness_score
         ));
     }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -20,7 +20,8 @@ use crate::schema::{
 };
 
 pub const STATS_PROFILE_SCHEMA_VERSION: u32 = 1;
-pub const SAAQ_READINESS_SCHEMA_VERSION: u32 = 1;
+pub const CANDIDATE_TENSOR_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub const SAAQ_READINESS_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, Debug)]
 pub struct StatsConfig {
@@ -137,8 +138,9 @@ pub fn build_saaq_readiness_report(
     let deferred_tensors = scored
         .iter()
         .filter(|candidate| {
-            candidate.region_class == SaaqRegionClass::EmbeddingHeavy
-                || candidate.disposition == SaaqDisposition::ObserveOnly
+            candidate.disposition != SaaqDisposition::Candidate
+                && candidate.region_class != SaaqRegionClass::RoutingCritical
+                && candidate.region_class != SaaqRegionClass::NormalizationSensitive
         })
         .cloned()
         .collect::<Vec<_>>();
@@ -159,7 +161,7 @@ pub fn build_saaq_readiness_report(
         model_family: inv.model_family.clone(),
         checkpoint_path: inv.checkpoint_path.clone(),
         candidates: quantization_candidates.clone(),
-        schema_version: SAAQ_READINESS_SCHEMA_VERSION,
+        schema_version: CANDIDATE_TENSOR_MANIFEST_SCHEMA_VERSION,
     };
 
     SaaqReadinessReport {
@@ -1005,6 +1007,29 @@ mod tests {
         assert_eq!(
             readiness.risky_tensors[0].structural_name,
             "block_001.slot_00.block_norm"
+        );
+    }
+
+    #[test]
+    fn saaq_readiness_keeps_already_compressed_tensors_in_deferred_bucket() {
+        let inv = inventory(Vec::new());
+        let stats = stats_report(vec![stat(
+            "block_000.slot_00.moe_scales",
+            "moe_scales",
+            Some(0),
+            0.0,
+            0.0,
+        )]);
+
+        let readiness = build_saaq_readiness_report(&inv, &stats);
+
+        assert!(
+            readiness
+                .deferred_tensors
+                .iter()
+                .any(|candidate| candidate.kind_label == "moe_scales"
+                    && candidate.region_class == SaaqRegionClass::AlreadyCompressed
+                    && candidate.disposition == SaaqDisposition::AvoidForNow)
         );
     }
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -112,6 +112,7 @@ pub fn build_saaq_readiness_report(
                     | SaaqRegionClass::NormalizationSensitive
                     | SaaqRegionClass::AlreadyCompressed
                     | SaaqRegionClass::EmbeddingHeavy
+                    | SaaqRegionClass::Unknown
             )
         }) {
             scored[fallback_index].disposition = SaaqDisposition::Candidate;
@@ -953,13 +954,38 @@ mod tests {
     }
 
     #[test]
-    fn saaq_fallback_promotion_updates_layer_readiness() {
+    fn saaq_unknown_not_promoted_by_fallback() {
         let inv = inventory(Vec::new());
         let stats = stats_report(vec![stat(
             "block_007.slot_03.custom",
             "custom",
             Some(7),
             0.0,
+            0.0,
+        )]);
+
+        let readiness = build_saaq_readiness_report(&inv, &stats);
+
+        assert_eq!(readiness.candidate_targets.len(), 0);
+        assert_eq!(readiness.quantization_candidates.len(), 0);
+        assert_eq!(
+            readiness
+                .layer_readiness
+                .iter()
+                .find(|layer| layer.block_index == Some(7))
+                .map(|layer| layer.candidate_target_count),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn saaq_fallback_promotion_updates_layer_readiness() {
+        let inv = inventory_with_total(Vec::new(), 1000);
+        let stats = stats_report(vec![stat(
+            "block_007.slot_03.attn_proj_f32",
+            "attn_proj_f32",
+            Some(7),
+            0.05,
             0.0,
         )]);
 
@@ -1034,6 +1060,10 @@ mod tests {
     }
 
     fn inventory(tensors: Vec<TensorInfo>) -> ModelInventory {
+        inventory_with_total(tensors, 32)
+    }
+
+    fn inventory_with_total(tensors: Vec<TensorInfo>, total_nbytes: u64) -> ModelInventory {
         ModelInventory {
             model_family: "grok-1".to_string(),
             checkpoint_path: PathBuf::from("/tmp/grok-1"),
@@ -1064,7 +1094,7 @@ mod tests {
                 quant_tensors: 0,
                 f32_tensors: 2,
                 i8_tensors: 0,
-                total_nbytes: 32,
+                total_nbytes,
                 total_elements: 8,
             },
             schema_version: 1,

--- a/tests/cli_help.rs
+++ b/tests/cli_help.rs
@@ -9,6 +9,7 @@ fn top_level_help_lists_current_commands() {
         "routing-report",
         "stats",
         "saaq-readiness",
+        "quant-plan",
     ] {
         assert!(
             stdout.contains(command),
@@ -25,6 +26,7 @@ fn analysis_commands_expose_output_tree_options() {
         "routing-report",
         "stats",
         "saaq-readiness",
+        "quant-plan",
     ] {
         let stdout = run_help(&[command, "--help"]);
         assert!(

--- a/tests/export_contracts.rs
+++ b/tests/export_contracts.rs
@@ -5,9 +5,9 @@ use std::fs;
 use xai_dissect::exports;
 
 use support::{
-    assert_snapshot_sections, bundle_sections, sample_checkpoint_slug, sample_expert_atlas,
-    sample_inventory, sample_routing_report, sample_saaq_readiness, sample_stats_profile,
-    unique_temp_root,
+    assert_snapshot_sections, bundle_sections, sample_checkpoint_slug, sample_conversion_manifest,
+    sample_expert_atlas, sample_inventory, sample_quant_plan, sample_routing_report,
+    sample_saaq_readiness, sample_stats_profile, unique_temp_root,
 };
 
 #[test]
@@ -62,5 +62,21 @@ fn saaq_bundle_matches_snapshot() {
     assert_eq!(bundle.checkpoint_slug, sample_checkpoint_slug());
     let sections = bundle_sections(&root, &bundle);
     assert_snapshot_sections("tests/fixtures/exports/saaq-readiness.snap", &sections);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn quant_plan_bundle_matches_snapshot() {
+    let root = unique_temp_root("quant-plan-bundle");
+    let bundle = exports::write_quant_plan_bundle(
+        &sample_conversion_manifest(),
+        &sample_quant_plan(),
+        &root,
+        None,
+    )
+    .expect("write quant-plan bundle");
+    assert_eq!(bundle.checkpoint_slug, sample_checkpoint_slug());
+    let sections = bundle_sections(&root, &bundle);
+    assert_snapshot_sections("tests/fixtures/exports/quant-plan.snap", &sections);
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/fixtures/exports/quant-plan.snap
+++ b/tests/fixtures/exports/quant-plan.snap
@@ -1,0 +1,182 @@
+=== manifests/grok-1-official__ckpt-0/conversion-manifest.json ===
+{
+  "model_family": "grok-1",
+  "checkpoint_path": "/fixtures/grok-1-official/ckpt-0",
+  "baseline_profile": "grok1-map-v1-clean",
+  "required_validation": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "discovered_validation": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "relevant_block_count": 64,
+  "expected_experts_per_block": 8,
+  "expert_tensor_families_per_block": 3,
+  "router_orientation": "d_model_to_experts",
+  "router_shape": [
+    6144,
+    8
+  ],
+  "tensors": [
+    {
+      "tensor_name": "tensor0000#0",
+      "structural_name": "embedding.slot_00.token_embedding",
+      "model_family": "grok-1",
+      "block": null,
+      "slot": null,
+      "kind": "token_embedding",
+      "region": "embedding_heavy",
+      "dtype": "f32",
+      "shape": [
+        16,
+        4
+      ],
+      "numel": 64,
+      "byte_len": 256,
+      "shard_index": 0,
+      "source_shard_path": "/fixtures/grok-1-official/ckpt-0/tensor0000",
+      "source_in_shard_index": 0,
+      "quant_policy": "candidate_saaq_embedding",
+      "protected_reason": null,
+      "deterministic_hash": "fnv1a64:1111111111111111",
+      "warnings": []
+    },
+    {
+      "tensor_name": "tensor0001#0",
+      "structural_name": "block_000.routing_slot_00",
+      "model_family": "grok-1",
+      "block": 0,
+      "slot": 0,
+      "kind": "router",
+      "region": "routing_critical",
+      "dtype": "f32",
+      "shape": [
+        4,
+        2
+      ],
+      "numel": 8,
+      "byte_len": 32,
+      "shard_index": 1,
+      "source_shard_path": "/fixtures/grok-1-official/ckpt-0/tensor0001",
+      "source_in_shard_index": 0,
+      "quant_policy": "passthrough_f32_router",
+      "protected_reason": "protected router tensor; keep f32 to preserve expert selection",
+      "deterministic_hash": "fnv1a64:2222222222222222",
+      "warnings": []
+    },
+    {
+      "tensor_name": "tensor0001#2",
+      "structural_name": "block_000.slot_02.block_norm",
+      "model_family": "grok-1",
+      "block": 0,
+      "slot": 2,
+      "kind": "block_norm",
+      "region": "normalization_sensitive",
+      "dtype": "f32",
+      "shape": [
+        4
+      ],
+      "numel": 4,
+      "byte_len": 16,
+      "shard_index": 1,
+      "source_shard_path": "/fixtures/grok-1-official/ckpt-0/tensor0001",
+      "source_in_shard_index": 2,
+      "quant_policy": "passthrough_f32_norm",
+      "protected_reason": "protected normalization tensor; keep f32 in first-pass planning",
+      "deterministic_hash": "fnv1a64:3333333333333333",
+      "warnings": []
+    }
+  ],
+  "warnings": [],
+  "schema_version": 1
+}
+
+=== manifests/grok-1-official__ckpt-0/quant-plan.json ===
+{
+  "model_family": "grok-1",
+  "checkpoint_path": "/fixtures/grok-1-official/ckpt-0",
+  "baseline": "grok1-map-v1-clean",
+  "required_validation": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "discovered_validation": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "keep_fp32": [
+    "router",
+    "block_norm",
+    "final_norm"
+  ],
+  "pilot_quantize": [
+    "attn_proj_i8.model_width",
+    "attn_proj_i8.narrow",
+    "moe_expert.gate",
+    "moe_expert.up",
+    "moe_expert.down"
+  ],
+  "defer": [
+    "token_embedding"
+  ],
+  "notes": [
+    "770 tensors partition into 1 quantization candidates, 1 routing-critical, 1 precision-sensitive, and 1 deferred entries.",
+    "Top quantization candidate is `block_000.slot_01.attn_proj` with readiness 0.820."
+  ],
+  "schema_version": 1
+}
+
+=== reports/grok-1-official__ckpt-0/quant-plan.md ===
+# xai-dissect quant plan
+
+- **model_family**: `grok-1`
+- **checkpoint**: `/fixtures/grok-1-official/ckpt-0`
+- **baseline**: `grok1-map-v1-clean`
+- **schema_version**: 1
+
+## Required validation
+
+| Metric | Required | Discovered |
+| ------ | -------: | ---------: |
+| blocks | 64 | 64 |
+| tensors | 770 | 770 |
+| routers | 64 | 64 |
+| expert_families | 192 | 192 |
+| unknown_tensors | 0 | 0 |
+
+## Keep fp32
+
+- `router`
+- `block_norm`
+- `final_norm`
+
+## Pilot quantize
+
+- `attn_proj_i8.model_width`
+- `attn_proj_i8.narrow`
+- `moe_expert.gate`
+- `moe_expert.up`
+- `moe_expert.down`
+
+## Defer
+
+- `token_embedding`
+
+## Notes
+
+- 770 tensors partition into 1 quantization candidates, 1 routing-critical, 1 precision-sensitive, and 1 deferred entries.
+- Top quantization candidate is `block_000.slot_01.attn_proj` with readiness 0.820.

--- a/tests/fixtures/exports/saaq-readiness.snap
+++ b/tests/fixtures/exports/saaq-readiness.snap
@@ -27,7 +27,7 @@
       "detail": "highest-risk tensor block_000.slot_02.norm at 0.740"
     }
   ],
-  "schema_version": 1
+  "schema_version": 2
 }
 
 === exports/grok-1-official__ckpt-0/saaq-readiness.json ===
@@ -230,7 +230,7 @@
     ],
     "schema_version": 1
   },
-  "schema_version": 1
+  "schema_version": 2
 }
 
 === manifests/grok-1-official__ckpt-0/candidate-saaq-targets.json ===
@@ -275,7 +275,7 @@
 - **precision_sensitive_tensors**: 1
 - **deferred_tensors**: 1
 - **routing_critical_tensors**: 1
-- **schema_version**: 1
+- **schema_version**: 2
 
 ## Quantization candidates
 

--- a/tests/fixtures/exports/saaq-readiness.snap
+++ b/tests/fixtures/exports/saaq-readiness.snap
@@ -67,6 +67,31 @@
       ]
     }
   ],
+  "quantization_candidates": [
+    {
+      "rank": 1,
+      "shard_ordinal": 1,
+      "in_shard_index": 1,
+      "block_index": 0,
+      "block_slot": 1,
+      "structural_name": "block_000.slot_01.attn_proj",
+      "kind_label": "attn_proj_f32",
+      "dtype": "f32",
+      "shape": [
+        4,
+        4
+      ],
+      "region_class": "potential_compression_target",
+      "disposition": "candidate",
+      "readiness_score": 0.82,
+      "opportunity_score": 0.78,
+      "risk_score": 0.24,
+      "reasons": [
+        "f32 tensor with moderate size share",
+        "not marked routing-critical"
+      ]
+    }
+  ],
   "routing_critical_tensors": [
     {
       "rank": 1,
@@ -88,6 +113,53 @@
       "risk_score": 0.91,
       "reasons": [
         "routing tensor linked to expert selection"
+      ]
+    }
+  ],
+  "precision_sensitive_tensors": [
+    {
+      "rank": 1,
+      "shard_ordinal": 1,
+      "in_shard_index": 2,
+      "block_index": 0,
+      "block_slot": 2,
+      "structural_name": "block_000.slot_02.norm",
+      "kind_label": "block_norm",
+      "dtype": "f32",
+      "shape": [
+        4
+      ],
+      "region_class": "normalization_sensitive",
+      "disposition": "avoid_for_now",
+      "readiness_score": 0.1,
+      "opportunity_score": 0.12,
+      "risk_score": 0.74,
+      "reasons": [
+        "normalization-sensitive tensor"
+      ]
+    }
+  ],
+  "deferred_tensors": [
+    {
+      "rank": 1,
+      "shard_ordinal": 0,
+      "in_shard_index": 0,
+      "block_index": null,
+      "block_slot": null,
+      "structural_name": "embedding.slot_00.token_embedding",
+      "kind_label": "token_embedding",
+      "dtype": "f32",
+      "shape": [
+        16,
+        4
+      ],
+      "region_class": "embedding_heavy",
+      "disposition": "observe_only",
+      "readiness_score": 0.08,
+      "opportunity_score": 0.15,
+      "risk_score": 0.55,
+      "reasons": [
+        "embedding is deferred from first-pass quantization"
       ]
     }
   ],
@@ -126,7 +198,7 @@
   ],
   "notes": [
     "routing tensors remain avoid-for-now in this structural profile",
-    "attention projection is the top candidate in the synthetic sample"
+    "attention projection is the top quantization candidate in the synthetic sample"
   ],
   "manifest": {
     "model_family": "grok-1",
@@ -199,11 +271,13 @@
 - **model_family**: `grok-1`
 - **checkpoint**: `/fixtures/grok-1-official/ckpt-0`
 - **shards**: 2
-- **candidate_targets**: 1
+- **quantization_candidates**: 1
+- **precision_sensitive_tensors**: 1
+- **deferred_tensors**: 1
 - **routing_critical_tensors**: 1
 - **schema_version**: 1
 
-## Candidate target tensors
+## Quantization candidates
 
 | Rank | Tensor | Kind | Region | Readiness | Opportunity | Risk | Disposition |
 | ---: | ------ | ---- | ------ | --------: | ----------: | ---: | ----------- |
@@ -214,6 +288,18 @@
 | Tensor | Readiness | Risk | Reasons |
 | ------ | --------: | ---: | ------- |
 | `block_000.routing_slot_00` | 0.050 | 0.910 | routing tensor linked to expert selection |
+
+## Precision-sensitive tensors
+
+| Tensor | Risk | Reasons |
+| ------ | ---: | ------- |
+| `block_000.slot_02.norm` | 0.740 | normalization-sensitive tensor |
+
+## Deferred tensors
+
+| Tensor | Kind | Disposition | Reasons |
+| ------ | ---- | ----------- | ------- |
+| `embedding.slot_00.token_embedding` | token_embedding | observe_only | embedding is deferred from first-pass quantization |
 
 ## Highest-risk tensors
 
@@ -230,4 +316,4 @@
 ## Notes
 
 - routing tensors remain avoid-for-now in this structural profile
-- attention projection is the top candidate in the synthetic sample
+- attention projection is the top quantization candidate in the synthetic sample

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -8,10 +8,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use xai_dissect::exports::OutputBundle;
 use xai_dissect::inventory;
 use xai_dissect::schema::{
-    BlockSummary, CandidateTensorManifest, ExpertAtlas, ExpertBlock, ExpertNamingCheck,
-    ExpertNamingPattern, ExpertSlice, ExpertSliceTensor, ExpertTensorRef, InferredHyperparams,
-    InventoryTotals, KindCount, LayerStats, ModelInventory, MoeProjection, NormSummary,
-    OutlierSummary, RankedTensorStat, RoutingBlockReport, RoutingCriticalBlock, RoutingGateMetrics,
+    BlockSummary, CandidateTensorManifest, ConversionManifest, ConversionManifestTensor,
+    ExpertAtlas, ExpertBlock, ExpertNamingCheck, ExpertNamingPattern, ExpertSlice,
+    ExpertSliceTensor, ExpertTensorRef, Grok1CoverageCounts, InferredHyperparams, InventoryTotals,
+    KindCount, LayerStats, ModelInventory, MoeProjection, NormSummary, OutlierSummary, QuantPlan,
+    QuantPolicy, RankedTensorStat, RoutingBlockReport, RoutingCriticalBlock, RoutingGateMetrics,
     RoutingOrientation, RoutingOrientationSummary, RoutingReport, RoutingTensorLocator,
     RoutingTensorRef, SaaqCandidate, SaaqDisposition, SaaqLayerReadiness, SaaqReadinessReport,
     SaaqRegionClass, ShardRange, StatsProfileReport, StatsSamplingConfig, TensorDType, TensorInfo,
@@ -653,6 +654,23 @@ pub fn sample_saaq_readiness() -> SaaqReadinessReport {
         risk_score: 0.74,
         reasons: vec!["normalization-sensitive tensor".into()],
     };
+    let deferred = SaaqCandidate {
+        rank: 1,
+        shard_ordinal: 0,
+        in_shard_index: 0,
+        block_index: None,
+        block_slot: None,
+        structural_name: "embedding.slot_00.token_embedding".into(),
+        kind_label: "token_embedding".into(),
+        dtype: TensorDType::F32,
+        shape: TensorShape::new(vec![16, 4]),
+        region_class: SaaqRegionClass::EmbeddingHeavy,
+        disposition: SaaqDisposition::ObserveOnly,
+        readiness_score: 0.08,
+        opportunity_score: 0.15,
+        risk_score: 0.55,
+        reasons: vec!["embedding is deferred from first-pass quantization".into()],
+    };
     SaaqReadinessReport {
         model_family: "grok-1".into(),
         checkpoint_path: sample_checkpoint_path(),
@@ -664,7 +682,10 @@ pub fn sample_saaq_readiness() -> SaaqReadinessReport {
             ..Default::default()
         },
         candidate_targets: vec![candidate.clone()],
+        quantization_candidates: vec![candidate.clone()],
         routing_critical_tensors: vec![routing_critical.clone()],
+        precision_sensitive_tensors: vec![risky.clone()],
+        deferred_tensors: vec![deferred.clone()],
         risky_tensors: vec![risky],
         layer_readiness: vec![SaaqLayerReadiness {
             block_index: Some(0),
@@ -676,7 +697,7 @@ pub fn sample_saaq_readiness() -> SaaqReadinessReport {
         }],
         notes: vec![
             "routing tensors remain avoid-for-now in this structural profile".into(),
-            "attention projection is the top candidate in the synthetic sample".into(),
+            "attention projection is the top quantization candidate in the synthetic sample".into(),
         ],
         manifest: CandidateTensorManifest {
             model_family: "grok-1".into(),
@@ -696,5 +717,136 @@ fn rank(stats: &TensorStats, kind_label: &str, value: f64) -> RankedTensorStat {
         kind_label: kind_label.into(),
         block_index: stats.block_index,
         value,
+    }
+}
+
+pub fn sample_quant_plan() -> QuantPlan {
+    QuantPlan {
+        model_family: "grok-1".into(),
+        checkpoint_path: sample_checkpoint_path(),
+        baseline: "grok1-map-v1-clean".into(),
+        required_validation: Grok1CoverageCounts {
+            blocks: 64,
+            tensors: 770,
+            routers: 64,
+            expert_families: 192,
+            unknown_tensors: 0,
+        },
+        discovered_validation: Grok1CoverageCounts {
+            blocks: 64,
+            tensors: 770,
+            routers: 64,
+            expert_families: 192,
+            unknown_tensors: 0,
+        },
+        keep_fp32: vec!["router".into(), "block_norm".into(), "final_norm".into()],
+        pilot_quantize: vec![
+            "attn_proj_i8.model_width".into(),
+            "attn_proj_i8.narrow".into(),
+            "moe_expert.gate".into(),
+            "moe_expert.up".into(),
+            "moe_expert.down".into(),
+        ],
+        defer: vec!["token_embedding".into()],
+        notes: vec![
+            "770 tensors partition into 1 quantization candidates, 1 routing-critical, 1 precision-sensitive, and 1 deferred entries.".into(),
+            "Top quantization candidate is `block_000.slot_01.attn_proj` with readiness 0.820.".into(),
+        ],
+        schema_version: 1,
+    }
+}
+
+pub fn sample_conversion_manifest() -> ConversionManifest {
+    ConversionManifest {
+        model_family: "grok-1".into(),
+        checkpoint_path: sample_checkpoint_path(),
+        baseline_profile: "grok1-map-v1-clean".into(),
+        required_validation: Grok1CoverageCounts {
+            blocks: 64,
+            tensors: 770,
+            routers: 64,
+            expert_families: 192,
+            unknown_tensors: 0,
+        },
+        discovered_validation: Grok1CoverageCounts {
+            blocks: 64,
+            tensors: 770,
+            routers: 64,
+            expert_families: 192,
+            unknown_tensors: 0,
+        },
+        relevant_block_count: 64,
+        expected_experts_per_block: Some(8),
+        expert_tensor_families_per_block: Some(3),
+        router_orientation: Some(RoutingOrientation::DModelToExperts),
+        router_shape: Some(TensorShape::new(vec![6144, 8])),
+        tensors: vec![
+            ConversionManifestTensor {
+                tensor_name: "tensor0000#0".into(),
+                structural_name: "embedding.slot_00.token_embedding".into(),
+                model_family: "grok-1".into(),
+                block: None,
+                slot: None,
+                kind: "token_embedding".into(),
+                region: SaaqRegionClass::EmbeddingHeavy,
+                dtype: TensorDType::F32,
+                shape: TensorShape::new(vec![16, 4]),
+                numel: 64,
+                byte_len: 256,
+                shard_index: 0,
+                source_shard_path: PathBuf::from("/fixtures/grok-1-official/ckpt-0/tensor0000"),
+                source_in_shard_index: 0,
+                quant_policy: QuantPolicy::CandidateSaaqEmbedding,
+                protected_reason: None,
+                deterministic_hash: "fnv1a64:1111111111111111".into(),
+                warnings: Vec::new(),
+            },
+            ConversionManifestTensor {
+                tensor_name: "tensor0001#0".into(),
+                structural_name: "block_000.routing_slot_00".into(),
+                model_family: "grok-1".into(),
+                block: Some(0),
+                slot: Some(0),
+                kind: "router".into(),
+                region: SaaqRegionClass::RoutingCritical,
+                dtype: TensorDType::F32,
+                shape: TensorShape::new(vec![4, 2]),
+                numel: 8,
+                byte_len: 32,
+                shard_index: 1,
+                source_shard_path: PathBuf::from("/fixtures/grok-1-official/ckpt-0/tensor0001"),
+                source_in_shard_index: 0,
+                quant_policy: QuantPolicy::PassthroughF32Router,
+                protected_reason: Some(
+                    "protected router tensor; keep f32 to preserve expert selection".into(),
+                ),
+                deterministic_hash: "fnv1a64:2222222222222222".into(),
+                warnings: Vec::new(),
+            },
+            ConversionManifestTensor {
+                tensor_name: "tensor0001#2".into(),
+                structural_name: "block_000.slot_02.block_norm".into(),
+                model_family: "grok-1".into(),
+                block: Some(0),
+                slot: Some(2),
+                kind: "block_norm".into(),
+                region: SaaqRegionClass::NormalizationSensitive,
+                dtype: TensorDType::F32,
+                shape: TensorShape::new(vec![4]),
+                numel: 4,
+                byte_len: 16,
+                shard_index: 1,
+                source_shard_path: PathBuf::from("/fixtures/grok-1-official/ckpt-0/tensor0001"),
+                source_in_shard_index: 2,
+                quant_policy: QuantPolicy::PassthroughF32Norm,
+                protected_reason: Some(
+                    "protected normalization tensor; keep f32 in first-pass planning".into(),
+                ),
+                deterministic_hash: "fnv1a64:3333333333333333".into(),
+                warnings: Vec::new(),
+            },
+        ],
+        warnings: Vec::new(),
+        schema_version: 1,
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -705,7 +705,7 @@ pub fn sample_saaq_readiness() -> SaaqReadinessReport {
             candidates: vec![candidate],
             schema_version: 1,
         },
-        schema_version: 1,
+        schema_version: 2,
     }
 }
 


### PR DESCRIPTION
## **User description**
Closes #21

## Summary
- document the minimal `grok-ozempic` handoff contract in `docs/export-contracts.md` and `docs/output-conventions.md`
- add clean-baseline Grok-1 coverage metadata plus deterministic conversion and quant-planning artifacts via a new `quant-plan` bundle
- extend snapshot and CLI coverage for the new artifacts and grouped SAAQ outputs

## Validation
- `cargo fmt --check`
- `cargo test`


___

## **CodeAnt-AI Description**
**Add Grok-1 quant planning output and a clearer handoff contract**

### What Changed
- Added a new `quant-plan` command that writes a conversion manifest, a family-level quant plan, and a Markdown summary for Grok-1 checkpoints
- SAAQ readiness reports now split tensors into quantization candidates, precision-sensitive tensors, and deferred tensors, with the summary and Markdown updated to show those groups
- Grok-1 coverage output now includes the named clean baseline profile `grok1-map-v1-clean`, and the export docs now spell out the required bundle files for the `grok-ozempic` handoff

### Impact
`✅ Faster Grok-1 conversion handoff`
`✅ Clearer quantization planning output`
`✅ Fewer missing-file surprises during downstream ingest`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `quant-plan` CLI command and grok-ozempic export contract for Grok-1 quantization planning
> - Introduces a new `quant-plan` subcommand in [src/main.rs](https://github.com/rmems/xai-dissect/pull/32/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc) that validates a complete Grok-1 inventory, builds SAAQ readiness stats, and produces a `ConversionManifest` and `QuantPlan` via the new `planning` module.
> - Adds [src/planning/mod.rs](https://github.com/rmems/xai-dissect/pull/32/files#diff-9a6933fdd4d1be17fba6c7274732f5b9f287fe2cf464df5f97b93a8a8a35c407) with validation logic for expert atlas, routing report, and readiness group coverage, plus manifest and plan builders that assign per-tensor quantization policies and deterministic FNV-1a hashes.
> - Extends [src/schema/mod.rs](https://github.com/rmems/xai-dissect/pull/32/files#diff-bcd29853272b1eaad52850a6456c5d1e9d4f6c07aedfdb2ce28df189b83f5ace) with new types: `ConversionManifest`, `ConversionManifestTensor`, `QuantPlan`, and `QuantPolicy`; bumps `SaaqReadinessReport` to schema version 2 with new `quantization_candidates`, `precision_sensitive_tensors`, and `deferred_tensors` groupings.
> - Adds report renderers and write helpers in [src/report/mod.rs](https://github.com/rmems/xai-dissect/pull/32/files#diff-67f4662c66d4f01dd2f4298d263536b4d5aabadcb46fd11ff5da62c760674b9a) for `conversion-manifest.json`, `quant-plan.json`, and `quant-plan.md`; updates SAAQ readiness Markdown to reflect the new groupings.
> - Documents the grok-ozempic handoff contract in [docs/export-contracts.md](https://github.com/rmems/xai-dissect/pull/32/files#diff-ff7b48c8564ab357e79ba0585031b25272458626b290342486ffa71a5a0dded9) and [docs/output-conventions.md](https://github.com/rmems/xai-dissect/pull/32/files#diff-342ab287ad0b358d67d241bfcd59b7c947de240cb8bb0fe90bb9f589ab684326).
> - Behavioral Change: `SaaqReadinessReport` deserialization now reads `quantization_candidates` from the legacy `candidate_targets` key; `candidate_targets` will no longer be populated from input. `SAAQ_READINESS_SCHEMA_VERSION` bumps from 1 to 2 and `GROK1_COVERAGE_SCHEMA_VERSION` bumps from 1 to 2.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 422f94a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->