### PR TITLE
Harden CI: clippy, non-blocking Qodana reports, and security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: CI
+#
+# Authoritative Rust correctness gate.
+# This workflow is required; Qodana and Security workflows are advisory only.
+#
 
 on:
   pull_request:
@@ -20,7 +24,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -28,5 +32,8 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Run tests
-        run: cargo test --locked
+        run: cargo test --all-features --locked

--- a/.github/workflows/qodana-reports.yml
+++ b/.github/workflows/qodana-reports.yml
@@ -1,0 +1,44 @@
+name: Qodana Report
+#
+# Non-blocking static-analysis report workflow.
+# Qodana provides supplementary code-quality signals (YAML, Markdown, JSON,
+# TOML, etc.); it is NOT the Rust correctness gate.
+# Cargo fmt, Clippy, and cargo test in CI.yml remain the required checks.
+#
+# This job is allowed to fail (continue-on-error: true) so that Qodana
+# results never block merge.
+#
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  qodana-scan:
+    name: Qodana Scan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      checks: write          # needed to publish SARIF / check results
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # Qodana performs incremental analysis when history is available
+
+      - name: Qodana Scan
+        uses: JetBrains/qodana-action@v2024.1
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+
+      - name: Upload Qodana report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qodana-report-${{ github.run_id }}
+          path: ${{ runner.temp }}/qodana/report/
+          retention-days: 30

--- a/.github/workflows/qodana-reports.yml
+++ b/.github/workflows/qodana-reports.yml
@@ -3,7 +3,7 @@ name: Qodana Report
 # Non-blocking static-analysis report workflow.
 # Qodana provides supplementary code-quality signals (YAML, Markdown, JSON,
 # TOML, etc.); it is NOT the Rust correctness gate.
-# Cargo fmt, Clippy, and cargo test in CI.yml remain the required checks.
+# Cargo fmt, Clippy, and cargo test in ci.yml remain the required checks.
 #
 # This job is allowed to fail (continue-on-error: true) so that Qodana
 # results never block merge.
@@ -30,15 +30,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0   # Qodana performs incremental analysis when history is available
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Qodana Scan
         uses: JetBrains/qodana-action@v2024.1
         env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+          QODANA_TOKEN: ${{ secrets.QODANA_CONFIGURATIONS_TOKEN }}
 
       - name: Upload Qodana report artifact
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: qodana-report-${{ github.run_id }}
-          path: ${{ runner.temp }}/qodana/report/
+          path: ${{ runner.temp }}/qodana/results/
           retention-days: 30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,6 @@ jobs:
   cargo-audit:
     name: Cargo Audit
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -34,13 +33,19 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
 
       - name: Run cargo audit
-        run: cargo audit 2>&1 | tee cargo-audit.log
+        id: audit
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo audit 2>&1 | tee cargo-audit.log
 
       - name: Upload audit log artifact
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: cargo-audit-log-${{ github.run_id }}
           path: cargo-audit.log

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+name: Security
+#
+# Dependency vulnerability scanning.
+# Runs cargo-audit against the Cargo.lock file.
+# This job is advisory (continue-on-error: true) so that new advisory
+# publications do not block unrelated PRs, while still surfacing issues.
+#
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run daily at 06:00 UTC to catch newly published advisories
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  cargo-audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit 2>&1 | tee cargo-audit.log
+
+      - name: Upload audit log artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-audit-log-${{ github.run_id }}
+          path: cargo-audit.log
+          retention-days: 30


### PR DESCRIPTION
## **User description**
## Summary

Tightens the Rust CI gate and adds two advisory-only workflows for code-quality reporting and dependency security scanning.

### What changed

**`.github/workflows/ci.yml`** — authoritative Rust correctness gate
- Added `components: rustfmt, clippy` to the Rust toolchain install step
- Added **Clippy** job: `cargo clippy --all-targets --all-features -- -D warnings`
- Updated test job to: `cargo test --all-features --locked`
- Kept `cargo fmt --check`

**`.github/workflows/qodana-reports.yml`** — non-blocking code-quality reporter (new)
- Uses the official `JetBrains/qodana-action@v2024.1` for scanning
- `continue-on-error: true` so Qodana never blocks merge
- Uploads the Qodana report as a GitHub Actions artifact (30-day retention)
- Includes comments explaining that Cargo/Clippy/Test remain the required correctness gate

**`.github/workflows/security.yml`** — dependency vulnerability scanning (new)
- Runs `cargo audit` on every push/PR and on a daily cron schedule
- `continue-on-error: true` so newly published advisories do not block unrelated PRs
- Uploads the audit log as an artifact

### Design decisions

- **Qodana is non-blocking**: Qodana does not natively analyze Rust; it scans YAML, TOML, Markdown, JSON, etc. It provides useful supplementary signals but should never gate a Rust PR.
- **Security is non-blocking**: `cargo audit` can fail when a new advisory is published against an existing dependency. Making it blocking would create merge-blocking noise. The log artifact ensures maintainers still see the report.
- **Rust CI is required**: `fmt`, `clippy`, and `test` are the only required checks.

### Validation

- `cargo test --all-features --locked` passes locally


___

## **CodeAnt-AI Description**
Tighten Rust checks and add non-blocking quality and security reports

### What Changed
- CI now runs Clippy along with formatting checks and tests, so Rust issues are caught before merge
- Test runs now cover all features, which reduces the chance of feature-specific breakages slipping through
- Added a separate Qodana report workflow that runs in the background and uploads its results without blocking pull requests
- Added a separate security audit workflow that scans dependencies on pushes, pull requests, and a daily schedule, and uploads the report for review

### Impact
`✅ Fewer broken Rust merges`
`✅ Earlier detection of feature-specific test failures`
`✅ Clearer code-quality reports without blocking PRs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden CI with Clippy linting, Qodana static analysis, and security auditing
> - Adds Clippy to the CI toolchain in [ci.yml](.github/workflows/ci.yml) and runs `cargo clippy --all-targets --all-features --deny warnings`, failing the build on any warnings; also runs `cargo test` with `--all-features`
> - Adds a new [qodana-reports.yml](.github/workflows/qodana-reports.yml) workflow that runs JetBrains Qodana on push, PR, and manual dispatch, uploading results as artifacts for 30 days; the step is non-blocking (`continue-on-error: true`)
> - Adds a new [security.yml](.github/workflows/security.yml) workflow that runs `cargo audit` on push, PR, daily at 06:00 UTC, and manual dispatch, uploading the audit log as an artifact for 30 days; also non-blocking
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99cfb2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->