### PR TITLE
docs: bot-review verification gate (gh-30 / iz3.1)

### DIFF
--- a/.beads/PLAN.md
+++ b/.beads/PLAN.md
@@ -220,8 +220,18 @@ while true; do
 done
 
 echo "totals resolved=${RESOLVED_N} unresolved=${UNRESOLVED_N}" >&2
-# Smoke (PR #37): require unresolved==0 before recording 34/0.
-[ "$UNRESOLVED_N" = "0" ] || { echo "unresolved threads remain: ${UNRESOLVED_N}" >&2; exit 1; }
+# Smoke (PR #37): require the documented 34/0 result.
+# Other PRs may have valid unresolved threads (fixed-now).
+if [ "$PR" = "37" ]; then
+  [ "$RESOLVED_N" = "34" ] || {
+    echo "expected 34 resolved threads, got ${RESOLVED_N}" >&2
+    exit 1
+  }
+  [ "$UNRESOLVED_N" = "0" ] || {
+    echo "expected 0 unresolved threads, got ${UNRESOLVED_N}" >&2
+    exit 1
+  }
+fi
 
 # Per thread: proof target is main (squash-merge reply SHAs are not ancestors).
 git show main:<file>

--- a/.beads/PLAN.md
+++ b/.beads/PLAN.md
@@ -1,7 +1,7 @@
 # xai-dissect Beads Plan — Bot Review Backfill Audit (gh-30)
 
 > **Handoff doc for agent/model switches.** Read this + run `bd ready` before starting work.
-> Last updated: 2026-07-31 (gh-33: Codecov + Qodana + optional Sentry; Aikido and New Relic excluded from CI scope)
+> Last updated: 2026-08-14 (iz3.1: GitHub MCP enumeration + `docs/contributing-bot-reviews.md`; CI #33 landed in PR #48 / RM-148 Done)
 
 ## Quick start (any agent)
 
@@ -66,9 +66,9 @@ xai-dissect-iz3 [EPIC P0] Bot review backfill audit — all previous PRs (gh-30)
 
 ## Per-bead acceptance criteria
 
-### iz3.1 — Setup (CURRENT)
-- Document repeatable commands (below) in gh-30 comment or `docs/contributing-bot-reviews.md` stub
-- Confirm GraphQL query returns resolved threads for PR #37 as smoke test
+### iz3.1 — Setup
+- Document repeatable commands in `docs/contributing-bot-reviews.md` and a gh-30 comment
+- Confirm GitHub MCP `get_review_comments` returns resolved threads for PR #37 as smoke test (34 resolved / 0 unresolved on 2026-08-14)
 
 ### iz3.2–iz3.8 — Per-PR audit (same pattern)
 - List all `isResolved=true` inline threads from: macroscopeapp, codacy-production, chatgpt-codex-connector
@@ -97,12 +97,15 @@ xai-dissect-iz3 [EPIC P0] Bot review backfill audit — all previous PRs (gh-30)
 
 ---
 
-## Verification commands (copy-paste)
+## Verification commands
+
+**Prefer GitHub MCP** (`github__pull_request_read` method `get` + `get_review_comments`, `perPage=50`, paginate `after` until `hasNextPage` is false). GraphQL below is fallback only when MCP is unavailable.
 
 ```bash
-# Per PR N:
+# Per PR N (fallback):
 set -euo pipefail
 PR=N
+# Prefer: github__pull_request_read method=get owner=rmems repo=xai-dissect pullNumber=$PR
 gh pr view "$PR" --json mergedAt,mergeCommit,title,state
 
 # Resolved threads only (GraphQL). Fail the loop on API errors (no silent truncate).
@@ -223,7 +226,7 @@ git show main:<file>
 
 | Issue | Title |
 |-------|-------|
-| #33 | ~~CI~~ — **started 2026-07-31** (user priority; not blocked by iz3). Full scope: Codecov + Qodana + optional Sentry; **no Aikido/NR**. |
+| #33 | ~~CI~~ — **done** (PR #48 merged 2026-08-01; Linear RM-148 Done). Codecov + Qodana + optional Sentry; **no Aikido/NR**. |
 | #41 | docs/codebase-map.md |
 | #42 | model-family extension design |
 | #43 | split report/mod.rs |

--- a/.beads/PLAN.md
+++ b/.beads/PLAN.md
@@ -67,14 +67,18 @@ xai-dissect-iz3 [EPIC P0] Bot review backfill audit — all previous PRs (gh-30)
 ## Per-bead acceptance criteria
 
 ### iz3.1 — Setup
+
 - Document repeatable commands in `docs/contributing-bot-reviews.md` and a gh-30 comment
 - Confirm GitHub MCP `get_review_comments` returns resolved threads for PR #37 as smoke test (34 resolved / 0 unresolved on 2026-08-14)
 
 ### iz3.2–iz3.8 — Per-PR audit (same pattern)
-- List all `isResolved=true` inline threads from: macroscopeapp, codacy-production, chatgpt-codex-connector
-- Skip kilo-code-bot if informational-only (no inline suggestion)
+
+Same author/skip policy as `docs/contributing-bot-reviews.md`:
+
+- In-scope first authors: `macroscopeapp`, `chatgpt-codex-connector`, `codacy-production`, `devin-ai-integration`
+- Skip unless they left an inline thread with a concrete suggestion: `kilo-code-bot`, `codeant-ai` conversation summaries, `gemini-code-assist`, `copilot-pull-request-reviewer` with no inline comments, `coderabbitai` conversation-only / rate-limit notes
 - Each thread status: **verified** | **fixed-now** | **deferred-with-rationale**
-- Evidence: `git merge-base --is-ancestor <sha> main` + `git show <sha> -- <file>` + `git show main:<file>`
+- Evidence: `git show main:<file>` is required. After a squash merge, `git merge-base --is-ancestor <reply-sha> main` is expected to fail; do not treat that as a missing fix. Keep **fixed-now** unresolved until the follow-up lands on `main`.
 
 ### iz3.9 — Audit table
 - Single markdown table on gh-30: PR | thread_id | file | bot | status | evidence
@@ -108,9 +112,12 @@ PR=N
 # Prefer: github__pull_request_read method=get owner=rmems repo=xai-dissect pullNumber=$PR
 gh pr view "$PR" --json mergedAt,mergeCommit,title,state
 
-# Resolved threads only (GraphQL). Fail the loop on API errors (no silent truncate).
+# GraphQL fallback. Fail the loop on API errors (no silent truncate).
 # Paginate reviewThreads via $after; each node includes id for the audit table.
+# Count resolved and unresolved so smoke can assert unresolved==0.
 AFTER=""
+RESOLVED_N=0
+UNRESOLVED_N=0
 while true; do
   if [ -n "$AFTER" ]; then AFTER_ARG=(-f after="$AFTER"); else AFTER_ARG=(); fi
   PAGE=$(gh api graphql \
@@ -144,6 +151,13 @@ while true; do
     (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type == "boolean")
   ' >/dev/null \
     || { echo "invalid GraphQL payload for reviewThreads page" >&2; exit 1; }
+
+  # Count both states so the smoke result can assert unresolved==0.
+  PAGE_RES=$(echo "$PAGE" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == true)] | length')
+  PAGE_UNRES=$(echo "$PAGE" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+  RESOLVED_N=$((RESOLVED_N + PAGE_RES))
+  UNRESOLVED_N=$((UNRESOLVED_N + PAGE_UNRES))
+  echo "page resolved=${PAGE_RES} unresolved=${PAGE_UNRES}" >&2
 
   # Emit only resolved threads for the gh-30 audit table.
   echo "$PAGE" | jq -c \
@@ -205,9 +219,11 @@ while true; do
   [ -n "$AFTER" ] || { echo "missing/invalid reviewThreads endCursor" >&2; exit 1; }
 done
 
-# Per thread with cited SHA:
-git merge-base --is-ancestor <sha> main
-git show <sha> -- <file>
+echo "totals resolved=${RESOLVED_N} unresolved=${UNRESOLVED_N}" >&2
+# Smoke (PR #37): require unresolved==0 before recording 34/0.
+[ "$UNRESOLVED_N" = "0" ] || { echo "unresolved threads remain: ${UNRESOLVED_N}" >&2; exit 1; }
+
+# Per thread: proof target is main (squash-merge reply SHAs are not ancestors).
 git show main:<file>
 ```
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ See:
 - [docs/export-contracts.md](docs/export-contracts.md)
 - [docs/tensor-schema.md](docs/tensor-schema.md)
 - [docs/output-conventions.md](docs/output-conventions.md)
+- [Bot review verification](docs/contributing-bot-reviews.md) — do not resolve review threads without `git show` proof
 
 ## Legal / Ethical Scope
 

--- a/docs/contributing-bot-reviews.md
+++ b/docs/contributing-bot-reviews.md
@@ -1,0 +1,49 @@
+# Bot review verification (maintainers / agents)
+
+Resolve a GitHub review thread only after the cited change exists on
+`main` (or on the fix PR that will merge to `main`). `isResolved=true`
+is not evidence.
+
+## Enumerate threads (GitHub MCP)
+
+Use `github__pull_request_read` method `get_review_comments` on
+`rmems/xai-dissect` with `perPage=50`. Paginate with `after` until
+`hasNextPage` is false.
+
+In-scope first authors for this audit:
+
+- `macroscopeapp`
+- `chatgpt-codex-connector`
+- `codacy-production`
+- `devin-ai-integration`
+
+Skip unless they left an inline thread with a concrete suggestion:
+
+- `kilo-code-bot` (conversation summaries)
+- `codeant-ai` conversation “reviewing / finished”
+- `gemini-code-assist`, `copilot-pull-request-reviewer` with no inline comments
+- `coderabbitai` conversation-only / rate-limit notes
+
+## Per-thread proof (required before resolve)
+
+```bash
+# SHA from the "Addressed in <sha>" reply, or the commit that should contain the fix
+git merge-base --is-ancestor <sha> main
+git show <sha> -- <path>
+git show main:<path>
+```
+
+Status vocabulary:
+
+| Status | Meaning |
+| --- | --- |
+| verified | Diff on `main` matches the bot concern |
+| fixed-now | Missing on `main`; landed in `audit/bot-followups` |
+| deferred-with-rationale | Intentional non-fix; rationale already on the thread or recorded |
+
+## Anti-patterns
+
+- Reply “Addressed in …” without a commit that touches `<path>`
+- Paste a truncated or concatenated SHA
+- Resolve at session end without per-thread `git show`
+- Trust `isResolved` on a historical PR

--- a/docs/contributing-bot-reviews.md
+++ b/docs/contributing-bot-reviews.md
@@ -1,8 +1,9 @@
 # Bot review verification (maintainers / agents)
 
-Resolve a GitHub review thread only after the cited change exists on
-`main` (or on the fix PR that will merge to `main`). `isResolved=true`
-is not evidence.
+Resolve a GitHub review thread only after the change is on `main`.
+`isResolved=true` is not evidence. Historical PRs in this repo are usually
+**squash-merged**, so the original review-reply SHA is often *not* an ancestor
+of `main`.
 
 ## Enumerate threads (GitHub MCP)
 
@@ -26,20 +27,32 @@ Skip unless they left an inline thread with a concrete suggestion:
 
 ## Per-thread proof (required before resolve)
 
+**Proof target is always `main`.** For a squash-merged PR, use the merge
+commit on `main` (for example PR #37 → `3b31ebf`), not the pre-squash
+review-reply SHA.
+
 ```bash
-# SHA from the "Addressed in <sha>" reply, or the commit that should contain the fix
-git merge-base --is-ancestor <sha> main
-git show <sha> -- <path>
+# 1) Content on main (required for verified)
 git show main:<path>
+
+# 2) Optional: original review SHA still exists as an object
+git cat-file -t <reply-sha>
+
+# 3) Only if the PR was *not* squashed (merge commit preserves parents)
+git merge-base --is-ancestor <reply-sha> main
 ```
+
+If `git merge-base --is-ancestor <reply-sha> main` fails after a squash,
+that is expected. Do not treat it as a missing fix. Compare `main:<path>`
+to the bot concern instead.
 
 Status vocabulary:
 
-| Status | Meaning |
-| --- | --- |
-| verified | Diff on `main` matches the bot concern |
-| fixed-now | Missing on `main`; landed in `audit/bot-followups` |
-| deferred-with-rationale | Intentional non-fix; rationale already on the thread or recorded |
+| Status | Meaning | Resolve? |
+| --- | --- | --- |
+| verified | Diff on `main` matches the bot concern | yes, after `git show main:<path>` |
+| fixed-now | Gap confirmed; fix committed on `audit/bot-followups` (or this follow-up PR) but **not yet on `main`** | **no** — leave open until the follow-up is merged and `git show main:<path>` proves it |
+| deferred-with-rationale | Intentional non-fix; rationale already on the thread or recorded | yes, with the rationale on the thread |
 
 ## Anti-patterns
 


### PR DESCRIPTION
Refs #30, #40

Linear:
- [RM-151](https://linear.app/rpd-34/issue/RM-151/xai-dissect-gh40-harden-agent-workflow-no-resolve-without-diff-proof) — GH#40 workflow gate (this PR)
- [RM-147](https://linear.app/rpd-34/issue/RM-147/xai-dissect-gh30-audit-bot-review-items-from-previous-prs) — GH#30 parent audit epic

## Summary

Beads **iz3.1** setup for the historical bot-review audit: document the verification gate and switch enumeration to GitHub MCP.

- Add [`docs/contributing-bot-reviews.md`](docs/contributing-bot-reviews.md): MCP `get_review_comments` enumeration, `git show` proof before resolve, status vocabulary (`verified` / `fixed-now` / `deferred-with-rationale`)
- Link it from the README Architecture list
- Update `.beads/PLAN.md`: MCP-first (GraphQL fallback), CI #33 / PR #48 / RM-148 marked done

## GitHub MCP smoke (PR #37)

`pull_request_read` / `get_review_comments`: **34** resolved inline threads, **0** unresolved (`hasNextPage=false`). Devin 19 / Codacy 6 / Codex 5 / Macroscope 4. Conversation-only bots (kilo, CodeAnt, Gemini, Copilot, CodeRabbit) are out of the inline table.

PR #37 was **squash-merged** as `3b31ebf`, so reply SHAs are not ancestors of `main`. Later iz3.2 audit must prove fixes with `git show main:`.

## Non-goals

- No Rust behavior change
- Does not close #30 / #38 (audit table still outstanding)
- Does not `Fixes #40` until the rest of that issue’s AC is checked after merge

## Verification

- `cargo fmt --check`
- `cargo test --locked` (84 tests)

Co-authored-by: Grok 4.6 (medium) <grok@x.ai>
