### PR TITLE
fix: Sentry xai-dissect project, sentry-cli release script, run3 docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .codex/
 .idea/
 Cargo.lock.bak
+# Campaign artifacts (local dir or symlink to ~/rmems/grok-result/xai-dissect)
 out/
+/out
 run_*.sh
 ckpt-*/
 *.ckpt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +129,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -281,6 +299,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +463,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -778,6 +817,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +842,165 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "object"
@@ -854,6 +1064,22 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1029,9 +1255,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1052,7 +1278,6 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
@@ -1070,6 +1295,15 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1098,12 +1332,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -1144,10 +1372,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry"
-version = "0.46.2"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92d893ba7469d361a6958522fa440e4e2bc8bf4c5803cd1bf40b9af63f8f9a8"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sentry"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e4790d8c2f43a6645ee2cb12aac2db79221fddd035b94c8166b88ea094408"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -1155,6 +1389,7 @@ dependencies = [
  "reqwest",
  "sentry-anyhow",
  "sentry-backtrace",
+ "sentry-contexts",
  "sentry-core",
  "sentry-panic",
  "sentry-tracing",
@@ -1164,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.46.2"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6924ad794a4786c26739816afc9b54b31c13cad479698f53c0398c5f6400954"
+checksum = "8190c69f08c6c6054b528c61ec2c138b53be85a96887f0f4d4f0e7085f54d69b"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -1175,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.46.2"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8784d0a27b5cd4b5f75769ffc84f0b7580e3c35e1af9cd83cb90b612d769cc"
+checksum = "326e106874a7ea90636f1ca42e2f7b912929d29307982cab37f81208c16cf043"
 dependencies = [
  "backtrace",
  "regex",
@@ -1185,10 +1420,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-core"
-version = "0.46.2"
+name = "sentry-contexts"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b1e7ca40f965db239da279bf278d87b7407469b98835f27f0c8e59ed189b06"
+checksum = "3ab62ebc8076326e509c71a7424d2aaeff63fba9bc4e5b55074cd33f356c759f"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9efafefbb78d7e02cb06c10aec08b77e7500428389eabbf6d5a668325265e8"
 dependencies = [
  "rand",
  "sentry-types",
@@ -1199,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.46.2"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8906f8be87aea5ac7ef937323fb655d66607427f61007b99b7cb3504dc5a156c"
+checksum = "b8fc536a3e1fc68d626ae8dd18b628cafd474d9d36fea74e4bbb4d038877f003"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -1209,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.46.2"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b07eefe04486316c57aba08ab53dd44753c25102d1d3fe05775cc93a13262d9"
+checksum = "96be2253fe14b3fa10c1ba047af2d3e58ce85c8cb297bbd19d6fa81b604e7877"
 dependencies = [
  "bitflags",
  "sentry-backtrace",
@@ -1222,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.46.2"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567711f01f86a842057e1fc17779eba33a336004227e1a1e7e6cc2599e22e259"
+checksum = "f967748632cd4c5405dbed45426b27b407c0e53ac59b7df1c163e7f5aa57a77c"
 dependencies = [
  "debugid",
  "hex",
@@ -1278,18 +1527,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -1614,6 +1851,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 # Opt-in crash/error reporting for real-weight campaigns (see docs/ci.md).
-# Pinned below 0.49 (requires rustc 1.88). Slim defaults: panic+backtrace+transport
-# only — skip contexts/logs/metrics/debug-images on a public CLI binary.
-# `anyhow`: capture_anyhow for error chains.
+# MSRV is 1.88 → sentry 0.49+ is fine. Slim feature set for a public CLI:
+# panic + backtrace + transport + anyhow; skip logs/metrics/debug-images
+# (release strips symbols; we do not want Sentry performance product on by default).
 sentry = {
-  version = "0.46",
+  version = "0.49",
   default-features = false,
-  features = ["backtrace", "panic", "transport", "anyhow"],
+  features = ["backtrace", "contexts", "panic", "transport", "anyhow"],
 }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ files, builds a normalized tensor inventory, and emits structural reports for
 experts, routing, and future SAAQ-oriented profiling. It does not run the
 model, mutate weights, or act as an inference runtime.
 
-Current release target:
+Current focus:
 
-- **Grok-1**: supported now
-- **Grok-2**: not supported yet; tracked as a future follow-on only if public
-  weights are released under a compatible license
+- **Grok-1**: **supported now** — full inventory, experts, routing, stats,
+  SAAQ readiness, conversion-manifest, quant-plan, pilot-plan, and
+  route-preservation. This is the path that matters for **slice-by-slice /
+  pilot quantization** (block/expert/attention policies, routers+norms
+  protected). Downstream packing/runtime lives in sibling `grok-ozempic`.
+- **Grok-2**: public weights exist, but **this CLI does not support Grok-2
+  yet**. No parser/family profile, no inventory guarantees. Tracked as a
+  separate follow-on only after Grok-1 pilot quant is proven; see
+  [docs/grok2-future-support.md](docs/grok2-future-support.md).
 
 Only open/public weights are in scope. This repo analyzes weights you already
 have lawful access to and does not redistribute them.
@@ -176,14 +182,17 @@ Pull requests and `main` run fmt, tests, clippy (`-D warnings`), and CLI help
 smokes. Optional Codecov, Qodana, and Sentry hooks are documented in
 [docs/ci.md](docs/ci.md).
 
-## Future Grok-2 Support
+## Grok-2 (available weights; not in this CLI yet)
 
-Grok-2 is not yet in scope for implementation, but the repo now includes a
-future-support checklist and issue template to keep that work bounded when the
-time comes:
+Grok-2 open weights are out in the world, but **xai-dissect still only
+implements Grok-1 layouts**. Do not assume Grok-2 shards parse or classify.
 
-- [docs/grok2-future-support.md](docs/grok2-future-support.md)
-- [.github/ISSUE_TEMPLATE/grok2-support.md](.github/ISSUE_TEMPLATE/grok2-support.md)
+Priority for this project remains **Grok-1 cartography → conversion-manifest
+→ pilot quant in grok-ozempic** (slice-by-slice / mode-limited pilots with
+route preservation). Grok-2 is a bounded follow-on after that loop is solid:
+
+- Checklist: [docs/grok2-future-support.md](docs/grok2-future-support.md)
+- Issue template: [.github/ISSUE_TEMPLATE/grok2-support.md](.github/ISSUE_TEMPLATE/grok2-support.md)
 
 ## Relationship To Sibling Repos
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -57,26 +57,36 @@ Local DSN helper (gitignored machine config, never commit):
 ```bash
 # after creating the project key in Sentry UI/API:
 #   ~/.config/xai-dissect/sentry_dsn.env  → SENTRY_DSN=...
-set -a && source ~/.config/xai-dissect/sentry_dsn.env && set +a
+# Always clear allexport even if source fails (missing/invalid file).
+set -a
+source ~/.config/xai-dissect/sentry_dsn.env
+src_status=$?
+set +a
+if [ "$src_status" -ne 0 ]; then
+  printf 'failed to source sentry_dsn.env (status=%s)\n' "$src_status" >&2
+  return "$src_status" 2>/dev/null || exit "$src_status"
+fi
 ```
 
 What is sent:
 
 - Panics (via Sentry panic integration) with tags `repo`, `run_id` (and `command` after CLI parse)
 - Top-level command `anyhow` failures via `capture_anyhow` (full error chain) with
-  the same tags **plus** `error_category` (only on command failures)
-- `$HOME` redacted from messages, exception values, stacktrace frame paths, and breadcrumbs
-- Release name: `xai-dissect@<AGENTOS_GIT_SHA|unknown>` (aligned with CI when SHA is set)
+  the same tags **plus** `error_category` (only on command failures). The full
+  error chain is application-controlled text; `before_send` redacts `$HOME`
+  prefixes from messages / exception values / stack paths / breadcrumbs, but
+  does **not** strip arbitrary error content
+- Release name: `xai-dissect@<AGENTOS_GIT_SHA|unknown>` (same fallback as
+  `scripts/observability/sentry_release.sh` and `observability::git_sha`)
 - With the `contexts` feature: device/OS/rustc metadata (not weight data). `server_name` is fixed to
   `xai-dissect` (machine hostname is not advertised)
 
-What is **not** sent by default:
+SDK defaults that stay off (does **not** claim application error strings are scrubbed):
 
 - Weight tensors / checkpoint bytes
-- Default PII (`send_default_pii = false`)
+- Default SDK PII only (`send_default_pii = false` — IPs/headers via HTTP integrations)
 - Performance transactions (traces strategy remains **Disabled**; no sample rate configured)
 - Events when `XAI_DISSECT_SENTRY` is unset, or when `SENTRY_DSN` is empty/invalid
-
 CI release markers (main only) use `SENTRY_AUTH_TOKEN` + org/project secrets and
 do not require a DSN. Runtime capture uses `SENTRY_DSN` + the enable flag.
 Invalid DSNs soft-disable Sentry instead of panicking the CLI.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -98,14 +98,22 @@ Invalid DSNs soft-disable Sentry instead of panicking the CLI.
 
 ## Qodana Cloud setup
 
-`qodana-rust` is **Ultimate-only** — it needs a [Qodana Cloud](https://qodana.cloud/) project token. Without `QODANA_TOKEN`, CI **skips** the scan (green job, no Cloud report).
+There **is** a Qodana for Rust product — CI uses **`jetbrains/qodana-rust:2026.2-eap`**
+(`qodana.yaml` sets `linter: qodana-rust`). It is **not** free Community edition:
+Rust support is **Ultimate / Cloud** and needs a [Qodana Cloud](https://qodana.cloud/)
+project token. Without `QODANA_TOKEN`, CI **skips** the scan (green job, no Cloud report).
 
 1. Create account / org / team / project on [qodana.cloud](https://qodana.cloud/) for `rmems/xai-dissect`
 2. Copy the **project token** from the project card
 3. GitHub → Settings → Secrets and variables → Actions → add **`QODANA_TOKEN`**
 4. Re-run CI; expect a long Docker scan when the EAP linter can open the project
 
-Rust image tags on Docker Hub (as of 2026-08): `latest`, `2026.2-eap`, `2026.1-eap`. CI passes `--image jetbrains/qodana-rust:2026.2-eap`. Scan step uses `continue-on-error` because project-open timeouts are common on GitHub-hosted runners.
+Rust image tags on Docker Hub (as of 2026-08): `latest`, `2026.2-eap`, `2026.1-eap`.
+CI passes `--image jetbrains/qodana-rust:2026.2-eap` and
+`qd.rust.configuration.timeout.minutes=90`. Scans on GHA commonly take
+**~1.5 hours** (not stuck — slow project-open + EAP). The scan step uses
+`continue-on-error: true` so timeouts do not block merge; **Rust** remains
+the required quality gate.
 
 ### Disable / soften Qodana
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -58,9 +58,14 @@ Local DSN helper (gitignored machine config, never commit):
 # after creating the project key in Sentry UI/API:
 #   ~/.config/xai-dissect/sentry_dsn.env  → SENTRY_DSN=...
 # Always clear allexport even if source fails (missing/invalid file).
+# Under `set -e`, bare `source` would abort before `src_status`/`set +a`;
+# `if source` is exempt from errexit so we can always restore allexport.
 set -a
-source ~/.config/xai-dissect/sentry_dsn.env
-src_status=$?
+if source ~/.config/xai-dissect/sentry_dsn.env; then
+  src_status=0
+else
+  src_status=$?
+fi
 set +a
 if [ "$src_status" -ne 0 ]; then
   printf 'failed to source sentry_dsn.env (status=%s)\n' "$src_status" >&2

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,8 +23,8 @@ Set under GitHub → Settings → Secrets and variables → Actions:
 | `CODECOV_TOKEN` | coverage | Optional. When set, used for upload; when empty, OIDC (`use_oidc`) is enabled. Upload still soft-fails. |
 | `QODANA_TOKEN` | qodana | Optional. JetBrains Cloud **project** token from the [project card](https://qodana.cloud/). When set, the scan runs (soft-fail on EAP timeout). When unset, the job skips. Not a merge gate. |
 | `SENTRY_AUTH_TOKEN` | release-observability | Optional |
-| `SENTRY_ORG` | release-observability | Optional (with token + project) |
-| `SENTRY_PROJECT_XAI_DISSECT` | release-observability | Optional |
+| `SENTRY_ORG` | release-observability | Optional (with token + project); org slug is **`limen-neural`** |
+| `SENTRY_PROJECT_XAI_DISSECT` | release-observability | Optional; project slug **`xai-dissect`** (dedicated Rust project) |
 
 Do **not** use `QODANA_CONFIGURATIONS_TOKEN` as the scan token — that is an uploader/config token, not a Cloud project token.
 
@@ -41,7 +41,8 @@ Grok-1 weight campaigns:
 
 ```bash
 export XAI_DISSECT_SENTRY=1
-export SENTRY_DSN='https://…@….ingest.sentry.io/…'
+# DSN for limen-neural / xai-dissect (not the shared liquidcortex/rust projects):
+export SENTRY_DSN='https://…@….ingest.us.sentry.io/…'
 # optional — use full SHA so runtime release matches CI markers:
 export SENTRY_ENVIRONMENT=local-weights
 export AGENTOS_GIT_SHA="$(git rev-parse HEAD)"
@@ -49,6 +50,14 @@ export AGENTOS_GIT_SHA="$(git rev-parse HEAD)"
 export AGENTOS_RUN_ID="weights-$(date -u +%Y%m%d)-1"
 
 ./target/release/xai-dissect inventory /path/to/grok-1/ckpt-0
+```
+
+Local DSN helper (gitignored machine config, never commit):
+
+```bash
+# after creating the project key in Sentry UI/API:
+#   ~/.config/xai-dissect/sentry_dsn.env  → SENTRY_DSN=...
+set -a && source ~/.config/xai-dissect/sentry_dsn.env && set +a
 ```
 
 What is sent:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -67,12 +67,14 @@ What is sent:
   the same tags **plus** `error_category` (only on command failures)
 - `$HOME` redacted from messages, exception values, stacktrace frame paths, and breadcrumbs
 - Release name: `xai-dissect@<AGENTOS_GIT_SHA|unknown>` (aligned with CI when SHA is set)
+- With the `contexts` feature: device/OS/rustc metadata (not weight data). `server_name` is fixed to
+  `xai-dissect` (machine hostname is not advertised)
 
 What is **not** sent by default:
 
 - Weight tensors / checkpoint bytes
 - Default PII (`send_default_pii = false`)
-- Performance transactions (`traces_sample_rate = 0`)
+- Performance transactions (traces strategy remains **Disabled**; no sample rate configured)
 - Events when `XAI_DISSECT_SENTRY` is unset, or when `SENTRY_DSN` is empty/invalid
 
 CI release markers (main only) use `SENTRY_AUTH_TOKEN` + org/project secrets and

--- a/docs/grok2-future-support.md
+++ b/docs/grok2-future-support.md
@@ -3,14 +3,21 @@
 This document exists to keep future Grok-2 work bounded. It is a planning
 checklist, not a commitment.
 
+**Status (2026-08):** public Grok-2 weights are available, but **xai-dissect
+has no Grok-2 family support yet**. Near-term priority stays **Grok-1**
+slice-by-slice / pilot quantization readiness (conversion-manifest, quant-plan,
+route preservation → grok-ozempic). Do not start Grok-2 implementation until
+the Grok-1 pilot loop is proven and a local Grok-2 checkpoint is in hand.
+
 ## Preconditions
 
 Work should not start until all of the following are true:
 
-- public Grok-2 weights are actually available
-- the weight license is compatible with this repo's lawful-analysis scope
+- public Grok-2 weights are available under a license compatible with this
+  repo's lawful-analysis scope
 - at least one checkpoint layout can be inspected locally
-
+- Grok-1 pilot / slice-quant handoff is stable enough that a second family
+  will not derail that path
 ## First Questions To Answer
 
 - Is the shard/container format still compatible with the current parser?

--- a/docs/runs/README.md
+++ b/docs/runs/README.md
@@ -1,0 +1,16 @@
+# Campaign run notes
+
+Large Grok-1 campaign artifacts are **not** stored in this repo.
+
+| What | Where |
+|------|--------|
+| Current baseline (run3) | `~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN` |
+| May baseline (run2) | `~/rmems/grok-result/xai-dissect/grok1_run2_after_fixes_20260525T002904Z` |
+| Comparison | [grok1_run3_vs_run2_comparison.md](./grok1_run3_vs_run2_comparison.md) |
+| Storage root README | `~/rmems/grok-result/README.md` |
+
+Optional local convenience (gitignored):
+
+```bash
+ln -sfn ~/rmems/grok-result/xai-dissect out
+```

--- a/docs/runs/README.md
+++ b/docs/runs/README.md
@@ -12,5 +12,11 @@ Large Grok-1 campaign artifacts are **not** stored in this repo.
 Optional local convenience (gitignored):
 
 ```bash
-ln -sfn ~/rmems/grok-result/xai-dissect out
+# If `out` already exists as a normal directory, `ln -sfn` can nest a link
+# inside it instead of replacing the path. Refuse that footgun:
+if [ -e out ] && [ ! -L out ]; then
+  printf '%s\n' 'out exists and is not a symlink; remove or rename it first.' >&2
+  exit 1
+fi
+ln -sfn "$HOME/rmems/grok-result/xai-dissect" out
 ```

--- a/docs/runs/grok1_run3_vs_run2_comparison.md
+++ b/docs/runs/grok1_run3_vs_run2_comparison.md
@@ -1,0 +1,179 @@
+# Grok-1 campaign comparison: run2 (May) vs run3 (Aug 2026)
+
+**Classification:** internal experimental comparison (checkpoint cartography re-run)  
+**Depth:** structural + statistical + schema delta analysis  
+**Sources:** local artifacts only (no external literature)
+
+| Field | May run2 | Aug run3 |
+|-------|----------|----------|
+| Path | `~/rmems/grok-result/xai-dissect/grok1_run2_after_fixes_20260525T002904Z` | `~/rmems/grok-result/xai-dissect/grok1_run3_20260802T023050Z` |
+| Generated | 2026-05-25T00:29:04Z | 2026-08-02T02:30:50Z → 02:51:47Z (~21 min) |
+| Checkpoint | `.../Downloads/SNN_Quantization/grok-1-official/ckpt-0` (historical) | `/home/raulmc/.models/xai-grok-1/ckpt-0` |
+| Slug | `grok-1-official__ckpt-0` | `xai-grok-1-ckpt-0` |
+| Tooling baseline | pre planning-surface PRs | main after #32/#34/#36/#37/#48 |
+
+---
+
+## Executive summary
+
+**Cartography is bit-stable on structure and sampled stats.** Re-running on the relocated Grok-1 ckpt-0 with the post-planning-surface binary reproduces:
+
+- identical tensor identities (770 tensors; path-stripped inventory equal)
+- identical experts atlas and routing report (path-stripped equal)
+- identical coverage counts and checksum (`fnv1a64:de5a1c978121c62c`)
+- identical offline stats aggregates (`avg_rms ≈ 19.76228`, `avg_var ≈ 631.45063` over 770 profiles at 65 536 samples/tensor)
+
+**What changed is product surface, not the model map.** Run3 adds conversion/quant/pilot/route-preservation artifacts and expands SAAQ readiness to schema v2 with much richer candidate payloads. That is expected tool evolution, not checkpoint drift.
+
+**Implication for GO/NO-GO:** structural prerequisites for a Grok-1 pilot remain green. Runtime gates (router agreement, block cosine) stay `unknown` by design until grok-ozempic (or similar) fills them.
+
+---
+
+## 1. Structural identity (unchanged)
+
+| Metric | run2 | run3 | Match |
+|--------|------|------|-------|
+| model_family | grok-1 | grok-1 | yes |
+| shards / tensors | 770 / 770 | 770 / 770 | yes |
+| total payload bytes | 318 114 914 304 | 318 114 914 304 | yes |
+| inferred (vocab, d_model, n_experts, d_ff, n_blocks) | 131072 / 6144 / 8 / 32768 / 64 | same | yes |
+| dtype mix | 322 f32 + 448 int8 | same | yes |
+| tensor identity sequence (ordinal, shape, offset, nbytes, kind, block) | — | — | **equal** |
+| inventory tensors path-stripped | — | — | **equal** |
+| experts path-stripped | — | — | **equal** |
+| routing path-stripped | — | — | **equal** |
+
+### Kind histogram (both runs)
+
+| Kind | Count |
+|------|------:|
+| attn_proj_i8.model_width | 128 |
+| attn_proj_i8.narrow | 128 |
+| block_norm | 256 |
+| final_norm | 1 |
+| moe_expert.down / gate / up | 64 each |
+| router | 64 |
+| token_embedding | 1 |
+
+### Coverage gate
+
+| Field | run2 | run3 |
+|-------|------|------|
+| validation | pass | pass |
+| coverage_schema_version | **1** | **2** |
+| baseline_profile | *(absent)* | **`grok1-map-v1-clean`** |
+| checksum | `fnv1a64:de5a1c978121c62c` | same |
+| expected = discovered | blocks 64, tensors 770, routers 64, expert_families 192, unknown 0 | same |
+| unknown_slots | [] | [] |
+
+Coverage schema v2 only adds the explicit baseline label; the integrity hash is unchanged.
+
+---
+
+## 2. Statistical profile (unchanged at aggregate level)
+
+Both runs used `--sample-values 65536` with the same near-zero thresholds (`f32_near_zero_abs=0.001`, `i8_near_zero_abs=1`).
+
+| Aggregate | run2 | run3 |
+|-----------|------|------|
+| profiles | 770 | 770 |
+| mean RMS (all tensors) | 19.76228195189274 | **identical** |
+| mean variance | 631.4506342843616 | **identical** |
+
+Shared JSON/MD bodies for inventory/experts/routing/stats differ by only ~24–30 bytes in most files — explained by shorter absolute `checkpoint_path` / `shard_path` strings on the new disk location, not by numerical drift.
+
+---
+
+## 3. SAAQ readiness: schema expansion (material delta)
+
+| Artifact | run2 size | run3 size | Δ |
+|----------|----------:|----------:|--:|
+| `exports/saaq-readiness.json` | 77 445 | 1 416 674 | **+1.34 MiB** |
+| `manifests/candidate-saaq-targets.json` | 926 | 371 133 | **+370 KiB** |
+| `reports/saaq-readiness.md` | 22 917 | 140 966 | **+118 KiB** |
+
+### Schema
+
+| | run2 | run3 |
+|--|------|------|
+| `schema_version` (saaq export) | 1 | **2** |
+| export keys | candidate_targets, inferred, layer_readiness, manifest, notes, risky_tensors, routing_critical_tensors, … | + **`deferred_tensors`**, **`precision_sensitive_tensors`**, **`quantization_candidates`** |
+
+Run3 readiness report notes partition **770** tensors into:
+
+- 448 quantization candidates  
+- 64 routing-critical  
+- 257 precision-sensitive  
+- 1 deferred (`token_embedding`)
+
+Top quant-plan readiness callout: `block_030.slot_01.moe_expert.down` (readiness ≈ 0.188).
+
+This is **richer scouting output**, not a change in which tensors exist.
+
+---
+
+## 4. New planning artifacts (run3 only)
+
+Absent from May run2; all require clean baseline and landed via #32/#34/#36:
+
+| Artifact | Role | Highlights |
+|----------|------|------------|
+| `conversion-manifest.json` | Per-tensor conversion handoff (770 entries) | Policies: wrap_existing_int8_expert 192, wrap_existing_int8_unknown 256, passthrough_f32_norm 257, passthrough_f32_router 64, candidate_saaq_embedding 1 |
+| `quant-plan.json` / `.md` | Family-level pilot policy | **keep_fp32:** router, block_norm, final_norm; **pilot_quantize:** attn + moe experts; **defer:** token_embedding |
+| `pilot-selection-plan.json` / `.md` | Representative blocks | blocks **0, 8, 28, 60, 63**; modes attention_only / expert_only / attention_plus_expert |
+| `route-preservation-report.json` / `.md` | Gate surface for runtime metrics | Router top-1/top-2, block cosine, etc. all **`status: unknown`** with thresholds reserved for downstream pilots |
+
+These close the handoff gap to grok-ozempic / SAAQ without re-deriving the May map.
+
+---
+
+## 5. What did *not* regress
+
+- No new unknown tensors  
+- No router/expert family count drift  
+- No expert unresolved entries  
+- No stats sampling regression at default 65 536  
+- No inventory kind reclassification  
+
+---
+
+## 6. Residual differences (non-semantic)
+
+| Difference | Cause | Action |
+|------------|--------|--------|
+| Absolute paths in JSON | Checkpoint relocated under `~/.models/` | Normalize on consumer side; use ordinal + kind identity |
+| Slug naming | Explicit `--checkpoint-slug` sanitized `__` → `-` | Prefer new slug for handoff |
+| File size −24 B on many shared exports | Shorter path strings | Ignore |
+| SAAQ size explosion | Schema v2 + full candidate expansion | Prefer run3 for scouting |
+| Coverage schema 1 → 2 | Explicit `baseline_profile` | Consumers should accept v2 |
+
+---
+
+## 7. Actionable insights
+
+1. **Trust run3 as the new structural baseline** for exports to grok-ozempic (`LATEST_CORRECT_GROK1_RUN`).  
+2. **Do not re-litigate MoE geometry** — path-stripped experts/routing match May.  
+3. **Start pilot work from** `pilot-selection-plan` blocks + `conversion-manifest` policies; protect routers/norms per quant-plan.  
+4. **Fill route-preservation `unknown` metrics** in the quant runtime repo; xai-dissect cannot clear quant GO alone.  
+5. **Optional:** store path-normalized golden fixtures from run3 for CI regression (checksum already stable).
+
+---
+
+## 8. Development plan
+
+| Horizon | Work |
+|---------|------|
+| Short | Point grok-ozempic at `~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/` |
+| Medium | Run attention/expert pilot modes on blocks 0/8/28/60/63; write observed router/cosine into route-preservation |
+| Long | Automate run3-style campaign in CI smoke against a tiny fixture; keep real-weight campaign as manual release gate |
+
+---
+
+## Verdict
+
+| Question | Answer |
+|----------|--------|
+| Did the checkpoint map change? | **No** (structure + stats aggregates identical) |
+| Did tooling output improve? | **Yes** (planning + conversion + SAAQ v2) |
+| Prefer run for handoff? | **run3** |
+| Quant GO? | Structural inputs **pass**; runtime metrics still **missing** |

--- a/docs/runs/grok1_run3_vs_run2_comparison.md
+++ b/docs/runs/grok1_run3_vs_run2_comparison.md
@@ -8,7 +8,7 @@
 |-------|----------|----------|
 | Path | `~/rmems/grok-result/xai-dissect/grok1_run2_after_fixes_20260525T002904Z` | `~/rmems/grok-result/xai-dissect/grok1_run3_20260802T023050Z` |
 | Generated | 2026-05-25T00:29:04Z | 2026-08-02T02:30:50Z → 02:51:47Z (~21 min) |
-| Checkpoint | `.../Downloads/SNN_Quantization/grok-1-official/ckpt-0` (historical) | `/home/raulmc/.models/xai-grok-1/ckpt-0` |
+| Checkpoint | `.../Downloads/SNN_Quantization/grok-1-official/ckpt-0` (historical) | `~/.models/xai-grok-1/ckpt-0` |
 | Slug | `grok-1-official__ckpt-0` | `xai-grok-1-ckpt-0` |
 | Tooling baseline | pre planning-surface PRs | main after #32/#34/#36/#37/#48 |
 

--- a/scripts/observability/sentry_release.sh
+++ b/scripts/observability/sentry_release.sh
@@ -8,7 +8,9 @@
 #
 # Optional:
 #   SENTRY_ENVIRONMENT  (default: local)
-#   AGENTOS_GIT_SHA     (default: short git HEAD)
+#   AGENTOS_GIT_SHA     (must match runtime when correlating events;
+#                       when unset, falls back to `unknown` like git_sha() in
+#                       src/observability.rs — not short HEAD)
 #
 # Note: sentry-cli 2.46+ rejects global `--org` / `--project` before the
 # subcommand. Prefer env vars (SENTRY_ORG / SENTRY_PROJECT), which work on
@@ -19,7 +21,11 @@ repo="xai-dissect"
 org="${SENTRY_ORG:-}"
 project="${SENTRY_PROJECT_XAI_DISSECT:-${SENTRY_PROJECT:-}}"
 environment="${SENTRY_ENVIRONMENT:-local}"
-git_sha="${AGENTOS_GIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || printf 'unknown')}"
+# Match runtime: xai-dissect@<AGENTOS_GIT_SHA|unknown> (see observability::git_sha).
+git_sha="${AGENTOS_GIT_SHA:-unknown}"
+if [[ -z "${git_sha// }" ]]; then
+  git_sha="unknown"
+fi
 release="${repo}@${git_sha}"
 
 if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
@@ -40,8 +46,27 @@ fi
 export SENTRY_ORG="${org}"
 export SENTRY_PROJECT="${project}"
 
-if ! sentry-cli releases info "${release}" >/dev/null 2>&1; then
-  sentry-cli releases new "${release}"
+# Only create when the release is confirmed missing. Auth/network/project
+# errors from `releases info` must surface, not be treated as "not found".
+info_err="$(mktemp)"
+set +e
+sentry-cli releases info "${release}" >/dev/null 2>"${info_err}"
+info_status=$?
+set -e
+if [[ "${info_status}" -ne 0 ]]; then
+  info_msg="$(cat "${info_err}" 2>/dev/null || true)"
+  rm -f "${info_err}"
+  # sentry-cli typically says "could not find release" / "Release not found"
+  # for a missing version; anything else is a hard failure.
+  if printf '%s' "${info_msg}" | grep -qiE 'not found|could not find release|404'; then
+    sentry-cli releases new "${release}"
+  else
+    printf 'sentry-cli releases info failed (status=%s):\n%s\n' \
+      "${info_status}" "${info_msg}" >&2
+    exit "${info_status}"
+  fi
+else
+  rm -f "${info_err}"
 fi
 
 sentry-cli releases set-commits "${release}" --auto --ignore-missing

--- a/scripts/observability/sentry_release.sh
+++ b/scripts/observability/sentry_release.sh
@@ -56,12 +56,14 @@ set -e
 if [[ "${info_status}" -ne 0 ]]; then
   info_msg="$(cat "${info_err}" 2>/dev/null || true)"
   rm -f "${info_err}"
-  # sentry-cli typically says "could not find release" / "Release not found"
-  # for a missing version; anything else is a hard failure.
-  if printf '%s' "${info_msg}" | grep -qiE 'not found|could not find release|404'; then
+  # Only treat a *version-specific* missing-release response as create-eligible.
+  # Generic "not found" / bare 404 can mean bad org, project, or token — fail closed.
+  # Typical missing-release text includes the version string and "release".
+  if printf '%s' "${info_msg}" | grep -qiF "${release}" \
+    && printf '%s' "${info_msg}" | grep -qiE 'could not find release|release not found|no such release'; then
     sentry-cli releases new "${release}"
   else
-    printf 'sentry-cli releases info failed (status=%s):\n%s\n' \
+    printf 'sentry-cli releases info failed (status=%s); not creating release:\n%s\n' \
       "${info_status}" "${info_msg}" >&2
     exit "${info_status}"
   fi

--- a/scripts/observability/sentry_release.sh
+++ b/scripts/observability/sentry_release.sh
@@ -1,12 +1,31 @@
 #!/usr/bin/env bash
+# Create/finalize a Sentry release + deploy for xai-dissect (main CI only).
+#
+# Required env:
+#   SENTRY_AUTH_TOKEN
+#   SENTRY_ORG
+#   SENTRY_PROJECT_XAI_DISSECT  (or SENTRY_PROJECT)
+#
+# Optional:
+#   SENTRY_ENVIRONMENT  (default: local)
+#   AGENTOS_GIT_SHA     (default: short git HEAD)
+#
+# Note: sentry-cli 2.46+ rejects global `--org` / `--project` before the
+# subcommand. Prefer env vars (SENTRY_ORG / SENTRY_PROJECT), which work on
+# both 2.x and 3.x.
 set -euo pipefail
 
 repo="xai-dissect"
 org="${SENTRY_ORG:-}"
-project="${SENTRY_PROJECT_XAI_DISSECT:-}"
+project="${SENTRY_PROJECT_XAI_DISSECT:-${SENTRY_PROJECT:-}}"
 environment="${SENTRY_ENVIRONMENT:-local}"
 git_sha="${AGENTOS_GIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || printf 'unknown')}"
 release="${repo}@${git_sha}"
+
+if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
+  printf 'SENTRY_AUTH_TOKEN is required\n' >&2
+  exit 2
+fi
 
 if [[ -z "${org}" ]]; then
   printf 'SENTRY_ORG is required\n' >&2
@@ -14,20 +33,19 @@ if [[ -z "${org}" ]]; then
 fi
 
 if [[ -z "${project}" ]]; then
-  printf 'SENTRY_PROJECT_XAI_DISSECT is required\n' >&2
+  printf 'SENTRY_PROJECT_XAI_DISSECT (or SENTRY_PROJECT) is required\n' >&2
   exit 2
 fi
 
-sentry_cmd() {
-  sentry-cli --org "${org}" --project "${project}" "$@"
-}
+export SENTRY_ORG="${org}"
+export SENTRY_PROJECT="${project}"
 
-if ! sentry_cmd releases info "${release}" >/dev/null 2>&1; then
-  sentry_cmd releases new "${release}"
+if ! sentry-cli releases info "${release}" >/dev/null 2>&1; then
+  sentry-cli releases new "${release}"
 fi
 
-sentry_cmd releases set-commits "${release}" --auto --ignore-missing
-sentry_cmd releases finalize "${release}"
-sentry_cmd deploys new --release "${release}" -e "${environment}"
+sentry-cli releases set-commits "${release}" --auto --ignore-missing
+sentry-cli releases finalize "${release}"
+sentry-cli deploys new --release "${release}" -e "${environment}"
 
 printf '%s\n' "${release}"

--- a/scripts/observability/sentry_release.sh
+++ b/scripts/observability/sentry_release.sh
@@ -21,13 +21,11 @@ repo="xai-dissect"
 org="${SENTRY_ORG:-}"
 project="${SENTRY_PROJECT_XAI_DISSECT:-${SENTRY_PROJECT:-}}"
 environment="${SENTRY_ENVIRONMENT:-local}"
-# Match runtime: xai-dissect@<AGENTOS_GIT_SHA|unknown> (see observability::git_sha).
-git_sha="${AGENTOS_GIT_SHA:-unknown}"
-# Trim leading/trailing whitespace to match runtime git_sha_from_value (str::trim).
-git_sha="$(printf '%s' "${git_sha}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+# Match runtime: xai-dissect@<AGENTOS_GIT_SHA|unknown> (see observability::git_sha /
+# git_sha_from_value: trim then empty → unknown).
+git_sha="$(printf '%s' "${AGENTOS_GIT_SHA:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 if [[ -z "${git_sha}" ]]; then
   git_sha="unknown"
-fi
 fi
 release="${repo}@${git_sha}"
 
@@ -72,9 +70,16 @@ sentry-cli releases info "${release}" >/dev/null 2>"${info_err}"
 info_status=$?
 set -e
 if [[ "${info_status}" -ne 0 ]]; then
-  # Auth/project already validated via list; treat info failure as missing release.
-  # (sentry-cli may print nothing at default log level on 404.)
+  info_msg="$(cat "${info_err}" 2>/dev/null || true)"
   rm -f "${info_err}"
+  # list already validated token/org/project. Still fail closed if info stderr
+  # looks like auth/permission (not the usual empty-404 missing release).
+  if printf '%s' "${info_msg}" | grep -qiE 'unauthorized|forbidden|invalid.?token|403|authentication|access denied'; then
+    printf 'sentry-cli releases info failed after list OK (status=%s):\n%s\n' \
+      "${info_status}" "${info_msg}" >&2
+    exit "${info_status}"
+  fi
+  # Missing release: often empty stderr at default log level (HTTP 404).
   sentry-cli releases new "${release}"
 else
   rm -f "${info_err}"

--- a/scripts/observability/sentry_release.sh
+++ b/scripts/observability/sentry_release.sh
@@ -46,27 +46,33 @@ fi
 export SENTRY_ORG="${org}"
 export SENTRY_PROJECT="${project}"
 
-# Only create when the release is confirmed missing. Auth/network/project
-# errors from `releases info` must surface, not be treated as "not found".
+# Preflight auth/org/project. sentry-cli 2.46+/3.x often returns empty stderr on a
+# missing release (HTTP 404) with no version string, so we cannot parse "not found"
+# text reliably. After list succeeds, a failed `releases info` means the version
+# is absent — create it. If list fails, surface that error (token/org/project).
+list_err="$(mktemp)"
+set +e
+sentry-cli releases list >/dev/null 2>"${list_err}"
+list_status=$?
+set -e
+if [[ "${list_status}" -ne 0 ]]; then
+  printf 'sentry-cli releases list failed (status=%s); check token/org/project:\n%s\n' \
+    "${list_status}" "$(cat "${list_err}" 2>/dev/null || true)" >&2
+  rm -f "${list_err}"
+  exit "${list_status}"
+fi
+rm -f "${list_err}"
+
 info_err="$(mktemp)"
 set +e
 sentry-cli releases info "${release}" >/dev/null 2>"${info_err}"
 info_status=$?
 set -e
 if [[ "${info_status}" -ne 0 ]]; then
-  info_msg="$(cat "${info_err}" 2>/dev/null || true)"
+  # Auth/project already validated via list; treat info failure as missing release.
+  # (sentry-cli may print nothing at default log level on 404.)
   rm -f "${info_err}"
-  # Only treat a *version-specific* missing-release response as create-eligible.
-  # Generic "not found" / bare 404 can mean bad org, project, or token — fail closed.
-  # Typical missing-release text includes the version string and "release".
-  if printf '%s' "${info_msg}" | grep -qiF "${release}" \
-    && printf '%s' "${info_msg}" | grep -qiE 'could not find release|release not found|no such release'; then
-    sentry-cli releases new "${release}"
-  else
-    printf 'sentry-cli releases info failed (status=%s); not creating release:\n%s\n' \
-      "${info_status}" "${info_msg}" >&2
-    exit "${info_status}"
-  fi
+  sentry-cli releases new "${release}"
 else
   rm -f "${info_err}"
 fi

--- a/scripts/observability/sentry_release.sh
+++ b/scripts/observability/sentry_release.sh
@@ -23,8 +23,11 @@ project="${SENTRY_PROJECT_XAI_DISSECT:-${SENTRY_PROJECT:-}}"
 environment="${SENTRY_ENVIRONMENT:-local}"
 # Match runtime: xai-dissect@<AGENTOS_GIT_SHA|unknown> (see observability::git_sha).
 git_sha="${AGENTOS_GIT_SHA:-unknown}"
-if [[ -z "${git_sha// }" ]]; then
+# Trim leading/trailing whitespace to match runtime git_sha_from_value (str::trim).
+git_sha="$(printf '%s' "${git_sha}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+if [[ -z "${git_sha}" ]]; then
   git_sha="unknown"
+fi
 fi
 release="${repo}@${git_sha}"
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -44,22 +44,23 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
     // Align with CI: scripts/observability/sentry_release.sh uses git SHA only.
     let release = format!("xai-dissect@{}", git_sha());
 
-    let guard = sentry::init(sentry::ClientOptions {
-        dsn: Some(dsn),
-        release: Some(Cow::Owned(release)),
-        environment: Some(Cow::Owned(environment)),
-        // Error reporting only for opt-in weight runs (no perf transactions).
-        traces_sample_rate: 0.0,
-        // CLI: never send IPs/headers/PII (docs enable this for HTTP servers only).
-        send_default_pii: false,
+    // sentry 0.49+: ClientOptions is non_exhaustive — use builder methods.
+    // Default traces strategy is Disabled (errors only; no performance product).
+    // Soft-parsed Dsn is assigned after builders (builder `.dsn(&str)` panics on bad input).
+    let mut options = sentry::ClientOptions::new()
+        .release(Cow::Owned(release))
+        .environment(Cow::Owned(environment))
+        // CLI: never send IPs/headers/PII (HTTP-server docs enable true).
+        .send_default_pii(false)
         // Avoid advertising hostname when contexts are compiled in.
-        server_name: Some(Cow::Borrowed("xai-dissect")),
-        before_send: Some(std::sync::Arc::new(|mut event| {
+        .server_name("xai-dissect")
+        .before_send(|mut event| {
             scrub_event_paths(&mut event);
             Some(event)
-        })),
-        ..Default::default()
-    });
+        });
+    options.dsn = Some(dsn);
+
+    let guard = sentry::init(options);
 
     if !guard.is_enabled() {
         return None;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -26,6 +26,14 @@ static CACHED_RUN_ID: OnceLock<String> = OnceLock::new();
 /// mis-attributed to a deploy that was never created.
 /// Invalid DSNs soft-fail (return `None`) instead of panicking — `sentry::init`
 /// panics on bad DSNs, which would break the CLI for a misconfigured opt-in.
+///
+/// # What leaves the machine (when enabled)
+///
+/// `capture_error` / `capture_anyhow` send the **full application error chain**.
+/// `before_send` only redacts `$HOME` prefixes from messages, exception values,
+/// stack frame paths, and breadcrumbs — it does **not** strip arbitrary error
+/// text. `send_default_pii(false)` only disables SDK default PII (IPs/headers
+/// via HTTP integrations), not app-provided error content.
 pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
     if !env_flag_enabled("XAI_DISSECT_SENTRY") {
         return None;
@@ -41,7 +49,7 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "local".to_owned());
 
-    // Align with CI: scripts/observability/sentry_release.sh uses git SHA only.
+    // Align with scripts/observability/sentry_release.sh: same git_sha fallback.
     let release = format!("xai-dissect@{}", git_sha());
 
     // sentry 0.49+: ClientOptions is non_exhaustive — use builder methods.
@@ -55,11 +63,11 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
         // Avoid advertising hostname when contexts are compiled in.
         .server_name("xai-dissect")
         .before_send(|mut event| {
+            // Path scrub only; error chain text from capture_anyhow still ships.
             scrub_event_paths(&mut event);
             Some(event)
         });
     options.dsn = Some(dsn);
-
     let guard = sentry::init(options);
 
     if !guard.is_enabled() {

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -35,14 +35,13 @@ static CACHED_RUN_ID: OnceLock<String> = OnceLock::new();
 /// text. `send_default_pii(false)` only disables SDK default PII (IPs/headers
 /// via HTTP integrations), not app-provided error content.
 pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
-    if !env_flag_enabled("XAI_DISSECT_SENTRY") {
+    let flag = std::env::var("XAI_DISSECT_SENTRY").ok();
+    let dsn_raw = std::env::var("SENTRY_DSN").ok();
+    // Parse before init: invalid DSNs must not panic the process.
+    if !sentry_opt_in_ready(flag.as_deref(), dsn_raw.as_deref()) {
         return None;
     }
-    let dsn_raw = std::env::var("SENTRY_DSN")
-        .ok()
-        .filter(|value| !value.trim().is_empty())?;
-    // Parse before init: invalid DSNs must not panic the process.
-    let dsn: sentry::types::Dsn = dsn_raw.trim().parse().ok()?;
+    let dsn = parse_optional_dsn(dsn_raw.as_deref())?;
 
     let environment = std::env::var("SENTRY_ENVIRONMENT")
         .ok()
@@ -51,7 +50,6 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
 
     // Align with scripts/observability/sentry_release.sh: same git_sha fallback.
     let release = format!("xai-dissect@{}", git_sha());
-
     // sentry 0.49+: ClientOptions is non_exhaustive — use builder methods.
     // Default traces strategy is Disabled (errors only; no performance product).
     // Soft-parsed Dsn is assigned after builders (builder `.dsn(&str)` panics on bad input).
@@ -83,13 +81,13 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
     Some(guard)
 }
 
-fn env_flag_enabled(name: &str) -> bool {
-    let Ok(raw) = std::env::var(name) else {
-        return false;
-    };
+/// Pure form of the dual-gate truthy check (env value already loaded).
+fn env_flag_from_value(raw: Option<&str>) -> bool {
     matches!(
-        raw.trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on"
+        raw.map(str::trim)
+            .map(|s| s.to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("yes") | Some("on")
     )
 }
 
@@ -110,11 +108,10 @@ fn scrub_stacktrace(stacktrace: &mut sentry::protocol::Stacktrace, home: &str) {
     }
 }
 
-/// Redact home-directory prefixes from messages, exceptions, frames, breadcrumbs.
-fn scrub_event_paths(event: &mut sentry::protocol::Event<'_>) {
-    let Some(home) = std::env::var_os("HOME").and_then(|h| h.into_string().ok()) else {
-        return;
-    };
+/// Redact `home` prefixes from messages, exceptions, frames, breadcrumbs.
+///
+/// Pure/testable core; production `scrub_event_paths` loads `$HOME` and calls this.
+fn scrub_event_paths_with_home(event: &mut sentry::protocol::Event<'_>, home: &str) {
     let home = home.trim_end_matches('/');
     if home.is_empty() {
         return;
@@ -135,6 +132,32 @@ fn scrub_event_paths(event: &mut sentry::protocol::Event<'_>) {
     }
 }
 
+/// Redact home-directory prefixes from messages, exceptions, frames, breadcrumbs.
+fn scrub_event_paths(event: &mut sentry::protocol::Event<'_>) {
+    let Some(home) = std::env::var_os("HOME").and_then(|h| h.into_string().ok()) else {
+        return;
+    };
+    scrub_event_paths_with_home(event, &home);
+}
+
+/// Parse a non-empty DSN string; empty/whitespace/invalid → `None` (soft-fail).
+fn parse_optional_dsn(raw: Option<&str>) -> Option<sentry::types::Dsn> {
+    let s = raw.map(str::trim).filter(|v| !v.is_empty())?;
+    s.parse().ok()
+}
+
+/// Dual-gate readiness without contacting Sentry: flag truthy **and** parseable DSN.
+fn sentry_opt_in_ready(flag_raw: Option<&str>, dsn_raw: Option<&str>) -> bool {
+    env_flag_from_value(flag_raw) && parse_optional_dsn(dsn_raw).is_some()
+}
+
+/// Release suffix from env: non-empty `AGENTOS_GIT_SHA` or `"unknown"`.
+fn git_sha_from_value(raw: Option<&str>) -> String {
+    raw.map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
 /// Report a top-level command failure (no-op when Sentry is disabled).
 ///
 /// Uses `capture_anyhow` so Sentry gets the full error chain (not a flat
@@ -181,10 +204,7 @@ pub fn run_id() -> String {
 }
 
 pub fn git_sha() -> String {
-    std::env::var("AGENTOS_GIT_SHA")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "unknown".to_owned())
+    git_sha_from_value(std::env::var("AGENTOS_GIT_SHA").ok().as_deref())
 }
 
 pub fn error_category(error: Option<&Error>) -> &'static str {
@@ -217,18 +237,11 @@ pub fn error_category(error: Option<&Error>) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        env_flag_enabled, error_category, git_sha, init_sentry, scrub_event_paths, scrub_str,
+        env_flag_from_value, error_category, git_sha_from_value, parse_optional_dsn,
+        scrub_event_paths_with_home, scrub_str, sentry_opt_in_ready,
     };
     use anyhow::Error;
-    use sentry::protocol::{Event, Exception, LogEntry, Values};
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
+    use sentry::protocol::{Event, Exception, Values};
 
     fn classify(message: &str) -> &'static str {
         let error = Error::msg(message.to_owned());
@@ -291,12 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn scrub_event_paths_redacts_message_and_exception() {
-        let _lock = env_lock();
-        // SAFETY: serialized by env_lock; restored below.
-        unsafe {
-            std::env::set_var("HOME", "/home/scrub-test-user");
-        }
+    fn scrub_event_paths_with_home_redacts_message_and_exception() {
         let mut event = Event {
             message: Some("/home/scrub-test-user/weights/ckpt".into()),
             exception: Values {
@@ -305,103 +313,66 @@ mod tests {
                     ..Default::default()
                 }],
             },
-            logentry: Some(LogEntry {
-                message: "ok".into(),
-                params: vec![],
-            }),
             ..Default::default()
         };
-        scrub_event_paths(&mut event);
+        scrub_event_paths_with_home(&mut event, "/home/scrub-test-user");
         assert_eq!(event.message.as_deref(), Some("$HOME/weights/ckpt"));
         assert_eq!(
             event.exception.values[0].value.as_deref(),
             Some("stat $HOME/missing")
         );
-        unsafe {
-            std::env::remove_var("HOME");
-        }
     }
 
     #[test]
-    fn env_flag_accepts_common_truthy_values() {
-        let _lock = env_lock();
-        let key = "XAI_DISSECT_TEST_FLAG_TRUTHY";
+    fn scrub_event_paths_with_home_noops_on_empty_home() {
+        let mut event = Event {
+            message: Some("/tmp/x".into()),
+            ..Default::default()
+        };
+        scrub_event_paths_with_home(&mut event, "");
+        scrub_event_paths_with_home(&mut event, "///");
+        assert_eq!(event.message.as_deref(), Some("/tmp/x"));
+    }
+
+    #[test]
+    fn env_flag_from_value_accepts_common_truthy_values() {
         for truthy in ["1", "true", "YES", "On", " true "] {
-            unsafe {
-                std::env::set_var(key, truthy);
-            }
-            assert!(env_flag_enabled(key), "expected truthy for {truthy:?}");
+            assert!(
+                env_flag_from_value(Some(truthy)),
+                "expected truthy for {truthy:?}"
+            );
         }
-        for falsy in ["0", "false", "no", ""] {
-            unsafe {
-                std::env::set_var(key, falsy);
-            }
-            assert!(!env_flag_enabled(key), "expected false for {falsy:?}");
-        }
-        unsafe {
-            std::env::remove_var(key);
-        }
-        assert!(!env_flag_enabled(key));
-    }
-
-    #[test]
-    fn git_sha_prefers_env_then_unknown() {
-        let _lock = env_lock();
-        unsafe {
-            std::env::set_var("AGENTOS_GIT_SHA", "abc1234");
-        }
-        assert_eq!(git_sha(), "abc1234");
-        unsafe {
-            std::env::remove_var("AGENTOS_GIT_SHA");
-        }
-        assert_eq!(git_sha(), "unknown");
-        unsafe {
-            std::env::set_var("AGENTOS_GIT_SHA", "   ");
-        }
-        assert_eq!(git_sha(), "unknown");
-        unsafe {
-            std::env::remove_var("AGENTOS_GIT_SHA");
+        for falsy in [None, Some("0"), Some("false"), Some("no"), Some("")] {
+            assert!(!env_flag_from_value(falsy), "expected false for {falsy:?}");
         }
     }
 
     #[test]
-    fn init_sentry_off_when_flag_unset() {
-        let _lock = env_lock();
-        unsafe {
-            std::env::remove_var("XAI_DISSECT_SENTRY");
-            std::env::set_var("SENTRY_DSN", "https://public@o0.ingest.sentry.io/0");
-        }
-        assert!(init_sentry().is_none());
-        unsafe {
-            std::env::remove_var("SENTRY_DSN");
-        }
+    fn git_sha_from_value_prefers_nonempty_then_unknown() {
+        assert_eq!(git_sha_from_value(Some("abc1234")), "abc1234");
+        assert_eq!(git_sha_from_value(None), "unknown");
+        assert_eq!(git_sha_from_value(Some("   ")), "unknown");
+        assert_eq!(git_sha_from_value(Some("")), "unknown");
     }
 
     #[test]
-    fn init_sentry_off_when_dsn_invalid() {
-        let _lock = env_lock();
-        unsafe {
-            std::env::set_var("XAI_DISSECT_SENTRY", "1");
-            std::env::set_var("SENTRY_DSN", "not-a-dsn");
-        }
-        assert!(init_sentry().is_none());
-        unsafe {
-            std::env::remove_var("XAI_DISSECT_SENTRY");
-            std::env::remove_var("SENTRY_DSN");
-        }
+    fn parse_optional_dsn_rejects_empty_and_invalid() {
+        assert!(parse_optional_dsn(None).is_none());
+        assert!(parse_optional_dsn(Some("")).is_none());
+        assert!(parse_optional_dsn(Some("   ")).is_none());
+        assert!(parse_optional_dsn(Some("not-a-dsn")).is_none());
+        assert!(parse_optional_dsn(Some("https://publickey@o0.ingest.sentry.io/1")).is_some());
     }
 
     #[test]
-    fn init_sentry_off_when_dsn_empty() {
-        let _lock = env_lock();
-        unsafe {
-            std::env::set_var("XAI_DISSECT_SENTRY", "1");
-            std::env::set_var("SENTRY_DSN", "   ");
-        }
-        assert!(init_sentry().is_none());
-        unsafe {
-            std::env::remove_var("XAI_DISSECT_SENTRY");
-            std::env::remove_var("SENTRY_DSN");
-        }
+    fn sentry_opt_in_ready_requires_flag_and_valid_dsn() {
+        let good = "https://publickey@o0.ingest.sentry.io/1";
+        assert!(!sentry_opt_in_ready(None, Some(good)));
+        assert!(!sentry_opt_in_ready(Some("0"), Some(good)));
+        assert!(!sentry_opt_in_ready(Some("1"), None));
+        assert!(!sentry_opt_in_ready(Some("1"), Some("bad")));
+        assert!(!sentry_opt_in_ready(Some("1"), Some("")));
+        assert!(sentry_opt_in_ready(Some("1"), Some(good)));
+        assert!(sentry_opt_in_ready(Some("yes"), Some(good)));
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -216,8 +216,19 @@ pub fn error_category(error: Option<&Error>) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::error_category;
+    use super::{
+        env_flag_enabled, error_category, git_sha, init_sentry, scrub_event_paths, scrub_str,
+    };
     use anyhow::Error;
+    use sentry::protocol::{Event, Exception, LogEntry, Values};
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     fn classify(message: &str) -> &'static str {
         let error = Error::msg(message.to_owned());
@@ -268,5 +279,129 @@ mod tests {
         // Guards the narrowed `"stat "` predicate against false positives
         // such as "statistics" or the `stats` subcommand name.
         assert_eq!(classify("stats subcommand misconfigured"), "unknown_error");
+    }
+
+    #[test]
+    fn scrub_str_replaces_home_prefix() {
+        assert_eq!(
+            scrub_str("/home/dev/ckpt/tensor00000_000", "/home/dev"),
+            "$HOME/ckpt/tensor00000_000"
+        );
+        assert_eq!(scrub_str("no home here", "/home/dev"), "no home here");
+    }
+
+    #[test]
+    fn scrub_event_paths_redacts_message_and_exception() {
+        let _lock = env_lock();
+        // SAFETY: serialized by env_lock; restored below.
+        unsafe {
+            std::env::set_var("HOME", "/home/scrub-test-user");
+        }
+        let mut event = Event {
+            message: Some("/home/scrub-test-user/weights/ckpt".into()),
+            exception: Values {
+                values: vec![Exception {
+                    value: Some("stat /home/scrub-test-user/missing".into()),
+                    ..Default::default()
+                }],
+            },
+            logentry: Some(LogEntry {
+                message: "ok".into(),
+                params: vec![],
+            }),
+            ..Default::default()
+        };
+        scrub_event_paths(&mut event);
+        assert_eq!(event.message.as_deref(), Some("$HOME/weights/ckpt"));
+        assert_eq!(
+            event.exception.values[0].value.as_deref(),
+            Some("stat $HOME/missing")
+        );
+        unsafe {
+            std::env::remove_var("HOME");
+        }
+    }
+
+    #[test]
+    fn env_flag_accepts_common_truthy_values() {
+        let _lock = env_lock();
+        let key = "XAI_DISSECT_TEST_FLAG_TRUTHY";
+        for truthy in ["1", "true", "YES", "On", " true "] {
+            unsafe {
+                std::env::set_var(key, truthy);
+            }
+            assert!(env_flag_enabled(key), "expected truthy for {truthy:?}");
+        }
+        for falsy in ["0", "false", "no", ""] {
+            unsafe {
+                std::env::set_var(key, falsy);
+            }
+            assert!(!env_flag_enabled(key), "expected false for {falsy:?}");
+        }
+        unsafe {
+            std::env::remove_var(key);
+        }
+        assert!(!env_flag_enabled(key));
+    }
+
+    #[test]
+    fn git_sha_prefers_env_then_unknown() {
+        let _lock = env_lock();
+        unsafe {
+            std::env::set_var("AGENTOS_GIT_SHA", "abc1234");
+        }
+        assert_eq!(git_sha(), "abc1234");
+        unsafe {
+            std::env::remove_var("AGENTOS_GIT_SHA");
+        }
+        assert_eq!(git_sha(), "unknown");
+        unsafe {
+            std::env::set_var("AGENTOS_GIT_SHA", "   ");
+        }
+        assert_eq!(git_sha(), "unknown");
+        unsafe {
+            std::env::remove_var("AGENTOS_GIT_SHA");
+        }
+    }
+
+    #[test]
+    fn init_sentry_off_when_flag_unset() {
+        let _lock = env_lock();
+        unsafe {
+            std::env::remove_var("XAI_DISSECT_SENTRY");
+            std::env::set_var("SENTRY_DSN", "https://public@o0.ingest.sentry.io/0");
+        }
+        assert!(init_sentry().is_none());
+        unsafe {
+            std::env::remove_var("SENTRY_DSN");
+        }
+    }
+
+    #[test]
+    fn init_sentry_off_when_dsn_invalid() {
+        let _lock = env_lock();
+        unsafe {
+            std::env::set_var("XAI_DISSECT_SENTRY", "1");
+            std::env::set_var("SENTRY_DSN", "not-a-dsn");
+        }
+        assert!(init_sentry().is_none());
+        unsafe {
+            std::env::remove_var("XAI_DISSECT_SENTRY");
+            std::env::remove_var("SENTRY_DSN");
+        }
+    }
+
+    #[test]
+    fn init_sentry_off_when_dsn_empty() {
+        let _lock = env_lock();
+        unsafe {
+            std::env::set_var("XAI_DISSECT_SENTRY", "1");
+            std::env::set_var("SENTRY_DSN", "   ");
+        }
+        assert!(init_sentry().is_none());
+        unsafe {
+            std::env::remove_var("XAI_DISSECT_SENTRY");
+            std::env::remove_var("SENTRY_DSN");
+        }
     }
 }


### PR DESCRIPTION
## **User description**

## Summary

Fixes the broken **release-observability** job on `main` and finishes opt-in Sentry wiring for real-weight CLI runs under a **dedicated** Sentry project (`limen-neural` / `xai-dissect`), not LiquidCortex or the shared `rust` project.

Also documents the **third** full Grok-1 structural campaign (**run3**) and where those artifacts now live (out of the git tree).

Closes rmems/xai-dissect#49 (opt-in Sentry for real Grok-1 weight CLI runs).

### Code / CI

* Upgrade `sentry` **0.46 → 0.49** (MSRV 1.88); non-exhaustive `ClientOptions` builder; soft-parse DSN (no panic on bad DSN)
* Keep dual-gate: `XAI_DISSECT_SENTRY=1` **and** valid `SENTRY_DSN` (default still off for public clones)
* Fix `scripts/observability/sentry_release.sh` for **sentry-cli 2.46+** (export `SENTRY_ORG` / `SENTRY_PROJECT` instead of illegal global `--org` before the subcommand)
* Require `SENTRY_AUTH_TOKEN` early; allow `SENTRY_PROJECT` fallback for local runs
* Docs: project slugs, US ingest placeholder, local DSN helper path, contexts / Disabled traces wording

### Third campaign (run3) — not committed as blobs

Ran a full structural campaign on the real checkpoint after planning surfaces ([#32](<https://github.com/rmems/xai-dissect/issues/32>)/[#34](<https://github.com/rmems/xai-dissect/issues/34>)/[#36](<https://github.com/rmems/xai-dissect/issues/36>)):

`inventory` → `experts` → `routing-report` → `pilot-plan` → `route-preservation` → `stats` → `saaq-readiness` → `quant-plan`  <br>(`--sample-values 65536` where applicable)

<!-- linear:table-colwidths:400,400 -->
| Gate | Result |
| -- | -- |
| `baseline_profile` | `grok1-map-v1-clean` |
| `validation` | **pass** |
| blocks / tensors / routers / expert_families / unknown | 64 / 770 / 64 / 192 / **0** |
| coverage checksum | same as May run2 (`fnv1a64:de5a1c978121c62c`) |

**Results moved off-repo** so the git tree stays lean:

* Storage: `~/rmems/grok-result/xai-dissect/`
* Pointer: `LATEST_CORRECT_GROK1_RUN` → `grok1_run3_20260802T023050Z`
* Optional local symlink: `xai-dissect/out` → that directory (gitignored)
* In-repo write-up only: `docs/runs/grok1_run3_vs_run2_comparison.md` + `docs/runs/README.md`

Handoff path for grok-ozempic:

`~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/`  <br>(especially `conversion-manifest.json`, `quant-plan.json`)

### Secrets / ops (already set)

* GH secret `SENTRY_PROJECT_XAI_DISSECT=xai-dissect`
* Runtime DSN: machine-local only (`~/.config/xai-dissect/sentry_dsn.env`) — never commit
* Do **not** export LiquidCortex’s DSN as global `SENTRY_DSN` (was routing smokes into LC alerts)

## Version

**No crate version bump** — stays `0.1.0`. This is CI/docs/SDK plumbing, not a packaging release.

Post-merge we can cut a **git tag** when ready for a named release (e.g. roll Unreleased → `0.2.0` or tag `0.1.0` as-is if that is the chosen story).

## Test plan

- [X] `cargo test --locked`
- [X] `cargo fmt --check` / clippy clean locally
- [X] Local `sentry_release.sh` against project `xai-dissect` (release + deploy)
- [X] Opt-in deliberate CLI failure → events in **xai-dissect** (not liquidcortex), `$HOME` scrubbed
- [ ] CI green on this PR (esp. rust-ci; release-observability runs on `main` only after merge)
- [ ] Confirm GH secrets: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG=limen-neural`, `SENTRY_PROJECT_XAI_DISSECT=xai-dissect`

## Attribution

Prepared and implemented with **Grok Build: Grok 4.5** (xAI).

Co-authored-by: Grok [grok@x.ai](<mailto:grok@x.ai>)

---

## **CodeAnt-AI Description**

Harden opt-in Sentry reporting and document the Grok-1 campaign baseline

### What Changed

* Sentry reporting now starts only with an enabled flag and a valid DSN, and invalid configuration safely disables reporting instead of stopping the CLI.
* Release automation now uses the current Sentry CLI configuration, requires authentication up front, matches runtime release names, and avoids creating releases when failures may indicate authentication or project errors.
* Sentry events redact local home-directory paths while clearly documenting that application error chains may still be included; device, OS, and compiler context reporting is documented for enabled runs.
* Added focused tests for opt-in checks, DSN parsing, release fallback, and path redaction.
* Documented the run3 Grok-1 structural baseline, its expanded quantization planning artifacts, and the continued lack of Grok-2 support.

### Impact

`✅ Fewer CLI failures from invalid Sentry settings`  <br>`✅ Safer Sentry release creation`  <br>`✅ Reduced exposure of local filesystem paths`  <br>`✅ Clearer Grok-1 quantization handoff`

<details><summary>💡 Usage Guide</summary>

### Checking Your Pull Request

Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI

Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:

```
@codeant-ai ask: Your question here
```

This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example

```
@codeant-ai ask: Can you suggest a safer alternative to storing this secret?
```

### Preserve Org Learnings with CodeAnt

You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:

```
@codeant-ai: Your feedback here
```

This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example

```
@codeant-ai: Do not flag unused imports.
```

### Retrigger review

Ask CodeAnt AI to review the PR again, by typing:

```
@codeant-ai: review
```

### Check Your Repository Health

To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](<https://app.codeant.ai>). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>