### PR TITLE
docs: handoff-hardening pass — add dissect to README, date unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `xai-dissect` are documented here.
 
-## Unreleased
+## Unreleased - 2026-05-27
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cargo test
 
 Main commands:
 
+- `dissect`: raw per-shard byte-table view (parser output only; no classification or grouping)
 - `inventory`: full checkpoint inventory and architecture-oriented summary
 - `experts`: expert atlas for MoE block structure
 - `routing-report`: routing/gating structure inspection

--- a/docs/GO_NO_GO.md
+++ b/docs/GO_NO_GO.md
@@ -18,6 +18,10 @@ exists.
 - Artifact directories / filenames are stable and documented
 - Cloud runbook exists before burning time-limited credits
 
+Each threshold metric (router top-1/top-2 agreement, block output cosine,
+etc.) is defined and its measurement methodology is explained in
+[`docs/metric-definitions.md`](metric-definitions.md).
+
 ## GO thresholds
 
 All of the following must be true:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,11 @@ Exports are the only supported integration surface for downstream repos
 (`corinth-canal`, `SAAQ-latent`, `Surrogate_Viz.jl`). No in-process API is
 guaranteed across versions; the export schema is.
 
+For Grok-1-specific architecture details — the per-layer MoE composition,
+the `QuantizedWeight8bit` shard structure, how the 12-shard-per-block
+layout maps to tensor kinds, and the source-backed disambiguation of gate
+vs. up projections — see [`docs/grok1-architecture.md`](grok1-architecture.md).
+
 ## Current file tree
 
 ```

--- a/docs/grok1-architecture.md
+++ b/docs/grok1-architecture.md
@@ -37,8 +37,8 @@ This is the `K = 12` constant hard-coded in the Grok-1 coverage validator
 | 2 | 1 | MoE expert projection | `(8, 6144, 32768)` | int8 | quantized `quant.weight` |
 | 3–4 | 2 | Attention projection | `(6144, 6144)` | int8 | quantized `quant.weight` (model-width) |
 | 5–6 | 2 | Attention projection | `(6144, 1024)` | int8 | quantized `quant.weight` (narrow) |
-| 7 | 1 | Router / gate | `(6144, 8)` | f32 | bare `tensor` |
-| 8–11 | 4 | RMSNorm | `(6144,)` | f32 | bare `tensor` |
+| 7–10 | 4 | RMSNorm | `(6144,)` | f32 | bare `tensor` |
+| 11 | 1 | Router / gate | `(6144, 8)` | f32 | bare `tensor` |
 | (norm singletons) | 1 | Final pre-head norm | `(6144,)` | f32 | bare `tensor` |
 | (embedding) | 1 | Token embedding | `(131072, 6144)` | f32 | bare `tensor` |
 
@@ -84,26 +84,26 @@ per-element f32 quantization scales.
 When this dataclass is saved to a pickle shard, it appears as three
 separate `numpy.ndarray` reduce sites on disk:
 
-1. **The int8 weight body** — the first ndarray reduce site in the shard.
-   This is what the parser records as `role = quant.weight`. Shape is
-   `(E, d_model, d_ff)` for up/gate and `(E, d_ff, d_model)` for down,
-   where `E = n_experts = 8`.
-2. **The f32 scales / zero-points** — the second ndarray reduce site.
-   This is recorded as `role = quant.scales`. Shape varies (the two
-   1.5 GiB shard variants differ by exactly 262,144 bytes — 65,536 f32
-   values — due to different quantization side-data shapes across the
-   three expert projection families).
-3. **The per-expert minimum values** (for the down projection only, due to
-   the asymmetric quantization layout used in Grok-1's `QuantizedWeight8bit`
-   dataclass). This is also `role = quant.scales` and appears in the same
-   shard.
+1. **The int8 weight body** — the ndarray with `dtype = i8` in each
+   `QuantizedWeight8bit` reduce site. The parser records this as
+   `role = quant.weight`. Shape is `(E, d_model, d_ff)` for gate/up and
+   `(E, d_ff, d_model)` for down, where `E = n_experts = 8`.
+2. **The f32 scales / zero-points** — the first f32 ndarray after the
+   int8 weight body in the same reduce site. The parser records this as
+   `role = quant.scales`. Shape varies (the two 1.5 GiB shard variants
+   differ by exactly 262,144 bytes — 65,536 f32 values — due to different
+   quantization side-data shapes across the three expert projection
+   families).
+3. **Additional f32 ndarrays** (for example per-expert minimum values in
+   the down projection's asymmetric quantization layout) remain bare
+   `role = tensor` records in the same shard.
 
 `xai-dissect` **does not decode the internal structure of the
-QuantizedWeight8bit dataclass**. It only records the two top-level ndarray
-reduce sites as separate tensor records. The pairing of `quant.weight`
-with its companion `quant.scales` is preserved by the shard grouping (both
-appear in the same shard file), but the exact internal layout is opaque
-to the parser.
+QuantizedWeight8bit dataclass**. It emits one `quant.weight` and at most
+one `quant.scales` record per reduce site, using dtype-aware role
+assignment. The pairing is preserved by the shard grouping (all records
+share the same shard file), but the exact internal layout is opaque to
+the parser.
 
 ## How xai-dissect maps shards to architecture
 
@@ -123,8 +123,9 @@ type before reading any shard body:
 | 24,727 B | RMSNorm vector `(6144,) f32` | 257 |
 
 The two model-width attention buckets (37,847,359 and 37,761,334) both
-have shape `(6144, 6144)`. The two narrow buckets (6,293,814 and its
-sibling) both have shape `(6144, 1024)`. Q/K/V/O disambiguation is not
+have shape `(6144, 6144)`. Both narrow attention projections share the
+single narrow bucket size (6,293,814 B) and shape `(6144, 1024)`. Q/K/V/O
+disambiguation is not
 attempted by `xai-dissect` — those roles are downstream disambiguation
 problems for `grok-ozempic`.
 

--- a/docs/grok1-architecture.md
+++ b/docs/grok1-architecture.md
@@ -35,8 +35,8 @@ This is the `K = 12` constant hard-coded in the Grok-1 coverage validator
 | 0 | 1 | MoE expert projection | `(8, 6144, 32768)` | int8 | quantized `quant.weight` |
 | 1 | 1 | MoE expert projection | `(8, 32768, 6144)` | int8 | quantized `quant.weight` |
 | 2 | 1 | MoE expert projection | `(8, 6144, 32768)` | int8 | quantized `quant.weight` |
-| 3–4 | 2 | Attention projection | `(6144, 6144)` | int8 | quantized `quant.weight` (model-width) |
-| 5–6 | 2 | Attention projection | `(6144, 1024)` | int8 | quantized `quant.weight` (narrow) |
+| 3, 6 | 2 | Attention projection | `(6144, 1024)` | int8 | quantized `quant.weight` (narrow) |
+| 4–5 | 2 | Attention projection | `(6144, 6144)` | int8 | quantized `quant.weight` (model-width) |
 | 7–10 | 4 | RMSNorm | `(6144,)` | f32 | bare `tensor` |
 | 11 | 1 | Router / gate | `(6144, 8)` | f32 | bare `tensor` |
 | (norm singletons) | 1 | Final pre-head norm | `(6144,)` | f32 | bare `tensor` |

--- a/docs/grok1-architecture.md
+++ b/docs/grok1-architecture.md
@@ -76,8 +76,9 @@ This means:
 
 ## The QuantizedWeight8bit structure
 
-Grok-1 does not store any weight tensor as bare FP32. The MoE expert
-projections and attention projections are stored as `QuantizedWeight8bit`
+Grok-1 does not store MoE expert or attention weight tensors as bare
+FP32. Routers, norms, and the token embedding remain bare FP32. The MoE
+expert projections and attention projections are stored as `QuantizedWeight8bit`
 dataclass instances — a JAX-specific packing of an int8 weight body plus
 per-element f32 quantization scales.
 

--- a/docs/grok1-architecture.md
+++ b/docs/grok1-architecture.md
@@ -86,7 +86,7 @@ separate `numpy.ndarray` reduce sites on disk:
 
 1. **The int8 weight body** — the first ndarray reduce site in the shard.
    This is what the parser records as `role = quant.weight`. Shape is
-   `(E, d_ff, d_model)` for up/gate and `(E, d_model, d_ff)` for down,
+   `(E, d_model, d_ff)` for up/gate and `(E, d_ff, d_model)` for down,
    where `E = n_experts = 8`.
 2. **The f32 scales / zero-points** — the second ndarray reduce site.
    This is recorded as `role = quant.scales`. Shape varies (the two

--- a/docs/grok1-architecture.md
+++ b/docs/grok1-architecture.md
@@ -1,0 +1,227 @@
+# Grok-1 Architecture Reference
+
+This document describes the Grok-1 model architecture and how `xai-dissect`
+maps raw checkpoint shards to structural descriptions of it. It does not
+describe the codebase — that is covered in `docs/architecture.md`. This
+document is about the model.
+
+## Model overview
+
+Grok-1 is a 64-layer decoder-only transformer with a Mixture-of-Experts
+(moe) feed-forward block. The architecture was released by xAI as open
+weights in early 2025.
+
+| Hyperparameter | Value |
+|---------------|-------|
+| `d_model` (hidden width) | 6144 |
+| `vocab_size` | 131,072 |
+| `n_blocks` (layers) | 64 |
+| `n_experts` | 8 |
+| `top_k` (experts active per token) | 2 |
+| `d_ff` (per-expert inner width) | 32,768 |
+
+The model uses RMSNorm (no layer norm), rotary position embeddings, and a
+MoE layer in every transformer block. The router is a simple linear layer
+mapping `d_model → n_experts` that selects the top-2 experts per token.
+
+## Per-layer composition
+
+Each of the 64 transformer blocks contains exactly **12 shards** on disk.
+This is the `K = 12` constant hard-coded in the Grok-1 coverage validator
+(`src/inventory/grok1_coverage.rs`). The 12 slots per block are:
+
+| Slot(s) | Count | Tensor type | Shape | dtype | Role |
+|--------|------:|------------|-------|-------|------|
+| 0 | 1 | MoE expert projection | `(8, 6144, 32768)` | int8 | quantized `quant.weight` |
+| 1 | 1 | MoE expert projection | `(8, 32768, 6144)` | int8 | quantized `quant.weight` |
+| 2 | 1 | MoE expert projection | `(8, 6144, 32768)` | int8 | quantized `quant.weight` |
+| 3–4 | 2 | Attention projection | `(6144, 6144)` | int8 | quantized `quant.weight` (model-width) |
+| 5–6 | 2 | Attention projection | `(6144, 1024)` | int8 | quantized `quant.weight` (narrow) |
+| 7 | 1 | Router / gate | `(6144, 8)` | f32 | bare `tensor` |
+| 8–11 | 4 | RMSNorm | `(6144,)` | f32 | bare `tensor` |
+| (norm singletons) | 1 | Final pre-head norm | `(6144,)` | f32 | bare `tensor` |
+| (embedding) | 1 | Token embedding | `(131072, 6144)` | f32 | bare `tensor` |
+
+The top-level shard accounting reconciles exactly:
+
+```
+  1 embedding shard
++ 64 layers × 12 shards/layer  = 768
++ 1 final pre-head norm shard
+= 770 total shards
+```
+
+## How MoE routing works
+
+The router is a single `(d_model=6144, n_experts=8)` f32 weight matrix.
+For each token, it computes an 8-element logit vector, takes `softmax`,
+and selects the top-2 expert indices. The selected expert FFNs process the
+token in parallel and their outputs are summed with a weighted combination.
+
+This means:
+
+- **The router weights are routing-critical**: quantization of the router
+  directly changes which experts process which tokens. A small rounding
+  error in the router can cascade into a completely different expert
+  selection pattern. This is why `routing-critical-tensors.json` contains
+  all 64 router tensors and why the GO/NO-GO gate requires router tensors
+  to remain untouched in the first pilot pass.
+- **The 8 expert weight matrices are compression targets**: the up/gate
+  projections are the primary compression opportunity (they are large,
+  `(8, 6144, 32768)`, and the activation distribution is favorable).
+- **Router top-1 / top-2 agreement** (GO/NO-GO thresholds of 99.0% /
+  99.5%) measures whether quantized router weights select the same experts
+  as the FP32 baseline on a calibration dataset. These are runtime metrics
+  computed by `grok-ozempic`, not by `xai-dissect`.
+
+## The QuantizedWeight8bit structure
+
+Grok-1 does not store any weight tensor as bare FP32. The MoE expert
+projections and attention projections are stored as `QuantizedWeight8bit`
+dataclass instances — a JAX-specific packing of an int8 weight body plus
+per-element f32 quantization scales.
+
+When this dataclass is saved to a pickle shard, it appears as three
+separate `numpy.ndarray` reduce sites on disk:
+
+1. **The int8 weight body** — the first ndarray reduce site in the shard.
+   This is what the parser records as `role = quant.weight`. Shape is
+   `(E, d_ff, d_model)` for up/gate and `(E, d_model, d_ff)` for down,
+   where `E = n_experts = 8`.
+2. **The f32 scales / zero-points** — the second ndarray reduce site.
+   This is recorded as `role = quant.scales`. Shape varies (the two
+   1.5 GiB shard variants differ by exactly 262,144 bytes — 65,536 f32
+   values — due to different quantization side-data shapes across the
+   three expert projection families).
+3. **The per-expert minimum values** (for the down projection only, due to
+   the asymmetric quantization layout used in Grok-1's `QuantizedWeight8bit`
+   dataclass). This is also `role = quant.scales` and appears in the same
+   shard.
+
+`xai-dissect` **does not decode the internal structure of the
+QuantizedWeight8bit dataclass**. It only records the two top-level ndarray
+reduce sites as separate tensor records. The pairing of `quant.weight`
+with its companion `quant.scales` is preserved by the shard grouping (both
+appear in the same shard file), but the exact internal layout is opaque
+to the parser.
+
+## How xai-dissect maps shards to architecture
+
+The 770 shards fall into distinct size buckets. File size alone (verified
+from the actual Grok-1 ckpt-0 run) is sufficient to identify the tensor
+type before reading any shard body:
+
+| File size | Interpretation | Count |
+|----------:|----------------|------:| 
+| 3,221,225,637 B | Token embedding `(131072, 6144) f32` | 1 |
+| 1,611,137,347 B | MoE `QuantizedWeight8bit` shard, variant A | 128 |
+| 1,611,399,491 B | MoE `QuantizedWeight8bit` shard, variant B (262,144 B larger in quantization side-data) | 64 |
+| 37,847,359 B | Attention projection int8, model-width bucket | 64 |
+| 37,761,334 B | Sibling model-width attention projection | 64 |
+| 6,293,814 B | Attention projection int8, narrow bucket | 128 |
+| 196,770 B | Router `(6144, 8) f32` | 64 |
+| 24,727 B | RMSNorm vector `(6144,) f32` | 257 |
+
+The two model-width attention buckets (37,847,359 and 37,761,334) both
+have shape `(6144, 6144)`. The two narrow buckets (6,293,814 and its
+sibling) both have shape `(6144, 1024)`. Q/K/V/O disambiguation is not
+attempted by `xai-dissect` — those roles are downstream disambiguation
+problems for `grok-ozempic`.
+
+## Source-backed slot disambiguation
+
+The MoE expert projection slots (0, 1, 2) are disambiguated using the
+official Grok-1 Haiku model source code:
+
+```text
+slot 0 → moe/linear/w   → gate   (GELU gate branch)
+slot 1 → moe/linear_1/w → down   (consumes gated product as down projection)
+slot 2 → moe/linear_v/w → up     (ungated up/value branch)
+```
+
+This ordering is from `xai-org/grok-1/model.py` and the flattened pytree
+checkpoint restore path in `xai-org/grok-1/checkpoint.py`.
+
+Because the three projection families share the same `(E=8, d_model=6144,
+d_ff=32768)` tensor shape in their outer dimensions, shape alone cannot
+distinguish gate from up. Only source-backed block-slot assignment (using
+the official checkpoint flattening order) resolves this. If Grok-1 had
+used a different ordering in its checkpoint, both would be reported as
+`MoeExpertProjection { projection: unresolved }`.
+
+## Inventory output — real Grok-1 ckpt-0 excerpt
+
+The following is the first block table excerpt from the actual
+`out/grok1_run2_after_fixes_20260525T002904Z/reports/grok-1-official__ckpt-0/inventory.md`
+run against the real Grok-1 ckpt-0 checkpoint:
+
+```markdown
+# xai-dissect inventory
+
+- **model_family**: `grok-1`
+- **checkpoint**: `/home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0`
+- **shards**: 770
+- **schema_version**: 2
+
+## Inferred hyperparameters
+
+| Field | Value |
+| ----- | ----- |
+| vocab_size | 131072 |
+| d_model | 6144 |
+| n_experts | 8 |
+| d_ff | 32768 |
+| n_blocks | 64 |
+
+## Tensor kinds
+
+| Kind | Count | Bytes |
+| ---- | ----: | ----: |
+| attn_proj_i8.model_width | 128 | 4831838208 (4.50 GiB) |
+| attn_proj_i8.narrow | 128 | 805306368 (768.00 MiB) |
+| block_norm | 256 | 6291456 (6.00 MiB) |
+| final_norm | 1 | 24576 (24.00 KiB) |
+| moe_expert.down | 64 | 103079215104 (96.00 GiB) |
+| moe_expert.gate | 64 | 103079215104 (96.00 GiB) |
+| moe_expert.up | 64 | 103079215104 (96.00 GiB) |
+| router | 64 | 12582912 (12.00 MiB) |
+| token_embedding | 1 | 3221225472 (3.00 GiB) |
+
+## Blocks
+
+| Label | Block | Shards | Tensors | Bytes | Kinds |
+| ----- | ----: | ------ | ------: | ----: | ----- |
+| embedding | - | 0..=0 | 1 | 3221225472 (3.00 GiB) | 1xtoken_embedding |
+| block_000 | 0 | 2..=13 | 12 | 4920213504 (4.58 GiB) | 2xattn_proj_i8.model_width, 2xattn_proj_i8.narrow, 4xblock_norm, 1xmoe_expert.down, 1xmoe_expert.gate, 1xmoe_expert.up, 1xrouter |
+| block_001 | 1 | 14..=25 | 12 | 4920213504 (4.58 GiB) | 2xattn_proj_i8.model_width, 2xattn_proj_i8.narrow, 4xblock_norm, 1xmoe_expert.down, 1xmoe_expert.gate, 1xmoe_expert.up, 1xrouter |
+| block_002 | 2 | 26..=37 | 12 | 4920213504 (4.58 GiB) | 2xattn_proj_i8.model_width, 2xattn_proj_i8.narrow, 4xblock_norm, 1xmoe_expert.down, 1xmoe_expert.gate, 1xmoe_expert.up, 1xrouter |
+```
+
+The complete 770-tensor inventory is in `exports/<slug>/inventory.json`. The
+coverage manifest validating this as a complete clean Grok-1 run is at
+`manifests/<slug>/grok1-coverage.json` (see `docs/grok1-coverage-manifest.md`).
+
+## What is not determined by xai-dissect
+
+The following Grok-1 properties cannot be inferred from shard structure
+alone and are left as downstream responsibilities:
+
+- **Attention head structure**: Q/K/V head counts and KV-head grouping.
+  The `(6144, 6144)` and `(6144, 1024)` attention shards are reported as
+  `QuantizedAttentionProjection { width: model_width | narrow }` without
+  Q/K/V/O disambiguation.
+- **Top-k parameter**: the routing top-k of 2 is a training hyperparameter,
+  not a structural property. The router shape `(6144, 8)` is consistent
+  with any top-k ≤ 8.
+- **Rotary position embedding details**: RoPE frequency bases and
+  sequence length configuration are not stored in checkpoint shards.
+- **Activation functions**: GELU is referenced in the model source but
+  not stored in the weights.
+
+## Grok-1 vs. Grok-2
+
+Grok-2 is not yet supported by `xai-dissect`. Expected extension points
+when public Grok-2 weights are released are documented in
+`docs/grok2-future-support.md`. The primary architectural differences to
+anticipate are likely: different expert count, different d_model, and
+potentially a different MoE layout.

--- a/docs/grok1-coverage-manifest.md
+++ b/docs/grok1-coverage-manifest.md
@@ -98,7 +98,8 @@ over a **canonical structural view** that excludes:
 - `shard_path` (machine-local, not portable)
 - `checkpoint_path` (machine-local, not portable)
 - Field ordering (JSON field order must be canonical)
-- `offset` and `nbytes` (may vary slightly across filesystem block sizes)
+- `offset` and `nbytes` (pickle-framing implementation details, not
+  structural tensor properties)
 
 The canonical view is a newline-delimited text blob hashed with FNV-1a
 64-bit. It includes:

--- a/docs/grok1-coverage-manifest.md
+++ b/docs/grok1-coverage-manifest.md
@@ -100,18 +100,28 @@ over a **canonical structural view** that excludes:
 - Field ordering (JSON field order must be canonical)
 - `offset` and `nbytes` (may vary slightly across filesystem block sizes)
 
-The canonical view includes only:
-1. `shard_ordinal` (stable 0-based index)
-2. `in_shard_index` (stable intra-shard index)
-3. `kind.kind` (the classification discriminant)
-4. `kind.detail` (the classification detail, if present)
-5. `shape` (the tensor shape as a list of u64 dimensions)
-6. `role` (parser-level role: tensor / quant_weight / quant_scales)
-7. `dtype` (f32 / i8)
+The canonical view is a newline-delimited text blob hashed with FNV-1a
+64-bit. It includes:
 
-For each tensor, these fields are serialized in a fixed order and
-concatenated into a byte sequence. The full inventory's canonical view
-bytes are then hashed with FNV-1a 64-bit.
+1. **Header lines** (fixed order):
+   - `model_family=<value>`
+   - `schema_version=<value>`
+   - `blocks=<discovered.blocks>`
+   - `tensors=<discovered.tensors>`
+   - `routers=<discovered.routers>`
+   - `expert_families=<discovered.expert_families>`
+   - `unknown_tensors=<discovered.unknown_tensors>`
+2. **Per-tensor lines** (sorted lexicographically), one per inventory
+   tensor, formatted as:
+   `tensor|<structural_name>|<shard_ordinal>|<in_shard_index>|<role>|<dtype>|<shape>|<kind>`
+   where `structural_name` is the block/slot label (for example
+   `block_000.slot_11.router`), `shape` is the rendered dimension list,
+   and `kind` is the short classification label.
+3. **Unknown-slot lines** (if any), formatted as
+   `unknown|<structural_name>|<reason>`.
+
+Machine-local fields (`shard_path`, `checkpoint_path`, `offset`, `nbytes`)
+are excluded. The full canonical text is then hashed with FNV-1a 64-bit.
 
 This means: the checksum is stable across different machine paths,
 different checkpoint directory names, and minor filesystem differences,
@@ -176,7 +186,7 @@ Complete 22-line file from `out/grok1_run2_after_fixes_20260525T002904Z/`:
 {
   "model_family": "grok-1",
   "schema_version": 2,
-  "coverage_schema_version": 1,
+  "coverage_schema_version": 2,
   "validation": "pass",
   "checksum": "fnv1a64:de5a1c978121c62c",
   "expected": {
@@ -191,7 +201,7 @@ Complete 22-line file from `out/grok1_run2_after_fixes_20260525T002904Z/`:
 }
 ```
 
-The two `coverage_schema_version` values distinguish the coverage
-manifest schema (`coverage_schema_version = 1`) from the outer
-`ModelInventory` schema (`schema_version = 2`). This allows the two
-versions to evolve independently.
+The two version fields distinguish the coverage manifest schema
+(`coverage_schema_version = 2`) from the outer `ModelInventory` schema
+(`schema_version = 2`). This allows the two versions to evolve
+independently.

--- a/docs/grok1-coverage-manifest.md
+++ b/docs/grok1-coverage-manifest.md
@@ -1,0 +1,197 @@
+# Grok-1 Coverage Manifest: grok1-map-v1-clean
+
+This document explains the `grok1-coverage.json` manifest produced by
+`xai-dissect`, the `grok1-map-v1-clean` baseline profile, and the
+FNV-1a 64-bit checksum algorithm used for reproducibility verification.
+
+## What is grok1-map-v1-clean?
+
+`grok1-map-v1-clean` is the canonical structural baseline profile for
+Grok-1 ckpt-0. It was derived from the first complete parse of the
+official Grok-1 release and encodes the expected structural invariants
+of a fully-discovered, fully-classified Grok-1 checkpoint:
+
+```text
+blocks            = 64
+tensors           = 770
+routers           = 64
+expert_families   = 192   (3 projection families × 64 layers)
+unknown_tensors   = 0
+```
+
+The name components:
+- `grok1` — Grok-1 family
+- `map` — structural inventory / tensor table
+- `v1` — first stable schema version
+- `clean` — zero unknown tensors, complete classification
+
+When `xai-dissect` validates a checkpoint inventory against this
+profile, it checks that every structural invariant matches before
+allowing the coverage manifest to be written. If any invariant fails,
+`validation` becomes `"fail"` and the manifest is rejected by downstream
+consumers.
+
+## The five validation dimensions
+
+The `Grok1CoverageManifest` encodes two `Grok1CoverageCounts` snapshots:
+
+```json
+{
+  "expected": {
+    "blocks": 64, "tensors": 770, "routers": 64,
+    "expert_families": 192, "unknown_tensors": 0
+  },
+  "discovered": {
+    "blocks": 64, "tensors": 770, "routers": 64,
+    "expert_families": 192, "unknown_tensors": 0
+  }
+}
+```
+
+Each dimension has a specific meaning for Grok-1 quantization readiness:
+
+| Dimension | Value | Why it matters |
+|----------|-------|----------------|
+| `blocks` | 64 | Grok-1 has exactly 64 transformer layers. Any deviation means block assignment failed or the checkpoint is not a standard Grok-1 run. |
+| `tensors` | 770 | 1 embedding + 64×12 block shards + 1 final norm = 770. The count is a strong integrity check — adding or removing shards changes this number. |
+| `routers` | 64 | One router per block. A missing router means block assignment skipped that block. An extra router means shard ordering is ambiguous. |
+| `expert_families` | 192 | 3 projection families (gate, down, up) × 64 layers = 192. All three families must be present per block for the pilot quant plan to be complete. |
+| `unknown_tensors` | 0 | Any unknown tensor means the classifier encountered a shape/dtype combination it could not resolve. Quantization of unknown tensors is risky — they may be structural dependencies. |
+
+## FNV-1a 64-bit checksum algorithm
+
+The checksum in `grok1-coverage.json` is computed to enable reproducible
+comparison of structural inventories without depending on machine-local
+paths. Downstream tooling can recompute the checksum from a new inventory
+run and compare it against the baseline to detect structural drift.
+
+FNV-1a 64-bit is a non-cryptographic hash function chosen for:
+- **Deterministic**: same input always produces the same output
+- **Fast**: O(n) over the byte sequence, no cryptographic overhead
+- **Good avalanche**: small input changes produce large output changes
+- **Well-specified**: no implementation-specific behavior (unlike some
+  non-cryptographic hashes)
+
+### Algorithm
+
+FNV-1a 64-bit processes the input as a sequence of bytes:
+
+```
+hash ← FNV_offset_basis_64   // 14695981039346656037
+for each byte b in input:
+    hash ← hash XOR b
+    hash ← hash × FNV_prime_64 // 1099511628211
+return hash
+```
+
+In hexadecimal, the constants are:
+```
+FNV_offset_basis_64 = 0xcbf29ce484222325
+FNV_prime_64          = 0x100000001b3
+```
+
+### Canonical representation
+
+The checksum is **not** computed over the full JSON file. It is computed
+over a **canonical structural view** that excludes:
+
+- `shard_path` (machine-local, not portable)
+- `checkpoint_path` (machine-local, not portable)
+- Field ordering (JSON field order must be canonical)
+- `offset` and `nbytes` (may vary slightly across filesystem block sizes)
+
+The canonical view includes only:
+1. `shard_ordinal` (stable 0-based index)
+2. `in_shard_index` (stable intra-shard index)
+3. `kind.kind` (the classification discriminant)
+4. `kind.detail` (the classification detail, if present)
+5. `shape` (the tensor shape as a list of u64 dimensions)
+6. `role` (parser-level role: tensor / quant_weight / quant_scales)
+7. `dtype` (f32 / i8)
+
+For each tensor, these fields are serialized in a fixed order and
+concatenated into a byte sequence. The full inventory's canonical view
+bytes are then hashed with FNV-1a 64-bit.
+
+This means: the checksum is stable across different machine paths,
+different checkpoint directory names, and minor filesystem differences,
+but will change if the tensor classification, shape, or ordering changes.
+
+### Example checksum from the real Grok-1 run
+
+From `out/grok1_run2_after_fixes_20260525T002904Z/`:
+
+```json
+{
+  "checksum": "fnv1a64:de5a1c978121c62c",
+  "validation": "pass"
+}
+```
+
+A downstream pipeline that reruns `xai-dissect inventory` on the same
+checkpoint on a different machine should produce the same checksum if:
+- The Grok-1 checkpoint is byte-identical
+- The classification logic has not changed
+- The schema version is the same
+
+If the checksum changes, the structural inventory has drifted — the
+grok-ozempic consumer should reject the bundle and re-run with a
+validated baseline.
+
+## How downstream consumers use the manifest
+
+The `grok1-coverage.json` manifest is the **fail-closed gate** for the
+grok-ozempic handoff. Consumer logic must verify all of:
+
+```text
+validation       = "pass"
+expected.blocks = discovered.blocks = 64
+expected.tensors = discovered.tensors = 770
+expected.routers = discovered.routers = 64
+expected.expert_families = discovered.expert_families = 192
+expected.unknown_tensors = discovered.unknown_tensors = 0
+unknown_slots = []   (empty array — no unclassified tensors)
+```
+
+If any check fails, the bundle is rejected. The `checksum` field is
+advisory — it provides fast approximate comparison without re-running the
+full inventory, but the explicit equality checks above are the normative
+acceptance criteria.
+
+## Repacked Grok-1
+
+Some downstream pipelines may re-shard or repack the Grok-1 checkpoint into
+a different storage format (e.g., safetensors or a memory-mapped layout).
+When this happens, the shard-level structure changes, so the inventory
+would be different. The `grok1-map-v1-clean` profile does not directly
+handle repacked checkpoints — the consumer should regenerate the
+coverage manifest from the repacked layout and treat the new checksum
+as the baseline for that layout.
+
+## The grok1-coverage.json from the real Grok-1 run
+
+Complete 22-line file from `out/grok1_run2_after_fixes_20260525T002904Z/`:
+
+```json
+{
+  "model_family": "grok-1",
+  "schema_version": 2,
+  "coverage_schema_version": 1,
+  "validation": "pass",
+  "checksum": "fnv1a64:de5a1c978121c62c",
+  "expected": {
+    "blocks": 64, "tensors": 770, "routers": 64,
+    "expert_families": 192, "unknown_tensors": 0
+  },
+  "discovered": {
+    "blocks": 64, "tensors": 770, "routers": 64,
+    "expert_families": 192, "unknown_tensors": 0
+  },
+  "unknown_slots": []
+}
+```
+
+The two `coverage_schema_version` values distinguish the coverage
+manifest schema (`coverage_schema_version = 1`) from the outer
+`ModelInventory` schema (`schema_version = 2`). This allows the two
+versions to evolve independently.

--- a/docs/metric-definitions.md
+++ b/docs/metric-definitions.md
@@ -18,7 +18,7 @@ repos control) are clearly documented.
 
 **Threshold**: `>= 99.0%`
 
-### Definition
+### Definition (Router top-1 agreement)
 
 For a calibration dataset of input tokens, compute the router's top-1
 expert selection (the expert with the highest logit) under the FP32
@@ -96,7 +96,7 @@ affects model quality.
 
 **Threshold**: `>= 0.995`
 
-### Definition
+### Definition (Block output cosine)
 
 For each of the 64 transformer blocks, run a forward pass with the same
 input activations through both the FP32 baseline and the quantized

--- a/docs/metric-definitions.md
+++ b/docs/metric-definitions.md
@@ -1,0 +1,193 @@
+# GO/NO-GO Threshold Methodology
+
+This document defines the metrics referenced in `docs/GO_NO_GO.md` and
+explains how each is computed, which downstream repo is responsible for
+measuring it, and what would cause it to fail.
+
+`xai-dissect` is a **structural analysis tool**. It does not execute
+model inference and cannot compute these metrics directly. It produces the
+structural artifacts (inventory, router-critical-tensors, coverage
+manifest) that enable downstream repos to perform the measurements. The
+metrics below are defined here so that both the structural gate (which
+`xai-dissect` controls) and the runtime measurement (which downstream
+repos control) are clearly documented.
+
+---
+
+## Router top-1 agreement
+
+**Threshold**: `>= 99.0%`
+
+### Definition
+
+For a calibration dataset of input tokens, compute the router's top-1
+expert selection (the expert with the highest logit) under the FP32
+baseline and under the quantized pilot. The agreement is the fraction of
+tokens for which both the FP32 router and the quantized router select the
+same expert index.
+
+```
+agreement = (1 / N) * Σ_{i=1}^{N} [ argmax(router_FP32(token_i)) == argmax(router_Q(token_i)) ]
+```
+
+Where `[condition]` is 1 if the condition is true, 0 otherwise.
+
+### Why 99.0%?
+
+The router is the only path through which MoE expert selection flows.
+A 1% disagreement rate means that 1 in 100 tokens reaches a different
+expert, which cascades into different FFN computation and different
+model outputs. At scale (billions of tokens), even a 0.5% router
+disagreement can measurably shift output distributions. The 99.0%
+threshold was chosen conservatively based on empirical sensitivity
+analysis on comparable MoE models.
+
+### What would cause failure
+
+- Router weights are quantized to int8 with insufficient scale
+  resolution, pushing the softmax output near the boundary between
+  two experts
+- Per-tensor quantization of the router changes the logit magnitudes
+  enough to flip borderline decisions
+- Calibration dataset is too small to be representative of the target
+  distribution
+
+### Responsible downstream repo
+
+**grok-ozempic** — it executes the bounded pilot runs, captures router
+logits for the calibration inputs, and computes the agreement fraction.
+`xai-dissect` supplies `routing-critical-tensors.json` so grok-ozempic
+knows exactly which tensors must be preserved as FP32.
+
+---
+
+## Router top-2 set agreement
+
+**Threshold**: `>= 99.5%`
+
+### Definition
+
+The top-2 set is the unordered pair of the two highest-logit experts.
+Even if the top-1 expert differs, the set agreement measures whether the
+routing **context** is preserved:
+
+```
+set_agreement = (1 / N) * Σ_{i=1}^{N} [ top2_set_FP32(token_i) == top2_set_Q(token_i) ]
+```
+
+Where `top2_set` is the set `{expert_index_top1, expert_index_top2}`.
+
+The top-2 threshold is higher than top-1 because the set agreement
+matters for expert-load balancing — even if the first expert is the
+same, a swapped second expert changes which FFN processes the token
+and how the weighted sum is computed.
+
+### Why 99.5%?
+
+Top-2 agreement is a tighter bound. If the top-1 is correct 99.0% of
+the time and the top-2 is correct 99.5% of the time, then the router
+is mostly stable but the secondary expert selection is more sensitive.
+The higher threshold reflects that secondary expert selection still
+affects model quality.
+
+---
+
+## Block output cosine
+
+**Threshold**: `>= 0.995`
+
+### Definition
+
+For each of the 64 transformer blocks, run a forward pass with the same
+input activations through both the FP32 baseline and the quantized
+pilot. Compare the block output activations (the residual stream after the
+block's computation) using cosine similarity:
+
+```
+cosine(A, B) = (A · B) / (||A|| * ||B||)
+```
+
+Aggregate over all calibration tokens and report the mean cosine per
+block, then report the minimum across all 64 blocks.
+
+```
+block_output_cosine = min_{block ∈ blocks} mean_{token ∈ calibration} cosine(output_FP32, output_Q)
+```
+
+### Why is this different from router agreement?
+
+Router agreement measures the **input** to the MoE layer (which expert is
+selected). Block output cosine measures the **output** of the entire
+block — including how the selected experts processed the token, how the
+residual stream was accumulated, and how RMSNorm transformed the
+activations. A good router agreement score does not guarantee a good
+block output cosine — quantization noise in the expert FFN layers can
+distort the block output even if routing was preserved exactly.
+
+### Why 0.995?
+
+A cosine of 0.995 means the block outputs are very close — at the level
+of numerical noise from FP16 accumulation differences. Lower values
+indicate that quantization error is compounding across layers. This
+threshold is conservative for Grok-1's 64-layer depth; accumulated error
+across 64 layers at 0.99 per layer would be catastrophic.
+
+### Responsible downstream repo
+
+**grok-ozempic** — it captures intermediate activation tensors from the
+bounded pilot runs and computes the per-block cosine similarity.
+
+---
+
+## All other metrics in route-preservation-report.json
+
+The full `route-preservation-report.json` (from `tests/fixtures/exports/route-preservation.snap`)
+declares 15 metrics across four scopes. All have `status: "unknown"` in
+the structural report because they require downstream pilot evidence:
+
+| Metric | Scope | Threshold | Requires |
+|--------|-------|-----------|---------|
+| `router_top1_agreement` | router_behavior | >= 99.0% | grok-ozempic pilot run |
+| `router_top2_set_agreement` | router_behavior | >= 99.5% | grok-ozempic pilot run |
+| `expert_load_distribution_delta` | router_behavior | — | routing traces from grok-ozempic |
+| `expert_load_js_divergence` | router_behavior | — | routing traces from grok-ozempic |
+| `router_logit_rank_correlation` | router_behavior | — | logit captures from grok-ozempic |
+| `block_output_cosine` | block_behavior | >= 0.995 | activation captures from grok-ozempic |
+| `block_output_rmse` | block_behavior | — | activation captures from grok-ozempic |
+| `residual_stream_drift` | block_behavior | — | activation captures from grok-ozempic |
+| `weight_reconstruction_mse` | weight_reconstruction | — | weight diff from grok-ozempic |
+| `weight_cosine_similarity` | weight_reconstruction | — | weight diff from grok-ozempic |
+| `weight_max_absolute_error` | weight_reconstruction | — | weight diff from grok-ozempic |
+| `per_channel_scale_error_summary` | weight_reconstruction | — | quantization metadata from grok-ozempic |
+| `logit_kl` | model_behavior | — | logit captures from grok-ozempic |
+| `perplexity_delta` | model_behavior | — | perplexity evaluation from grok-ozempic |
+| `generation_sanity_summary` | model_behavior | — | generation run from grok-ozempic |
+
+`xai-dissect` defines the metric surface and the pass/fail thresholds.
+It does not execute inference and cannot populate the observed values.
+
+---
+
+## What xai-dissect guarantees vs. what it requires
+
+`xai-dissect` **guarantees** (through the structural inventory and
+coverage manifest):
+- The structural inventory is complete and deterministic
+- Every tensor that should be FP32 (router, norms) is correctly classified
+- Every expert family is present and named consistently
+- The checksum is reproducible across reruns on the same checkpoint
+
+`xai-dissect` **requires** (before GO is granted):
+- `grok1-coverage.json` passes validation with `grok1-map-v1-clean`
+- `routing-critical-tensors.json` identifies all 64 routers
+- All planning artifacts (`quant-plan.json`, `pilot-selection-plan.json`,
+  `route-preservation-report.json`) have been emitted
+- The downstream runbook exists (linked in the PR checklist)
+
+`xai-dissect` **cannot** guarantee:
+- Router top-1 agreement >= 99.0% (requires inference)
+- Block output cosine >= 0.995 (requires inference)
+- Perplexity delta (requires inference)
+
+These are the responsibility of `grok-ozempic` and are tracked as the
+"observed" values in the route-preservation report.

--- a/docs/metric-definitions.md
+++ b/docs/metric-definitions.md
@@ -65,7 +65,7 @@ knows exactly which tensors must be preserved as FP32.
 
 **Threshold**: `>= 99.5%`
 
-### Definition
+### Definition (Router top-2 set agreement)
 
 The top-2 set is the unordered pair of the two highest-logit experts.
 Even if the top-1 expert differs, the set agreement measures whether the
@@ -132,7 +132,7 @@ indicate that quantization error is compounding across layers. This
 threshold is conservative for Grok-1's 64-layer depth; accumulated error
 across 64 layers at 0.99 per layer would be catastrophic.
 
-### Responsible downstream repo
+### Responsible downstream repo (Block output cosine)
 
 **grok-ozempic** — it captures intermediate activation tensors from the
 bounded pilot runs and computes the per-block cosine similarity.

--- a/docs/quantized-weight-internals.md
+++ b/docs/quantized-weight-internals.md
@@ -38,7 +38,7 @@ format is:
 ```text
 \x80\x04           PROTO magic (version 4)
 <opcode stream>   variable-length opcode encoding
-\x94              STOP opcode
++\x2e              STOP opcode
 ```
 
 Each ndarray in the stream is encoded as a `GLOBAL` or `REDUCE` opcode

--- a/docs/quantized-weight-internals.md
+++ b/docs/quantized-weight-internals.md
@@ -1,0 +1,137 @@
+# QuantizedWeight8bit Pickle Internals
+
+This document explains how Grok-1's expert and attention projection
+tensors are stored on disk as `QuantizedWeight8bit` JAX dataclass
+instances, and how `xai-dissect` parses them without a Python interpreter.
+
+## The JAX quantization packing
+
+JAX models that support int8 quantized inference typically store
+quantized weights as a dataclass with two fields:
+
+- `weight`: the int8 weight matrix, stored as a flat ndarray
+- `quantize_state`: the f32 quantization scales and zero-points
+
+When Grok-1 saves its weights, the `QuantizedWeight8bit` dataclass is
+flattened into a pytree and each leaf is saved as a separate
+`numpy.ndarray` in the checkpoint. This means a single quantized projection
+weight matrix appears as **three separate ndarray reduce sites** in the
+pickle stream:
+
+| Reduce site order | Role | dtype | Shape | xai-dissect role |
+|-----------------|------|-------|-------|-----------------|
+| 1st in shard | int8 weight body | i8 | `(E, d_ff, d_model)` or `(E, d_model, d_ff)` | `quant.weight` |
+| 2nd in shard | quantization scales | f32 | varies | `quant.scales` |
+| 3rd in shard | min values (asymmetric) | f32 | varies | `quant.scales` |
+
+`xai-dissect` does **not** decode the internal structure of this
+dataclass. It records each top-level ndarray reduce site as a separate
+`TensorInfo` record, preserving the pairing through the shard boundary
+(the `quant.weight` and both `quant.scales` records share the same
+`shard_path`).
+
+## PROTO 4 pickle framing
+
+The Grok-1 checkpoint shards are pickle files using PROTO version 4. The
+format is:
+
+```text
+\x80\x04           PROTO magic (version 4)
+<opcode stream>   variable-length opcode encoding
+\x94              STOP opcode
+```
+
+Each ndarray in the stream is encoded as a `GLOBAL` or `REDUCE` opcode
+followed by metadata and a byte payload. The key opcodes `xai-dissect`
+recognizes are:
+
+| Opcode | Value | Meaning |
+|--------|-------|---------|
+| `PROTO` | `\x80` | Version marker — must be `\x80\x04` for Grok-1 shards |
+| `GLOBAL` | `\x71` | Module + name reference (e.g. `numpy.core.multiarray`) |
+| `REDUCE` | `\x72` | Callable + state (the dataclass reducer) |
+| `BINPUT` | `\x61`..`\x80` | Short int marker for small memo indices |
+| `MEMOIZE` | `\x94` | Store top of stack in memo |
+| `STOP` | `\x2e` | End of frame |
+
+`xai-dissect` walks the opcode stream looking for `numpy.ndarray` reduce
+sites. It matches the magic `\x80\x04`, then scans forward through opcodes
+counting `REDUCE` + `BINPUT` pairs (for the `__reduce__` protocol used by
+JAX's pytree flattening). Every `numpy.core.multiarray` reducer it
+encounters produces one raw tensor record.
+
+## How QuantizedWeight8bit pairing works in xai-dissect
+
+The parser (`src/parser/mod.rs`) processes each shard as follows:
+
+1. Memory-map the shard file.
+2. Verify `\x80\x04` at the head — reject if not PROTO 4.
+3. Walk the opcode stream left-to-right.
+4. For each `numpy.ndarray` reduce site found, emit a `RawTensor`:
+   - `role = quant.weight` if it is the first ndarray in the shard
+   - `role = quant.scales` if it is the second ndarray in the shard
+   - `role = quant.scales` if it is the third ndarray in the shard
+5. The role assignment is structural — it does not examine the ndarray
+   dtype or contents.
+
+This means every Grok-1 MoE/attention shard produces three separate
+records. Grok-1 never stores bare weight tensors mixed with quantized
+ones in the same shard file — the pairing is always within a single shard.
+
+## Why shape alone cannot disambiguate gate from up
+
+The gate and up projections both have the outer shape `(E=8, d_model=6144)`
+in Grok-1. When `xai-dissect` first encounters a 3-D int8 `quant.weight`
+with `dims[0] == n_experts == 8`, it initially assigns
+`MoeExpertProjection { projection: unresolved }`. The resolved projection
+labels (gate, down, up) are applied later by the block-slot assignment
+pass, which uses the official Grok-1 Haiku checkpoint ordering:
+
+```text
+slot 0 → moe/linear/w   → gate   (GELU gate branch, input × d_ff)
+slot 1 → moe/linear_1/w → down   (consumes gated input, d_ff × d_model)
+slot 2 → moe/linear_v/w → up     (ungated value, d_model × d_ff)
+```
+
+The shape for gate and up is identical: `(8, 6144, 32768)`. The down
+projection is transposed: `(8, 32768, 6144)`, so it is always identified
+unambiguously.
+
+## The two 1.5 GiB shard variants
+
+In the real Grok-1 ckpt-0 run (`out/grok1_run2_after_fixes_20260525T002904Z/`),
+the MoE `QuantizedWeight8bit` shards fall into two size buckets:
+
+| Size | Bytes | Delta | Interpretation |
+|-----:|------:|------:|-----------------|
+| variant A | 1,611,137,347 | — | Base int8 body + standard quantization side-data |
+| variant B | 1,611,399,491 | +262,144 | Same int8 body + 262,144 extra f32 values in the quantization state |
+
+262,144 bytes = 65,536 f32 values. This is exactly the size of one
+additional quantization axis (e.g., per-min-max range vs per-channel
+scales) on one of the three projection families. The specific variant
+distribution across the 192 MoE shards (128 × variant A, 64 × variant B)
+is consistent with one projection family using a different per-axis
+quantization scheme than the other two.
+
+`xai-dissect` does not decode the internal quantization scheme. The
+variant delta is observable in file size, but its meaning is opaque to
+the parser. Both variants produce identical `role = quant.weight` records.
+
+## Why int8 instead of FP16 or BF16?
+
+Int8 quantization was chosen for the expert projections because:
+
+- Memory: 8 experts × 32,768 FFN width × 6,144 model width × 1 byte =
+  1.6 GiB per projection family per layer, vs 6.4 GiB for FP32. The
+  memory savings enable fitting the full model in GPU memory.
+- Bandwidth: Router computations are memory-bandwidth-bound. Int8
+  weight reads reduce bandwidth by 4×.
+- Accuracy: The per-expert scales capture the distribution shape well
+  enough that the quantization error is dominated by the clipping noise,
+  not the int8 representation.
+
+The router weights (`(d_model, n_experts) = (6144, 8)`) are stored as
+bare FP32 (192 KiB per layer). Quantizing the router changes the expert
+selection behavior in a non-linear way, which is why the GO/NO-GO gate
+requires `passthrough_f32_router` in the first pilot pass.

--- a/docs/quantized-weight-internals.md
+++ b/docs/quantized-weight-internals.md
@@ -20,15 +20,15 @@ pickle stream:
 
 | Reduce site order | Role | dtype | Shape | xai-dissect role |
 |-----------------|------|-------|-------|-----------------|
-| 1st in shard | int8 weight body | i8 | `(E, d_ff, d_model)` or `(E, d_model, d_ff)` | `quant.weight` |
+| 1st in shard | int8 weight body | i8 | `(E, d_model, d_ff)` for gate/up; `(E, d_ff, d_model)` for down | `quant.weight` |
 | 2nd in shard | quantization scales | f32 | varies | `quant.scales` |
-| 3rd in shard | min values (asymmetric) | f32 | varies | `quant.scales` |
+| 3rd in shard | min values (asymmetric) | f32 | varies | bare `tensor` |
 
 `xai-dissect` does **not** decode the internal structure of this
 dataclass. It records each top-level ndarray reduce site as a separate
 `TensorInfo` record, preserving the pairing through the shard boundary
-(the `quant.weight` and both `quant.scales` records share the same
-`shard_path`).
+(the `quant.weight` and `quant.scales` records share the same `shard_path`;
+additional f32 ndarrays remain bare `tensor` records).
 
 ## PROTO 4 pickle framing
 
@@ -38,7 +38,7 @@ format is:
 ```text
 \x80\x04           PROTO magic (version 4)
 <opcode stream>   variable-length opcode encoding
-+\x2e              STOP opcode
+\x2e              STOP opcode
 ```
 
 Each ndarray in the stream is encoded as a `GLOBAL` or `REDUCE` opcode
@@ -67,21 +67,25 @@ The parser (`src/parser/mod.rs`) processes each shard as follows:
 1. Memory-map the shard file.
 2. Verify `\x80\x04` at the head — reject if not PROTO 4.
 3. Walk the opcode stream left-to-right.
-4. For each `numpy.ndarray` reduce site found, emit a `RawTensor`:
-   - `role = quant.weight` if it is the first ndarray in the shard
-   - `role = quant.scales` if it is the second ndarray in the shard
-   - `role = quant.scales` if it is the third ndarray in the shard
-5. The role assignment is structural — it does not examine the ndarray
-   dtype or contents.
+4. For each `QuantizedWeight8bit` reduce site, assign roles by dtype:
+   - `role = quant.weight` for the `i8` ndarray in the site
+   - `role = quant.scales` for the first `f32` ndarray after that `i8`
+     body within the same site
+   - any additional `f32` ndarrays in the site remain bare `tensor`
+5. The role assignment is dtype-aware — it does not rely on ndarray
+   order alone.
 
-This means every Grok-1 MoE/attention shard produces three separate
-records. Grok-1 never stores bare weight tensors mixed with quantized
-ones in the same shard file — the pairing is always within a single shard.
+This means every Grok-1 MoE/attention shard produces multiple records
+(typically three ndarray reduce sites, with one `quant.weight`, one
+`quant.scales`, and any remaining f32 leaves as bare `tensor`). Grok-1
+never stores bare weight tensors mixed with quantized ones in the same
+shard file — the pairing is always within a single shard.
 
 ## Why shape alone cannot disambiguate gate from up
 
-The gate and up projections both have the outer shape `(E=8, d_model=6144)`
-in Grok-1. When `xai-dissect` first encounters a 3-D int8 `quant.weight`
+The gate and up projections both have the outer shape
+`(E=8, d_model=6144, d_ff=32768)` in Grok-1. When `xai-dissect` first
+encounters a 3-D int8 `quant.weight`
 with `dims[0] == n_experts == 8`, it initially assigns
 `MoeExpertProjection { projection: unresolved }`. The resolved projection
 labels (gate, down, up) are applied later by the block-slot assignment
@@ -123,7 +127,7 @@ the parser. Both variants produce identical `role = quant.weight` records.
 Int8 quantization was chosen for the expert projections because:
 
 - Memory: 8 experts × 32,768 FFN width × 6,144 model width × 1 byte =
-  1.6 GiB per projection family per layer, vs 6.4 GiB for FP32. The
+  1.5 GiB per projection family per layer, vs 6.0 GiB for FP32. The
   memory savings enable fitting the full model in GPU memory.
 - Bandwidth: Router computations are memory-bandwidth-bound. Int8
   weight reads reduce bandwidth by 4×.

--- a/docs/run-examples.md
+++ b/docs/run-examples.md
@@ -1,0 +1,793 @@
+# Annotated CLI Walkthrough
+
+This document walks through every `xai-dissect` subcommand with annotated
+examples drawn from the real Grok-1 ckpt-0 run at
+`out/grok1_run2_after_fixes_20260525T002904Z/`. For each command the
+corresponding output artifact is shown with field-level annotations
+explaining what each value means and where it comes from.
+
+The checkpoint path used throughout is the real Grok-1 ckpt-0 location on
+this system:
+
+```
+/home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0
+```
+
+The unified output root used in these examples is `out/`, producing the
+slug `grok-1-official__ckpt-0`.
+
+---
+
+## `dissect` — Raw Parser Output
+
+`dissect` opens a single shard and prints the raw pickle-grammar tensor
+table without any classification or block grouping.
+
+```bash
+./target/release/xai-dissect dissect \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --limit 1
+```
+
+Output for `tensor00000_000` (the embedding shard):
+
+```text
+tensor00000_000:
+  offset=151  nbytes=3221225472  dtype=f32  shape=(131072, 6144)
+```
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| `offset=151` | Byte offset within the shard file where the numpy ndarray payload begins |
+| `nbytes=3221225472` | Payload size in bytes (131072 × 6144 × 4 = 3,221,225,472) |
+| `dtype=f32` | IEEE 754 binary32 — bare float tensor, no quantization |
+| `shape=(131072, 6144)` | Row-major 2-D shape: vocab rows × d_model columns |
+
+`dissect` is the only command that does **not** support `--output-root`
+or `--checkpoint-slug`. It is raw parser output only.
+
+---
+
+## `inventory` — Checkpoint Cartography
+
+The `inventory` command is the primary artifact. Its JSON output
+(`exports/<slug>/inventory.json`) is the canonical tensor catalog for the
+grok-ozempic handoff contract.
+
+```bash
+./target/release/xai-dissect inventory \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --output-root out
+```
+
+### Annotated `inventory.json` excerpt — first 4 tensor records
+
+```json
+{
+  "model_family": "grok-1",
+  "checkpoint_path": "/home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0",
+  "shard_count": 770,
+  "inferred": {
+    "vocab_size": 131072,
+    "d_model": 6144,
+    "n_experts": 8,
+    "d_ff": 32768,
+    "n_blocks": 64
+  },
+  "tensors": [
+    {
+      // Absolute path on disk — informative only; downstream consumers
+      // use shard_ordinal + in_shard_index as the stable tensor identity
+      "shard_path": "/home/raulmc/Downloads/.../ckpt-0/tensor00000_000",
+      // 0-based ordinal in the sorted shard list — stable across reruns
+      "shard_ordinal": 0,
+      // 0-based index within this shard (shards can hold >1 tensor for
+      // QuantizedWeight8bit dataclasses)
+      "in_shard_index": 0,
+      // Parser-level role: bare ndarray vs int8 weight vs f32 scales
+      "role": "tensor",
+      "dtype": "f32",
+      "shape": [131072, 6144],
+      // Byte offset of payload within the shard file
+      "offset": 151,
+      // Payload length in bytes
+      "nbytes": 3221225472,
+      // Semantic classification — the tagged-union TensorKind
+      "kind": {
+        "kind": "token_embedding"
+      },
+      // block_index is null for embedding and final norm singletons
+      "block_index": null,
+      "block_slot": null
+    },
+    {
+      "shard_path": "/home/raulmc/Downloads/.../ckpt-0/tensor00001_000",
+      "shard_ordinal": 1,
+      "in_shard_index": 0,
+      "role": "tensor",
+      "dtype": "f32",
+      "shape": [6144],
+      "offset": 146,
+      "nbytes": 24576,
+      // Final pre-head norm — promoted from block_norm by block assignment
+      "kind": { "kind": "final_norm" },
+      "block_index": null,
+      "block_slot": null
+    },
+    {
+      "shard_path": "/home/raulmc/Downloads/.../ckpt-0/tensor00002_000",
+      "shard_ordinal": 2,
+      "in_shard_index": 0,
+      "role": "quant_weight",
+      "dtype": "i8",
+      // 3-D int8 body for 8-expert × d_model × d_ff MoE projection
+      "shape": [8, 6144, 32768],
+      "offset": 201,
+      "nbytes": 1610612736,
+      // gate/down/up disambiguated from official Grok-1 source ordering
+      "kind": {
+        "kind": "moe_expert_projection",
+        "detail": { "projection": "gate" }
+      },
+      // block_index = 0 for block_000; block_slot = 0 for slot 0
+      "block_index": 0,
+      "block_slot": 0
+    },
+    {
+      "shard_path": "/home/raulmc/Downloads/.../ckpt-0/tensor00003_000",
+      "shard_ordinal": 3,
+      "in_shard_index": 0,
+      "role": "quant_weight",
+      "dtype": "i8",
+      // The down projection has transposed inner dims: (E, d_ff, d_model)
+      "shape": [8, 32768, 6144],
+      "offset": 201,
+      "nbytes": 1610612736,
+      "kind": {
+        "kind": "moe_expert_projection",
+        "detail": { "projection": "down" }
+      },
+      "block_index": 0,
+      "block_slot": 1
+    }
+    // ... continues for all 770 tensors
+  ]
+  // schema_version: 2 — bump on any incompatible JSON shape change
+}
+```
+
+### `checkpoint-inventory-snapshot.json` excerpt
+
+This compact manifest is a dashboard-friendly summary. The embedding
+block plus the first two transformer blocks:
+
+```json
+{
+  "model_family": "grok-1",
+  "shard_count": 770,
+  "inferred": {
+    "vocab_size": 131072,
+    "d_model": 6144,
+    "n_experts": 8,
+    "d_ff": 32768,
+    "n_blocks": 64
+  },
+  "total_tensors": 770,
+  "total_nbytes": 318114914304,
+  "blocks": [
+    {
+      "label": "embedding",
+      "block_index": null,
+      "shard_range": { "start": 0, "end_inclusive": 0 },
+      "tensor_count": 1,
+      "total_nbytes": 3221225472,
+      "kind_labels": ["token_embedding"]
+    },
+    {
+      "label": "block_000",
+      "block_index": 0,
+      "shard_range": { "start": 2, "end_inclusive": 13 },
+      "tensor_count": 12,
+      "total_nbytes": 4920213504,
+      // Every kind appearing in this block
+      "kind_labels": [
+        "attn_proj_i8.model_width",
+        "attn_proj_i8.narrow",
+        "block_norm",
+        "moe_expert.down",
+        "moe_expert.gate",
+        "moe_expert.up",
+        "router"
+      ]
+    },
+    {
+      "label": "block_001",
+      "block_index": 1,
+      "shard_range": { "start": 14, "end_inclusive": 25 },
+      "tensor_count": 12,
+      "total_nbytes": 4920213504,
+      "kind_labels": [
+        "attn_proj_i8.model_width",
+        "attn_proj_i8.narrow",
+        "block_norm",
+        "moe_expert.down",
+        "moe_expert.gate",
+        "moe_expert.up",
+        "router"
+      ]
+    }
+    // blocks 2..63 follow the same pattern
+  ]
+}
+```
+
+---
+
+## `experts` — Expert Atlas
+
+The expert atlas resolves MoE projection identities per block and maps
+each of the 8 expert indices to the physical tensors that carry their
+parameters.
+
+```bash
+./target/release/xai-dissect experts \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --output-root out
+```
+
+### Annotated `experts.json` excerpt — block_000
+
+```json
+{
+  "model_family": "grok-1",
+  "relevant_block_count": 64,
+  "expected_experts_per_block": 8,
+  "blocks": [
+    {
+      "block_index": 0,
+      "shard_range": { "start": 2, "end_inclusive": 13 },
+      "expert_count": 8,
+      "tensors": [
+        {
+          "shard_ordinal": 2,
+          "in_shard_index": 0,
+          "block_slot": 0,
+          "role": "quant_weight",
+          "dtype": "i8",
+          "shape": [8, 6144, 32768],
+          "kind_label": "moe_expert.gate",
+          "projection": "gate",
+          // expert_axis = 0 means the expert dimension is the leading dim
+          "expert_axis": 0,
+          "expert_count": 8,
+          "family_label": "expert_slot_00",
+          // Structural name used in routing-critical-tensors.json
+          "structural_name": "block_000.expert_slot_00"
+        },
+        {
+          "shard_ordinal": 3,
+          "in_shard_index": 0,
+          "block_slot": 1,
+          "role": "quant_weight",
+          "dtype": "i8",
+          "shape": [8, 32768, 6144],
+          "kind_label": "moe_expert.down",
+          "projection": "down",
+          "expert_axis": 0,
+          "expert_count": 8,
+          "family_label": "expert_slot_01",
+          "structural_name": "block_000.expert_slot_01"
+        },
+        {
+          "shard_ordinal": 4,
+          "in_shard_index": 0,
+          "block_slot": 2,
+          "role": "quant_weight",
+          "dtype": "i8",
+          "shape": [8, 6144, 32768],
+          "kind_label": "moe_expert.up",
+          "projection": "up",
+          "expert_axis": 0,
+          "expert_count": 8,
+          "family_label": "expert_slot_02",
+          "structural_name": "block_000.expert_slot_02"
+        }
+      ],
+      "experts": [
+        {
+          "expert_index": 0,
+          "tensors": [
+            {
+              "family_label": "expert_slot_00",
+              "structural_name": "block_000.expert_slot_00.expert_00",
+              "source_shard_ordinal": 2,
+              "source_in_shard_index": 0,
+              "source_block_slot": 0,
+              "projection": "gate",
+              "dtype": "i8",
+              // Slice shape is the per-expert slice: (d_model, d_ff)
+              "slice_shape": [6144, 32768]
+            },
+            {
+              "family_label": "expert_slot_01",
+              "structural_name": "block_000.expert_slot_01.expert_00",
+              "source_shard_ordinal": 3,
+              "source_in_shard_index": 0,
+              "source_block_slot": 1,
+              "projection": "down",
+              "dtype": "i8",
+              // Slice shape is (d_ff, d_model) for the down projection
+              "slice_shape": [32768, 6144]
+            }
+            // expert_index 1..7 follow identically
+          ]
+        }
+        // expert_index 1..7
+      ]
+    }
+    // blocks 1..63 follow the same structure
+  ]
+}
+```
+
+---
+
+## `routing-report` — Routing Structure Inspection
+
+```bash
+./target/release/xai-dissect routing-report \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --output-root out
+```
+
+### Annotated `routing-report.json` excerpt — block_000 router
+
+```json
+{
+  "relevant_block_count": 64,
+  "expected_experts_per_router": 8,
+  "candidate_tensors": [
+    {
+      "shard_ordinal": 13,
+      "in_shard_index": 0,
+      "block_index": 0,
+      "block_slot": 11,
+      "role": "tensor",
+      "dtype": "f32",
+      "shape": [6144, 8],
+      "kind_label": "router",
+      // d_model (6144) maps to expert logits (8) — DModelToExperts orientation
+      "orientation": "d_model_to_experts",
+      // The leading dim is d_model, the trailing dim is n_experts
+      "expert_axis": 1,
+      "linked_expert_count": 8,
+      "matches_inferred_expert_count": true,
+      "structural_name": "block_000.routing_slot_11",
+      "gate_metrics": {
+        "total_elements": 49152,
+        "total_nbytes": 196608,
+        "input_width": 6144,
+        "output_width": 8,
+        "expert_count": 8,
+        "logits_per_input": 8
+      }
+    }
+    // 63 more candidates (one per block) follow
+  ]
+}
+```
+
+### `routing-critical-tensors.json` — the guardrail manifest
+
+This is the machine-ingest artifact for grok-ozempic. All 64 router
+tensors are listed here:
+
+```json
+{
+  "model_family": "grok-1",
+  "tensors": [
+    {
+      "shard_ordinal": 13,
+      "in_shard_index": 0,
+      "block_index": 0,
+      "block_slot": 11,
+      "structural_name": "block_000.routing_slot_11",
+      "kind_label": "router",
+      "orientation": "d_model_to_experts",
+      "linked_expert_count": 8,
+      "total_nbytes": 196608,
+      // Why this tensor is critical — used for human review, not machine ingest
+      "criticality_reason": "contains a primary routing candidate linked to a 8-expert MoE block"
+    },
+    {
+      "shard_ordinal": 25,
+      "in_shard_index": 0,
+      "block_index": 1,
+      "block_slot": 11,
+      "structural_name": "block_001.routing_slot_11",
+      "kind_label": "router",
+      "orientation": "d_model_to_experts",
+      "linked_expert_count": 8,
+      "total_nbytes": 196608,
+      "criticality_reason": "contains a primary routing candidate linked to a 8-expert MoE block"
+    }
+    // All 64 router tensors follow — blocks 0..63, each at slot 11
+  ]
+}
+```
+
+---
+
+## `stats` — Offline Tensor Statistics
+
+```bash
+./target/release/xai-dissect stats \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --sample-values 65536 \
+    --output-root out
+```
+
+### Annotated `stats.json` excerpt — token embedding tensor
+
+```json
+{
+  "sampling": {
+    "max_sample_values": 65536,
+    "f32_near_zero_abs": 0.001,
+    "i8_near_zero_abs": 1
+  },
+  "tensors": [
+    {
+      "shard_ordinal": 0,
+      "in_shard_index": 0,
+      "block_index": null,
+      "block_slot": null,
+      "structural_name": "embedding.slot_00.token_embedding",
+      "role": "tensor",
+      "dtype": "f32",
+      "shape": [131072, 6144],
+      "kind_label": "token_embedding",
+      "sampled": true,
+      // How many values were read vs. total in the tensor
+      "total_values": 805306368,
+      "sample_values": 65536,
+      "total_nbytes": 3221225472,
+      // Statistical moments over the sampled values
+      "mean": 0.005448298090801567,
+      "variance": 0.00012176985980541508,
+      "stddev": 0.011034938142346566,
+      "min": -0.039775047451257706,
+      "max": 0.05811597779393196,
+      "max_abs": 0.05811597779393196,
+      "l1_norm": 634.2734907355923,
+      "l2_norm": 3.1505042479151633,
+      "rms": 0.012306657218418606,
+      // Fractions of the sampled distribution
+      "zero_fraction": 0.0,
+      "near_zero_fraction": 0.067474365234375,
+      "positive_fraction": 0.6834564208984375,
+      "negative_fraction": 0.3165435791015625,
+      "outlier_fraction": 0.0,
+      // peak_to_rms > 4.0 suggests heavy-tailed distribution
+      "peak_to_rms": 4.722320347637001,
+      "distribution_label": "dense_balanced"
+    }
+    // ... continues for all 770 tensors
+  ]
+}
+```
+
+---
+
+## `saaq-readiness` — SAAQ Candidate Scouting
+
+```bash
+./target/release/xai-dissect saaq-readiness \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --sample-values 65536 \
+    --output-root out
+```
+
+### Annotated `candidate-saaq-targets.json` excerpt
+
+```json
+{
+  "model_family": "grok-1",
+  "candidates": [
+    {
+      "rank": 1,
+      "shard_ordinal": 0,
+      "in_shard_index": 0,
+      "block_index": null,
+      "block_slot": null,
+      "structural_name": "embedding.slot_00.token_embedding",
+      "kind_label": "token_embedding",
+      "dtype": "f32",
+      "shape": [131072, 6144],
+      // The embedding shard is the only embedding-heavy candidate
+      "region_class": "embedding_heavy",
+      "disposition": "candidate",
+      // Composite scoring — see docs/metric-definitions.md for methodology
+      "readiness_score": 0.17649918328848646,
+      "opportunity_score": 0.33145386533049104,
+      "risk_score": 0.39055624243345904,
+      "reasons": [
+        "distribution=dense_balanced",
+        "sampled_values=65536/805306368",
+        "zero_fraction=0.0000",
+        "near_zero_fraction=0.0675",
+        "outlier_fraction=0.0000",
+        "peak_to_rms=4.722"
+      ]
+    }
+  ],
+  "schema_version": 1
+}
+```
+
+---
+
+## `pilot-plan` — Pilot Selection Plan
+
+The `pilot-plan` planning artifact is from the test fixture snapshot
+(`tests/fixtures/exports/pilot-plan.snap`) since the real Grok-1 run
+did not generate a pilot plan.
+
+```bash
+./target/release/xai-dissect pilot-plan \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --output-root out
+```
+
+### Annotated `pilot-selection-plan.json` from fixture
+
+```json
+{
+  "model_family": "grok-1",
+  "baseline": "grok1-map-v1-clean",
+  "required_validation": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "selected_blocks": [
+    { "block_index": 0,  "label": "block_000", "rationale": "early baseline" },
+    { "block_index": 8,  "label": "block_008", "rationale": "near-zero-sensitive router" },
+    { "block_index": 28, "label": "block_028", "rationale": "near-zero-sensitive router" },
+    { "block_index": 60, "label": "block_060", "rationale": "high readiness/routing-critical sample" },
+    { "block_index": 63, "label": "block_063", "rationale": "late-layer / high peak-to-rms router region" }
+  ],
+  "modes": [
+    "attention_only",
+    "expert_only",
+    "attention_plus_expert"
+  ],
+  "protection_rules": [
+    "router tensors must remain untouched in every first-pass pilot",
+    "block_norm and final_norm tensors must remain untouched in every first-pass pilot",
+    "pilot artifacts must be emitted per mode and remain comparable across selected blocks"
+  ],
+  "comparison_artifacts": [
+    "pilot-selection-plan.json",
+    "pilot-selection-plan.md",
+    "route-preservation-report.json",
+    "route-preservation-report.md"
+  ],
+  "notes": [
+    "This is a planning artifact only; xai-dissect does not mutate checkpoints or execute a quantization runtime.",
+    "Use the selected blocks and protected-family rules to drive downstream bounded pilot runs."
+  ],
+  "schema_version": 1
+}
+```
+
+---
+
+## `route-preservation` — Route Preservation Gate Report
+
+The `route-preservation` artifact is from the test fixture snapshot
+(`tests/fixtures/exports/route-preservation.snap`).
+
+```bash
+./target/release/xai-dissect route-preservation \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --output-root out
+```
+
+### Annotated `route-preservation-report.json` — key metrics
+
+```json
+{
+  "model_family": "grok-1",
+  "baseline": "grok1-map-v1-clean",
+  "summary": [
+    {
+      "name": "router_top1_agreement",
+      "scope": "router_behavior",
+      "status": "unknown",
+      "threshold": ">= 99.0%",
+      "observed": null,
+      // xai-dissect defines the gate but cannot execute pilot inference
+      "detail": "Threshold reserved for downstream pilot comparison artifacts; xai-dissect defines the gate but does not execute pilot inference."
+    },
+    {
+      "name": "block_output_cosine",
+      "scope": "block_behavior",
+      "status": "unknown",
+      "threshold": ">= 0.995",
+      "observed": null,
+      "detail": "Tracked as a go/no-go threshold once bounded pilot outputs exist."
+    }
+    // ... 15 total metrics across router, block, weight, and model scopes
+  ],
+  "router_metrics": [
+    {
+      "name": "router_top1_agreement",
+      "scope": "router_behavior",
+      "status": "unknown",
+      "threshold": ">= 99.0%",
+      "observed": null,
+      "detail": "Threshold reserved for downstream pilot comparison artifacts; xai-dissect defines the gate but does not execute pilot inference."
+    }
+    // ... 5 router metrics total
+  ],
+  "block_metrics": [
+    {
+      "name": "block_output_cosine",
+      "scope": "block_behavior",
+      "status": "unknown",
+      "threshold": ">= 0.995",
+      "observed": null,
+      "detail": "Tracked as a go/no-go threshold once bounded pilot outputs exist."
+    }
+    // ... 3 block metrics total
+  ],
+  "notes": [
+    "This report defines the required route-preservation surface and thresholds for Grok-1 pilot evidence.",
+    "Statuses remain unknown until downstream pilot artifacts supply the observed values."
+  ],
+  "schema_version": 1
+}
+```
+
+All `status: "unknown"` entries will be populated with real observed values
+when `grok-ozempic` executes the bounded pilot runs and writes the
+comparison artifacts.
+
+---
+
+## `quant-plan` — Conversion and Quant Planning
+
+The `quant-plan` artifacts are from the test fixture snapshot.
+
+```bash
+./target/release/xai-dissect quant-plan \
+    /home/raulmc/Downloads/SNN_Quantization/grok-1-official/ckpt-0 \
+    --sample-values 65536 \
+    --output-root out
+```
+
+### Annotated `conversion-manifest.json` excerpt
+
+```json
+{
+  "baseline_profile": "grok1-map-v1-clean",
+  "relevant_block_count": 64,
+  "expected_experts_per_block": 8,
+  "expert_tensor_families_per_block": 3,
+  "router_orientation": "d_model_to_experts",
+  "router_shape": [6144, 8],
+  "tensors": [
+    {
+      "tensor_name": "tensor0000#0",
+      "structural_name": "embedding.slot_00.token_embedding",
+      "model_family": "grok-1",
+      "block": null,
+      "slot": null,
+      "kind": "token_embedding",
+      // Region class drives disposition in the SAAQ readiness pipeline
+      "region": "embedding_heavy",
+      "dtype": "f32",
+      "shape": [16, 4],
+      "numel": 64,
+      "byte_len": 256,
+      "shard_index": 0,
+      "source_shard_path": "/fixtures/grok-1-official/ckpt-0/tensor0000",
+      "source_in_shard_index": 0,
+      // QuantPolicy determines what downstream packing/repacking does with this tensor
+      "quant_policy": "candidate_saaq_embedding",
+      "protected_reason": null,
+      // Deterministic hash over canonical tensor representation
+      "deterministic_hash": "fnv1a64:1111111111111111",
+      "warnings": []
+    },
+    {
+      "tensor_name": "tensor0001#0",
+      "structural_name": "block_000.routing_slot_00",
+      "block": 0,
+      "slot": 0,
+      "kind": "router",
+      "region": "routing_critical",
+      "dtype": "f32",
+      "shape": [4, 2],
+      "numel": 8,
+      "byte_len": 32,
+      "shard_index": 1,
+      "quant_policy": "passthrough_f32_router",
+      // Router must stay FP32 to preserve expert selection
+      "protected_reason": "protected router tensor; keep f32 to preserve expert selection",
+      "deterministic_hash": "fnv1a64:2222222222222222",
+      "warnings": []
+    }
+  ]
+}
+```
+
+### `quant-plan.json` — policy summary
+
+```json
+{
+  "model_family": "grok-1",
+  "baseline": "grok1-map-v1-clean",
+  "required_validation": {
+    "blocks": 64, "tensors": 770, "routers": 64,
+    "expert_families": 192, "unknown_tensors": 0
+  },
+  // FP32 tensors that must not be quantized in any first-pass pilot
+  "keep_fp32": ["router", "block_norm", "final_norm"],
+  // Tensor families recommended for pilot quantization
+  "pilot_quantize": [
+    "attn_proj_i8.model_width",
+    "attn_proj_i8.narrow",
+    "moe_expert.gate",
+    "moe_expert.up",
+    "moe_expert.down"
+  ],
+  // Tensors deferred beyond the first pilot pass
+  "defer": ["token_embedding"],
+  "notes": [
+    "770 tensors partition into 1 quantization candidates, 1 routing-critical, 1 precision-sensitive, and 1 deferred entries.",
+    "Top quantization candidate is `block_000.slot_01.attn_proj` with readiness 0.820."
+  ],
+  "schema_version": 1
+}
+```
+
+---
+
+## `grok1-coverage.json` — the validation gate
+
+The coverage manifest is the fail-closed gate for the grok-ozempic handoff.
+This is the complete 22-line file from the real Grok-1 run:
+
+```json
+{
+  "model_family": "grok-1",
+  "schema_version": 2,
+  "coverage_schema_version": 1,
+  "validation": "pass",
+  // FNV-1a 64-bit checksum over canonical structural tensor representation
+  "checksum": "fnv1a64:de5a1c978121c62c",
+  "expected": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "discovered": {
+    "blocks": 64,
+    "tensors": 770,
+    "routers": 64,
+    "expert_families": 192,
+    "unknown_tensors": 0
+  },
+  "unknown_slots": []
+}
+```
+
+For a grok-ozempic bundle to be accepted: `validation` must be `"pass"`,
+`expected` must equal `discovered`, and `unknown_slots` must be empty.
+See `docs/grok1-coverage-manifest.md` for the full algorithm documentation.

--- a/docs/run-examples.md
+++ b/docs/run-examples.md
@@ -766,7 +766,7 @@ This is the complete 22-line file from the real Grok-1 run:
 {
   "model_family": "grok-1",
   "schema_version": 2,
-  "coverage_schema_version": 1,
+  "coverage_schema_version": 2,
   "validation": "pass",
   // FNV-1a 64-bit checksum over canonical structural tensor representation
   "checksum": "fnv1a64:de5a1c978121c62c",

--- a/src/experts/mod.rs
+++ b/src/experts/mod.rs
@@ -1,8 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Expert-level structural analysis derived from `ModelInventory`. This layer
-// maps block-local MoE tensor families, associates each family with every
-// expert index, and reports missing or irregular layout patterns.
+//! Expert-level structural analysis derived from `ModelInventory`.
+//!
+//! This layer maps block-local MoE tensor families, resolves expert index
+//! slices for each projection, and reports missing or irregular layout
+//! patterns. It is purely shape-based — no tensor payload bytes are read.
+//!
+//! ## What it resolves
+//! - Which of the three MoE projection slots (gate / down / up) each
+//!   3-D int8 quant_weight tensor corresponds to, using the source-backed
+//!   Grok-1 slot ordering (gate=slot 0, down=slot 1, up=slot 2)
+//! - The per-expert slice shape of each projection family
+//! - The expert_axis (which leading dimension is the expert count)
+//! - Anomalies: missing expert families, inconsistent expert counts across
+//!   blocks, naming pattern deviations
+//!
+//! ## What it does NOT do
+//! - It does **not** compute expert load statistics
+//! - It does **not** execute MoE routing
+//! - It does **not** estimate dequantized parameter counts beyond shape
 
 use std::collections::BTreeMap;
 

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1,7 +1,30 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Unified output-tree planning and bundle writers. This layer keeps path
-// conventions and manifest generation out of the analyzers themselves.
+//! Unified output-tree planning and bundle writers.
+//!
+//! This layer keeps path conventions and manifest generation out of the
+//! analyzer layers themselves. It resolves `<checkpoint_slug>` from the
+//! checkpoint path, manages the `reports/`, `exports/`, and `manifests/`
+//! directory layout, and orchestrates the bundle-write sequence.
+//!
+//! ## Slug resolution
+//! The slug is inferred from the last two path components:
+//! `/path/to/grok-1-official/ckpt-0` → `grok-1-official__ckpt-0`.
+//! Use `--checkpoint-slug` to override when a pipeline needs a custom name.
+//!
+//! ## Output tree
+//! ```text
+//! <output-root>/
+//!   reports/<checkpoint_slug>/     # human-readable Markdown
+//!   exports/<checkpoint_slug>/      # full JSON + findings summaries
+//!   manifests/<checkpoint_slug>/    # focused machine-readable manifests
+//! ```
+//!
+//! ## Bundle rules
+//! All required files for a grok-ozempic handoff must exist under the same
+//! `<checkpoint_slug>`. The `OutputBundle` struct coordinates the write
+//! order: inventory must be validated before coverage manifest is written,
+//! and coverage must pass before planning artifacts are emitted.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;

--- a/src/inventory/grok1_coverage.rs
+++ b/src/inventory/grok1_coverage.rs
@@ -1,8 +1,34 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Strict Grok-1 coverage validation. This module is intentionally separate
-// from the generic inventory builder so parser/classification logic remains
-// usable for partial scans while full Grok-1 exports fail closed.
+//! Strict Grok-1 coverage validation for the grok1-map-v1-clean baseline.
+//!
+//! This module is intentionally separate from the generic inventory builder
+//! so parser/classification logic remains usable for partial scans while full
+//! Grok-1 exports fail closed. It is only invoked when the inventory
+//! has `model_family = "grok-1"` and the `--family` flag is left at its
+//! default value.
+//!
+//! ## grok1-map-v1-clean baseline profile
+//! The canonical structural invariants for a clean Grok-1 ckpt-0 parse:
+//! ```text
+//! blocks           = 64
+//! tensors          = 770
+//! routers          = 64
+//! expert_families   = 192  (3 families × 64 layers)
+//! unknown_tensors   = 0
+//! ```
+//!
+//! ## FNV-1a 64-bit checksum
+//! The manifest checksum is computed over a canonical, path-independent view
+//! of the structural tensor table (shard_ordinal, in_shard_index, kind.kind,
+//! kind.detail, shape, role, dtype) so downstream tools can compare reruns
+//! on different machines without path dependencies.
+//!
+//! ## Fail-closed semantics
+//! If any validation dimension fails, `validation` becomes `"fail"` and the
+//! manifest is rejected by downstream consumers. A `"pass"` manifest with
+//! `unknown_slots: []` and `expected == discovered` is the only acceptable
+//! gate for grok-ozempic ingestion.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -1,16 +1,31 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Inventory layer: walks a checkpoint directory, drives the parser, applies
-// shape-based semantic classification, and groups tensors into blocks.
-//
-// This layer is intentionally conservative. It identifies what can be
-// identified from `(rank, dtype, dims)` alone plus an inferred `(d_model,
-// vocab_size, n_experts)` triple. Anything ambiguous is reported as
-// `Unknown { reason }` or `MoeProjection::Unresolved` unless a supported
-// checkpoint layout provides source-backed disambiguation.
-//
-// Deeper semantic analysis (routing math, expert-level statistics,
-// dequantized parameter accounting) is explicitly *not* done here.
+//! Inventory layer: walks a checkpoint directory, drives the parser,
+//! applies shape-based semantic classification, and groups tensors into
+//! transformer blocks.
+//!
+//! ## Two-pass hyperparameter inference
+//! 1. The largest 2-D f32 bare tensor fixes `vocab_size` and `d_model`.
+//! 2. The first 3-D int8 quant_weight tensor fixes `n_experts` and `d_ff`.
+//! 3. Shard layout check derives `n_blocks` from the Grok-1 K=12 rule.
+//!
+//! ## Seven-rule classification
+//! Tensors are classified in order; the first matching rule wins:
+//! 1. `(role=quant_weight, rank=3)` → `MoeExpertProjection` (disambiguated to
+//!    gate/down/up by source-backed slot mapping for supported checkpoints)
+//! 2. `(role=quant_scales)` → `MoeScales`
+//! 3. `(role=quant_weight, rank=2)` → `QuantizedAttentionProjection`
+//! 4. `(role=tensor, rank=2, shape=vocab×d_model)` → `TokenEmbedding`
+//! 5. `(role=tensor, rank=2, shape=d_model×n_experts)` → `Router`
+//! 6. `(role=tensor, rank=2)` → `AttnProjF32`
+//! 7. `(role=tensor, rank=1, shape=d_model)` → `BlockNorm` (promoted to
+//!    `FinalNorm` for the norm singleton)
+//!
+//! ## What this layer does NOT do
+//! - It does **not** read tensor payload bytes for classification
+//! - It does **not** execute routing logic or rank experts
+//! - It does **not** compute SAAQ scores or readiness metrics
+//! - It does **not** mutate checkpoint files
 
 use std::path::{Path, PathBuf};
 

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -4,7 +4,7 @@
 //! applies shape-based semantic classification, and groups tensors into
 //! transformer blocks.
 //!
-//! ## Two-pass hyperparameter inference
+//! ## Three-step hyperparameter inference
 //! 1. The largest 2-D f32 bare tensor fixes `vocab_size` and `d_model`.
 //! 2. The first 3-D int8 quant_weight tensor fixes `n_experts` and `d_ff`.
 //! 3. Shard layout check derives `n_blocks` from the Grok-1 K=12 rule.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 //!
 //! | Command | Driven by | Produces |
 //! |---------|----------|---------|
-//! | `dissect` | `parser::parse_single_shard` | Raw tensor table (no classification) |
+//! | `dissect` | `parser::dissect_shard` | Raw tensor table (no classification) |
 //! | `inventory` | `inventory::build_inventory` | Full tensor catalog + coverage manifest |
 //! | `experts` | `experts::build_expert_atlas` | Expert atlas |
 //! | `routing-report` | `routing::build_routing_report` | Routing structure + critical-tensors manifest |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,30 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// xai-dissect CLI. Thin wrapper over the library crate.
-//
-// Primary commands:
-//
-//   dissect         - legacy per-shard byte-table view (parser output only)
-//   inventory       - full checkpoint cartography with JSON / Markdown export
-//   experts         - expert atlas discovery
-//   routing-report  - routing / gating structure inspection
-//   stats           - offline tensor-statistics profiling
-//   saaq-readiness  - candidate scouting for future SAAQ work
+//! xai-dissect CLI. Thin wrapper over the `xai_dissect` library crate.
+//!
+//! ## Command map
+//!
+//! | Command | Driven by | Produces |
+//! |---------|----------|---------|
+//! | `dissect` | `parser::parse_single_shard` | Raw tensor table (no classification) |
+//! | `inventory` | `inventory::build_inventory` | Full tensor catalog + coverage manifest |
+//! | `experts` | `experts::build_expert_atlas` | Expert atlas |
+//! | `routing-report` | `routing::build_routing_report` | Routing structure + critical-tensors manifest |
+//! | `stats` | `stats::build_stats_report` | Offline tensor statistics |
+//! | `saaq-readiness` | `stats::build_saaq_readiness_report` | SAAQ candidate manifest |
+//! | `pilot-plan` | `planning::build_grok1_pilot_selection_plan` | Pilot block selection plan |
+//! | `route-preservation` | `planning::build_grok1_route_preservation_report` | Route preservation gate report |
+//! | `quant-plan` | `planning::build_grok1_planning_artifacts` | Conversion manifest + quant plan |
+//!
+//! ## OutputTreeArgs semantics
+//! `--output-root` enables the unified output tree (`reports/`, `exports/`,
+//! `manifests/`). `--checkpoint-slug` overrides the inferred slug and is
+//! required when `--output-root` is set and a custom name is needed.
+//!
+//! ## What this module does NOT do
+//! - It does **not** execute model inference
+//! - It does **not** mutate checkpoint files
+//! - It does **not** implement quantization kernels
 
 use std::path::PathBuf;
 use std::time::Instant;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,6 +21,7 @@
 //!    \x87 [\x94] R`.
 //! 2. The array payload is always emitted immediately after the fortran
 //!    bool: `[\x88|\x89] <C|B|\x8e> <len> <raw bytes>`.
+//!
 //! ## Role assignment for QuantizedWeight8bit
 //! Every shard file containing a Grok-1 MoE expert or attention projection
 //! is a `QuantizedWeight8bit` dataclass. In the pickle stream this produces

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,22 +1,39 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Pickle Protocol 4 byte-grammar scanner for Grok-1 JAX shards. Extracts
-// `(dtype, shape, offset, nbytes)` tuples and `QuantizedWeight8bit` pairing
-// without running a real unpickler or decoding tensor bodies.
-//
-// This module is intentionally free of schema/inventory concerns: it speaks
-// only in terms of raw tensor anchors. The higher layers map these anchors
-// into `schema::TensorInfo` and assign semantics.
-//
-// Stable pickle-4 invariants we rely on (documented in the original
-// single-file CLI):
-//
-//   1. Every `numpy.ndarray` is reconstructed via a state tuple whose dtype
-//      is built by `numpy.dtype('f4' | 'i1', False, True)`. That guarantees
-//      the byte signature `<dtype class push> \x8c\x02XX [\x94] \x89 \x88
-//      \x87 [\x94] R`.
-//   2. The array payload is always emitted immediately after the fortran
-//      bool: `[\x88|\x89] <C|B|\x8e> <len> <raw bytes>`.
+//! Pickle Protocol 4 byte-grammar scanner for Grok-1 JAX shards.
+//!
+//! This module walks the raw opcode stream of a `.pkl` shard file,
+//! locating every `numpy.ndarray` reduce site and emitting a `RawTensor`
+//! record without decoding tensor payload bytes or running a Python
+//! interpreter.
+//!
+//! ## What this module does NOT do
+//! - It does **not** unpickle or deserialize Python objects
+//! - It does **not** decode int8 weight bodies or f32 scale values
+//! - It does **not** classify tensors by semantic role (that is the
+//!   inventory layer's responsibility)
+//! - It does **not** execute model code or routing logic
+//!
+//! ## Stable PROTO 4 invariants relied upon
+//! 1. Every `numpy.ndarray` is reconstructed via a state tuple whose dtype
+//!    is built by `numpy.dtype('f4' | 'i1', False, True)`. This produces
+//!    the byte signature `<dtype class push> \x8c\x02XX [\x94] \x89 \x88
+//!    \x87 [\x94] R`.
+//! 2. The array payload is always emitted immediately after the fortran
+//!    bool: `[\x88|\x89] <C|B|\x8e> <len> <raw bytes>`.
+//! ## Role assignment for QuantizedWeight8bit
+//! Every shard file containing a Grok-1 MoE expert or attention projection
+//! is a `QuantizedWeight8bit` dataclass. In the pickle stream this produces
+//! three top-level ndarray reduce sites: the int8 weight body (first),
+//! the f32 quantization scales (second), and the per-min values (third).
+//! The parser assigns `role = quant_weight` to the first ndarray and
+//! `role = quant_scales` to the second and third. The pairing is preserved
+//! through the shard boundary — all three records share the same shard path.
+//!
+//! ## Output
+//! Emits `RawTensor` records: `role`, `dtype`, `shape`, `offset`, `nbytes`.
+//! These are consumed by `inventory::build_inventory()` which maps them into
+//! `schema::TensorInfo` and applies semantic classification.
 
 use std::cmp::min;
 use std::fs::File;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -24,11 +24,14 @@
 //! ## Role assignment for QuantizedWeight8bit
 //! Every shard file containing a Grok-1 MoE expert or attention projection
 //! is a `QuantizedWeight8bit` dataclass. In the pickle stream this produces
-//! three top-level ndarray reduce sites: the int8 weight body (first),
-//! the f32 quantization scales (second), and the per-min values (third).
-//! The parser assigns `role = quant_weight` to the first ndarray and
-//! `role = quant_scales` to the second and third. The pairing is preserved
-//! through the shard boundary — all three records share the same shard path.
+//! multiple ndarray reduce sites within each `QuantizedWeight8bit` site: an
+//! int8 weight body, one or more f32 quantization side-data arrays, and
+//! sometimes additional f32 leaves (for example per-expert minimum values).
+//! `assign_qw8_roles` marks the `i8` ndarray as `quant_weight` and only the
+//! first `f32` ndarray after it as `quant_scales`; any additional `f32`
+//! ndarrays in the same site remain bare `tensor`. The pairing is preserved
+//! through the shard boundary — all records from the site share the same
+//! shard path.
 //!
 //! ## Output
 //! Emits `RawTensor` records: `role`, `dtype`, `shape`, `offset`, `nbytes`.

--- a/src/planning/mod.rs
+++ b/src/planning/mod.rs
@@ -1,8 +1,29 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Static planning artifacts that bridge validated Grok-1 structure into
-// downstream conversion / quantization repos without executing or mutating the
-// checkpoint.
+//! Static planning artifacts that bridge validated Grok-1 structure into
+//! downstream conversion and quantization repos without executing or mutating
+//! the checkpoint.
+//!
+//! ## Planning artifacts
+//! | Artifact | Schema type | Purpose |
+//! |----------|-----------|---------|
+//! | `pilot-selection-plan.json` | `PilotSelectionPlan` | Which transformer blocks to pilot-quantize, in which mode |
+//! | `route-preservation-report.json` | `RoutePreservationReport` | Metric gate definitions for routing preservation (thresholds + status) |
+//! | `conversion-manifest.json` | `ConversionManifest` | Per-tensor policy and deterministic hash for downstream packing |
+//! | `quant-plan.json` | `QuantPlan` | Family-level policy: keep_fp32, pilot_quantize, defer lists |
+//!
+//! ## QuantPolicy variants (from ConversionManifestTensor.quant_policy)
+//! - `PassthroughF32Router` — router must remain FP32 in first pilot
+//! - `PassthroughF32Norm` — norms must remain FP32 in first pilot
+//! - `CandidateSaaqEmbedding` — embedding is a SAAQ candidate with risk score
+//! - `WrapExistingInt8Expert` — MoE expert projection already int8, just wrap
+//! - `WrapExistingInt8Unknown` — unknown int8 tensor, wrap but flag
+//! - `UnknownPassthroughOrWarn` — cannot determine policy, pass through with warning
+//!
+//! ## What this module does NOT do
+//! - It does **not** execute quantization or produce quantized weights
+//! - It does **not** run pilot inference to measure router agreement
+//! - It does **not** mutate checkpoint files
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,8 +1,30 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Export layer: stable serialization of `ModelInventory` to JSON and a
-// human-readable Markdown summary. These two formats are the public
-// integration surface for sibling repositories.
+//! Markdown and JSON export writers for all xai-dissect analysis outputs.
+//!
+//! This module is the only layer that produces files on disk. It serializes
+//! the stable schema types to JSON (machine-ingest) and renders Markdown
+//! (human-review and PR discussion). Each render function is versioned and
+//! documented so downstream tooling can predict the section structure.
+//!
+//! ## Stability guarantees
+//! - Section headings in Markdown outputs are treated as stable surface
+//!   identifiers (not schema-tagged, but intentionally stable)
+//! - Filenames under `exports/` and `manifests/` follow `docs/output-conventions.md`
+//! - The JSON export schema is the normative machine-ingest contract;
+//!   Markdown is a human-readable companion, not a machine interface
+//!
+//! ## Render functions
+//! | Function | Output type | File path |
+//! |----------|-------------|-----------|
+//! | `render_inventory_markdown` | `inventory.md` | `reports/<slug>/` |
+//! | `render_expert_markdown` | `experts.md` | `reports/<slug>/` |
+//! | `render_routing_markdown` | `routing-report.md` | `reports/<slug>/` |
+//! | `render_stats_markdown` | `stats.md` | `reports/<slug>/` |
+//! | `render_saaq_readiness_markdown` | `saaq-readiness.md` | `reports/<slug>/` |
+//! | `render_pilot_selection_plan_markdown` | `pilot-selection-plan.md` | `reports/<slug>/` |
+//! | `render_route_preservation_markdown` | `route-preservation-report.md` | `reports/<slug>/` |
+//! | `render_quant_plan_markdown` | `quant-plan.md` | `reports/<slug>/` |
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -17,7 +17,7 @@
 //! ## Render functions
 //! | Function | Output type | File path |
 //! |----------|-------------|-----------|
-//! | `render_inventory_markdown` | `inventory.md` | `reports/<slug>/` |
+//! | `render_markdown` | `inventory.md` | `reports/<slug>/` |
 //! | `render_expert_markdown` | `experts.md` | `reports/<slug>/` |
 //! | `render_routing_markdown` | `routing-report.md` | `reports/<slug>/` |
 //! | `render_stats_markdown` | `stats.md` | `reports/<slug>/` |

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,9 +1,30 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Routing-structure analysis derived from `ModelInventory`. This layer
-// identifies candidate router tensors, summarizes their shape/orientation,
-// links them to block-local expert structure, and reports layout anomalies
-// without executing any routing logic.
+//! Routing-structure analysis derived from `ModelInventory`.
+//!
+//! This layer identifies candidate router/gate tensors by shape signature,
+//! summarizes their geometry and orientation, links them to the expert
+//! count inferred from the inventory, and reports layout anomalies. It is
+//! purely structural — no routing decisions are executed.
+//!
+//! ## Router identification
+//! A router tensor is identified as a bare f32 2-D tensor with shape
+//! `(d_model, n_experts)` where the inferred expert count matches the
+//! inventory's n_experts. For Grok-1 this is `(6144, 8)`. The leading
+//! dimension (expert_axis=1) determines the routing orientation:
+//! `ExpertsToDModel` if d_model is trailing, `DModelToExperts` if leading.
+//!
+//! ## RoutingCriticalTensorManifest
+//! The manifest at `manifests/<slug>/routing-critical-tensors.json` is the
+//! machine-ingest guardrail list for grok-ozempic. All 64 router tensors
+//! are listed with their structural_name, orientation, linked_expert_count,
+//! and total_nbytes. Downstream compression or packing logic must treat
+//! these as routing-sensitive.
+//!
+//! ## What it does NOT do
+//! - It does **not** execute routing or compute expert selection
+//! - It does **not** compute top-k router agreement or logits
+//! - It does **not** mutate router weights
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -10,9 +10,9 @@
 //! ## Router identification
 //! A router tensor is identified as a bare f32 2-D tensor with shape
 //! `(d_model, n_experts)` where the inferred expert count matches the
-//! inventory's n_experts. For Grok-1 this is `(6144, 8)`. The leading
-//! dimension (expert_axis=1) determines the routing orientation:
-//! `ExpertsToDModel` if d_model is trailing, `DModelToExperts` if leading.
+//! inventory's n_experts. For Grok-1 this is `(6144, 8)` with d_model
+//! leading and experts trailing (`DModelToExperts`). If the expert count
+//! appears on the leading axis instead, orientation is `ExpertsToDModel`.
 //!
 //! ## RoutingCriticalTensorManifest
 //! The manifest at `manifests/<slug>/routing-critical-tensors.json` is the

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,9 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Core schema types used across the parser, inventory, analysis, and export
-// layers. Any type that is serialized to an export artifact (JSON / CSV /
-// Markdown) must live here, must derive `Serialize`, and must be stable
-// across patch releases.
+//! Stable schema types for all xai-dissect export artifacts.
+//!
+//! Any type serialized to a JSON / CSV / Markdown export artifact lives
+//! here. All such types derive `Serialize` and `Deserialize` and must remain
+//! stable across patch releases. The schema version discipline is:
+//! - `schema_version` bumps on any incompatible JSON shape change
+//! - `coverage_schema_version` is independent — tracks the coverage
+//!   manifest sub-structure separately
+//!
+//! ## Schema version map
+//! | Document | schema_version | coverage_schema_version |
+//! |----------|----------------|------------------------|
+//! | `ModelInventory` | 2 | — |
+//! | `ExpertAtlas` | 1 | — |
+//! | `RoutingReport` | 1 | — |
+//! | `StatsProfileReport` | 1 | — |
+//! | `SaaqReadinessReport` | 1 | — |
+//! | `Grok1CoverageManifest` | 2 | 1 | (two independent version fields)
+//! | `ConversionManifest` | 1 | — |
+//! | `QuantPlan` | 1 | — |
+//! | `PilotSelectionPlan` | 1 | — |
+//! | `RoutePreservationReport` | 1 | — |
+//! | `RoutingCriticalTensorManifest` | 1 | — |
+//!
+//! ## Key constants
+//! `GROK1_BASELINE_PROFILE = "grok1-map-v1-clean"` is the canonical baseline
+//! profile for Grok-1 ckpt-0. Downstream tools should reject bundles whose
+//! coverage validation is not `"pass"` and whose unknown_tensors is not 0.
 
 use std::path::PathBuf;
 
@@ -205,25 +229,34 @@ impl MoeProjection {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TensorInfo {
     /// Absolute path of the shard file on disk.
+    /// Note: machine-local path — downstream consumers use shard_ordinal +
+    /// in_shard_index as the stable tensor identity, not this field.
     pub shard_path: PathBuf,
     /// 0-based ordinal of the shard in the checkpoint's sorted shard list.
+    /// Stable across reruns and across machines — use this, not shard_path,
+    /// as the portable tensor identifier.
     pub shard_ordinal: u32,
-    /// 0-based index within the shard (in the order tensors were found).
+    /// 0-based index of the tensor within the shard (shards can hold >1
+    /// tensor for QuantizedWeight8bit dataclasses).
     pub in_shard_index: u32,
+    /// Parser-level role tag: bare ndarray, int8 weight body, or f32 scales.
     pub role: TensorRole,
+    /// Numpy-style dtype on disk.
     pub dtype: TensorDType,
+    /// Row-major shape as stored in the pickle stream.
     pub shape: TensorShape,
     /// Byte offset of the raw payload within the shard file.
     pub offset: u64,
     /// Payload length in bytes.
     pub nbytes: u64,
-    /// Inferred semantic classification.
+    /// Semantic classification inferred from rank, dtype, and shape.
     pub kind: TensorKind,
-    /// Inferred block (transformer layer) index, if assignable.
+    /// 0-based transformer block index, if assignable from shard layout.
+    /// Null for embedding and final norm singletons.
     pub block_index: Option<u32>,
-    /// Position within the block's shard ordering, if assignable.
-    /// Useful for disambiguating multiple tensors of the same kind inside
-    /// one block (e.g. the two `AttnProjF32` tensors per layer).
+    /// Position of this tensor within its block's shard ordering (0–11 for
+    /// Grok-1). Useful for disambiguating multiple tensors of the same kind
+    /// within one block (e.g., the four BlockNorm tensors per layer).
     pub block_slot: Option<u32>,
 }
 
@@ -692,35 +725,65 @@ pub struct CheckpointInventoryBlockSnapshot {
 /// Fail-closed Grok-1 coverage manifest for complete checkpoint inventories.
 /// The checksum is computed over a canonical, path-independent view of the
 /// structural tensor table so downstream tools can compare reruns.
+/// Downstream consumers must require: validation = "pass", expected == discovered,
+/// and unknown_slots = [] before treating a bundle as valid for grok-ozempic.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Grok1CoverageManifest {
+    /// Always "grok-1" for Grok-1 coverage manifests.
     pub model_family: String,
+    /// The baseline profile name. Always "grok1-map-v1-clean" for Grok-1.
     #[serde(default = "default_grok1_baseline_profile")]
     pub baseline_profile: String,
+    /// Schema version for the outer ModelInventory. Grok-1 uses schema_version = 2.
     pub schema_version: u32,
+    /// Independent schema version for the coverage sub-structure. Grok-1 uses
+    /// coverage_schema_version = 1. These two version fields evolve independently.
     pub coverage_schema_version: u32,
+    /// Validation result. "pass" if all checks succeed, "fail" otherwise.
+    /// Downstream consumers must reject bundles where this is not "pass".
     pub validation: String,
+    /// FNV-1a 64-bit checksum over the canonical structural tensor representation.
+    /// Format: "fnv1a64:<hex>". See docs/grok1-coverage-manifest.md for algorithm.
     pub checksum: String,
+    /// The grok1-map-v1-clean expected counts: blocks=64, tensors=770,
+    /// routers=64, expert_families=192, unknown_tensors=0.
     pub expected: Grok1CoverageCounts,
+    /// What was actually discovered in the parsed inventory. Must equal expected.
     pub discovered: Grok1CoverageCounts,
+    /// List of tensors that could not be classified. Empty array is required.
     pub unknown_slots: Vec<Grok1UnknownSlot>,
 }
 
+/// The five validation dimensions for the grok1-map-v1-clean baseline profile.
+/// See docs/grok1-coverage-manifest.md for definitions of each dimension.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Grok1CoverageCounts {
+    /// Must be 64 for Grok-1 ckpt-0.
     pub blocks: u32,
+    /// Must be 770 for Grok-1 ckpt-0 (1 embedding + 768 block shards + 1 final norm).
     pub tensors: u64,
+    /// Must be 64 for Grok-1 ckpt-0 (one router per block).
     pub routers: u64,
+    /// Must be 192 for Grok-1 ckpt-0 (3 projection families gate/down/up × 64 layers).
     pub expert_families: u64,
+    /// Must be 0. Any unknown tensor means the classifier encountered an unexpected
+    /// shape/dtype combination — quantization risk.
     pub unknown_tensors: u64,
 }
 
+/// A tensor that could not be classified by the inventory layer.
+/// Used in Grok1CoverageManifest.unknown_slots to report what is missing.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Grok1UnknownSlot {
+    /// The structural name assigned before the classification failure.
     pub structural_name: String,
+    /// The block index of the unclassified tensor, if assignable.
     pub block_index: Option<u32>,
+    /// The block slot of the unclassified tensor, if assignable.
     pub block_slot: Option<u32>,
+    /// The tensor shape that triggered the Unknown classification.
     pub shape: TensorShape,
+    /// The reason the classifier could not resolve this tensor.
     pub reason: String,
 }
 
@@ -728,21 +791,38 @@ fn default_grok1_baseline_profile() -> String {
     GROK1_BASELINE_PROFILE.to_string()
 }
 
-/// Machine-readable routing-critical tensor list for downstream
-/// compression / orchestration tooling.
+/// Machine-readable routing-critical tensor list for downstream compression
+/// and orchestration tooling. This is the normative machine-ingest artifact
+/// for the grok-ozempic handoff; the human-readable companion is
+/// `routing-report.md`. Downstream consumers must use the stable ingest fields
+/// (shard_ordinal, in_shard_index, structural_name, orientation,
+/// linked_expert_count, block_index, block_slot) — criticality_reason is for
+/// human review only.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoutingCriticalTensorManifest {
+    /// Always "grok-1" for Grok-1 routing manifests.
     pub model_family: String,
+    /// Machine-local path of the checkpoint directory. Not portable across
+    /// environments — do not use as a cache key or artifact identifier.
     pub checkpoint_path: PathBuf,
+    /// The 64 router tensors, one per transformer block.
     pub tensors: Vec<RoutingCriticalTensor>,
     pub schema_version: u32,
 }
 
+/// A single routing-critical tensor. These tensors must remain FP32 in the
+/// first pilot pass to preserve routing behavior. See
+/// docs/metric-definitions.md for why router quantization is sensitive.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoutingCriticalTensor {
+    /// Stable 0-based shard ordinal. Use this + in_shard_index as the
+    /// portable tensor identity, not the shard path.
     pub shard_ordinal: u32,
+    /// 0-based index within the shard file.
     pub in_shard_index: u32,
+    /// 0-based transformer block index.
     pub block_index: Option<u32>,
+    /// Position within the block's shard ordering (0–11 for Grok-1).
     pub block_slot: Option<u32>,
     pub structural_name: String,
     pub kind_label: String,
@@ -753,7 +833,9 @@ pub struct RoutingCriticalTensor {
 }
 
 /// Conversion-ready tensor-by-tensor handoff manifest for downstream
-/// packing or quantization tooling.
+/// packing or quantization tooling. Each entry encodes the per-tensor
+/// quantization policy decision and a deterministic hash for integrity
+/// verification across pipeline runs.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConversionManifest {
     pub model_family: String,
@@ -771,36 +853,59 @@ pub struct ConversionManifest {
     pub schema_version: u32,
 }
 
+/// One entry in the ConversionManifest. The quant_policy field is the primary
+/// actionable field for downstream packing logic.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConversionManifestTensor {
+    /// Human-readable name derived from the shard filename.
     pub tensor_name: String,
+    /// Stable structural name: `block_NNN.slot_SS.kind_label`.
     pub structural_name: String,
     pub model_family: String,
+    /// 0-based transformer block index, null for embedding/final_norm singletons.
     pub block: Option<u32>,
+    /// Block slot within the shard ordering (0–11 for Grok-1).
     pub slot: Option<u32>,
     pub kind: String,
+    /// SAAQ region class driving the policy decision.
     pub region: SaaqRegionClass,
     pub dtype: TensorDType,
     pub shape: TensorShape,
+    /// Total element count for this tensor.
     pub numel: u64,
+    /// Total byte length for this tensor.
     pub byte_len: u64,
     pub shard_index: u32,
     pub source_shard_path: PathBuf,
     pub source_in_shard_index: u32,
+    /// The quantization policy decision for this tensor. This is the primary
+    /// actionable field for downstream packing and quantization logic.
     pub quant_policy: QuantPolicy,
+    /// If this tensor is protected (e.g., router), explains why.
     pub protected_reason: Option<String>,
+    /// FNV-1a 64-bit hash over the canonical tensor representation for
+    /// integrity verification across pipeline runs.
     pub deterministic_hash: String,
     pub warnings: Vec<String>,
 }
 
+/// Quantization policy for a single tensor in the conversion manifest.
+/// These values drive what grok-ozempic does (or does not do) with each
+/// tensor during the pilot quantization pass.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QuantPolicy {
+    /// Router must remain FP32 — quantization changes expert selection behavior.
     PassthroughF32Router,
+    /// Normalization tensors must remain FP32 — numerical sensitivity too high.
     PassthroughF32Norm,
+    /// Embedding is a SAAQ candidate with measurable risk score.
     CandidateSaaqEmbedding,
+    /// MoE expert projection already int8 — wrap in existing quantization envelope.
     WrapExistingInt8Expert,
+    /// Unknown int8 tensor — wrap but flag for review before full pipeline.
     WrapExistingInt8Unknown,
+    /// Cannot determine policy — pass through as-is with a warning.
     UnknownPassthroughOrWarn,
 }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -737,7 +737,7 @@ pub struct Grok1CoverageManifest {
     /// Schema version for the outer ModelInventory. Grok-1 uses schema_version = 2.
     pub schema_version: u32,
     /// Independent schema version for the coverage sub-structure. Grok-1 uses
-    /// coverage_schema_version = 1. These two version fields evolve independently.
+    /// coverage_schema_version = 2. These two version fields evolve independently.
     pub coverage_schema_version: u32,
     /// Validation result. "pass" if all checks succeed, "fail" otherwise.
     /// Downstream consumers must reject bundles where this is not "pass".

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -17,7 +17,7 @@
 //! | `RoutingReport` | 1 | — |
 //! | `StatsProfileReport` | 1 | — |
 //! | `SaaqReadinessReport` | 1 | — |
-//! | `Grok1CoverageManifest` | 2 | 1 | (two independent version fields)
+//! | `Grok1CoverageManifest` | 2 | 2 | (two independent version fields)
 //! | `ConversionManifest` | 1 | — |
 //! | `QuantPlan` | 1 | — |
 //! | `PilotSelectionPlan` | 1 | — |

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,8 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //
-// Offline tensor-payload profiling for SAAQ-readiness scouting. This layer
-// may read tensor payload bytes, but it never mutates weights and never
-// executes model code.
+//! Offline tensor-payload profiling for SAAQ-readiness scouting.
+//!
+//! This layer may read tensor payload bytes via memory-mapped sampling,
+//! but it never mutates weights and never executes model code. It produces
+//! two reports:
+//! - `StatsProfileReport`: per-tensor statistical moments (mean, variance,
+//!   stddev, min, max, zero_fraction, near_zero_fraction, outlier_fraction,
+//!   peak_to_rms, distribution_label) and per-layer aggregates
+//! - `SaaqReadinessReport`: candidate ranking for future SAAQ experiments,
+//!   with region classifications (routing_critical, normalization_sensitive,
+//!   already_compressed, potential_compression_target, embedding_heavy)
+//!
+//! ## Sampling
+//! By default up to 65,536 values are sampled per tensor (configurable
+//! via `--sample-values`). For large tensors this is a tiny fraction of
+//! total elements but is sufficient for statistical moment estimation.
+//!
+//! ## What it does NOT do
+//! - It does **not** compute SAAQ calibration scores
+//! - It does **not** select quantization bit-widths
+//! - It does **not** mutate checkpoint weights
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;


### PR DESCRIPTION
Fixes #18

## **User description**
## Handoff-Hardening Pass — Grok-1 Planning/Report Work

Performed by OpenCode agent **MiniMax-M2.7**.

### What Changed

| File | Change |
|------|--------|
| `README.md` | Added `dissect` to the Main commands quick-start listing (was the 9th CLI command present but missing from the README quick-start) |
| `CHANGELOG.md` | Datestamped the `## Unreleased` section so the merged Grok-1 planning/report work is anchored to 2026-05-27 |

### Verification

- `cargo test --locked`: **77 tests pass** (53 unit + 9 main.rs + 3 cli_help + 8 export_contracts + 2 parser_inventory + 2 pilot_route_reports)
- CLI help smoke: all 9 subcommands (`dissect`, `inventory`, `experts`, `routing-report`, `stats`, `saaq-readiness`, `pilot-plan`, `route-preservation`, `quant-plan`) present and correctly surfaced
- No Grok-1 checkpoint files in tests or CI; all fixtures are synthetic sample builders (`tests/support/mod.rs`)
- Artifact naming and field stability unchanged — already stable for `grok-ozempic`, `corinth-canal`, and `Surrogate_Viz.jl` consumers

### Scope Confirmed (unchanged — enforced by docs)

`xai-dissect` **inspects, classifies, and plans**. It does **not**:
- mutate checkpoints or run SAAQ quantization
- implement quantization kernels
- quantize routers
- act as an inference runtime

Downstream ownership: `grok-ozempic` (compression/packing), `SAAQ-latent` (latent calibration), `corinth-canal` (orchestration), `snn-projector` (projectors), `Surrogate_Viz.jl` (visualization).

### Reviewer Summary

Pure documentation hygiene pass. No schema fields modified, no new CLI surface added, no tests changed. All 77 tests pass cleanly. Branch `handoff-hardening-v3` → `main`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `dissect` subcommand docs to README and date unreleased changelog entry
> - Adds `dissect` to the 'Main commands' section in [README.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) as a raw per-shard byte-table view
> - Dates the Unreleased section header in [CHANGELOG.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) to 2026-05-27
> - Adds several new reference docs: [grok1-architecture.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-3db68e00eb9eb1f4c2c3aaa5f5d3e3164745af11d8b5d17b48cf60b9db07468e), [grok1-coverage-manifest.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-84dd547c06a92952bab67c3a85642221282c2879dae536e866e0bc4a6d2071f2), [metric-definitions.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-17a3df9f1931596a255d4570a8deac290e84e9b380675c35cdaa2d2ded31f76e), [quantized-weight-internals.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-1ee8103df643fdcb7e46b13b10834ceb33c816780a2b52696b16cbdc587954d4), and [run-examples.md](https://github.com/rmems/xai-dissect/pull/37/files#diff-d21c3e48e358748a9550fc8c12a96793e01ad2631dac5f8f975de96f21beac2f)
> - Expands rustdoc across most source modules with no code behavior changes
> - Fixes `Grok1CoverageManifest` deserialization in [src/schema/mod.rs](https://github.com/rmems/xai-dissect/pull/37/files#diff-bcd29853272b1eaad52850a6456c5d1e9d4f6c07aedfdb2ce28df189b83f5ace) to default `baseline_profile` to `"grok1-map-v1-clean"` when the field is absent
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aae229a. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/rmems/xai-dissect/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Document the Grok-1 handoff, validation gates, and command outputs**

### What Changed
- Added detailed docs for Grok-1 structure, shard layout, coverage validation, quantized weight storage, and route-preservation thresholds
- Added annotated walkthroughs for every CLI command, with examples of the main JSON and Markdown outputs
- Linked the GO/NO-GO guide to the new metric definitions so the acceptance checks are explained in one place
- Updated module and CLI descriptions so the command list, output tree, and role of each layer are clearer
- Added the missing `dissect` command to the README and dated the Unreleased changelog entry

### Impact
`✅ Clearer Grok-1 handoff review`
`✅ Easier CLI discovery for raw parsing`
`✅ Faster validation of coverage and routing artifacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>