### PR TITLE
refactor: extract shared CLI helpers from main.rs (#45)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Shared CLI helpers for inventory-backed subcommands.
+//!
+//! Keeps clap flag names, help text, and artifact paths unchanged while
+//! collapsing the repeated resolve → inventory → analyze → write loop.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, bail};
+use clap::Args;
+
+use xai_dissect::experts::build_expert_atlas;
+use xai_dissect::exports::{self, OutputBundle};
+use xai_dissect::inventory::{InventoryConfig, build_inventory};
+use xai_dissect::planning::{
+    build_grok1_pilot_selection_plan, build_grok1_planning_artifacts,
+    build_grok1_route_preservation_report,
+};
+use xai_dissect::report;
+use xai_dissect::routing::build_routing_report;
+use xai_dissect::schema::{
+    ExpertAtlas, ModelInventory, PilotSelectionPlan, QuantPlan, RoutePreservationReport,
+    RoutingReport, SaaqReadinessReport, StatsProfileReport, TensorInfo, TensorKind,
+};
+use xai_dissect::stats::{StatsConfig, build_saaq_readiness_report, build_stats_report};
+
+const FULL_TREE_DIRS: &str = "{reports,exports,manifests}";
+const PLANNING_TREE_DIRS: &str = "{reports,manifests}";
+
+#[derive(Args, Debug, Clone)]
+pub struct OutputTreeArgs {
+    /// If set, also write artifacts into
+    /// `<root>/{reports,exports,manifests}/<checkpoint-slug>/...`.
+    #[arg(long)]
+    pub output_root: Option<PathBuf>,
+    /// Optional override for the checkpoint slug used under the unified
+    /// output tree. If unset, the slug is inferred from the checkpoint path.
+    #[arg(long, requires = "output_root")]
+    pub checkpoint_slug: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CheckpointScanArgs {
+    /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
+    pub path: PathBuf,
+    /// Filename prefix filter.
+    #[arg(long, default_value = "tensor")]
+    pub prefix: String,
+    /// Only process the first N shards (sorted by filename).
+    #[arg(long)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ModelFamilyArg {
+    /// Model family tag written into the export header. Only `grok-1`
+    /// is officially supported today.
+    #[arg(long, default_value = "grok-1")]
+    pub family: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct PlanningFamilyArg {
+    /// Model family tag written into the export header.
+    #[arg(long, default_value = "grok-1")]
+    pub family: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct SampleValuesArg {
+    /// Maximum sampled values per tensor.
+    #[arg(long, default_value_t = 65_536)]
+    pub sample_values: usize,
+}
+
+pub fn run_inventory(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, None)?;
+    print_console_summary(&inv);
+    write_json_and_markdown(
+        &inv,
+        json_out,
+        md_out,
+        "JSON inventory",
+        "Markdown report",
+        report::write_json,
+        report::write_markdown,
+        report::render_markdown,
+    )?;
+    write_output_tree(
+        output_tree,
+        "inventory bundle",
+        FULL_TREE_DIRS,
+        |root, slug| exports::write_inventory_bundle(&inv, root, slug),
+    )
+}
+
+pub fn run_experts(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, None)?;
+    let atlas = build_expert_atlas(&inv);
+    print_expert_console_summary(&atlas);
+    write_json_and_markdown(
+        &atlas,
+        json_out,
+        md_out,
+        "JSON expert atlas",
+        "Markdown expert atlas",
+        report::write_expert_json,
+        report::write_expert_markdown,
+        report::render_expert_markdown,
+    )?;
+    write_output_tree(
+        output_tree,
+        "expert bundle",
+        FULL_TREE_DIRS,
+        |root, slug| exports::write_expert_bundle(&atlas, root, slug),
+    )
+}
+
+pub fn run_routing_report(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, None)?;
+    let report_doc = build_routing_report(&inv);
+    print_routing_console_summary(&report_doc);
+    write_json_and_markdown(
+        &report_doc,
+        json_out,
+        md_out,
+        "JSON routing report",
+        "Markdown routing report",
+        report::write_routing_json,
+        report::write_routing_markdown,
+        report::render_routing_markdown,
+    )?;
+    write_output_tree(
+        output_tree,
+        "routing bundle",
+        FULL_TREE_DIRS,
+        |root, slug| exports::write_routing_bundle(&report_doc, root, slug),
+    )
+}
+
+pub fn run_stats(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    sample_values: usize,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, None)?;
+    let report_doc = build_stats_report(&inv, &stats_config(sample_values))?;
+    print_stats_console_summary(&report_doc);
+    write_json_and_markdown(
+        &report_doc,
+        json_out,
+        md_out,
+        "JSON stats report",
+        "Markdown stats report",
+        report::write_stats_json,
+        report::write_stats_markdown,
+        report::render_stats_markdown,
+    )?;
+    write_output_tree(output_tree, "stats bundle", FULL_TREE_DIRS, |root, slug| {
+        exports::write_stats_bundle(&report_doc, root, slug)
+    })
+}
+
+pub fn run_saaq_readiness(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    sample_values: usize,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    manifest_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, None)?;
+    let stats = build_stats_report(&inv, &stats_config(sample_values))?;
+    let readiness = build_saaq_readiness_report(&inv, &stats);
+    print_saaq_console_summary(&readiness);
+    write_json_and_markdown(
+        &readiness,
+        json_out,
+        md_out,
+        "JSON SAAQ-readiness report",
+        "Markdown SAAQ-readiness report",
+        report::write_saaq_readiness_json,
+        report::write_saaq_readiness_markdown,
+        report::render_saaq_readiness_markdown,
+    )?;
+    write_optional_file(manifest_out, "candidate manifest", |p| {
+        report::write_candidate_manifest_json(&readiness.manifest, p)
+    })?;
+    write_output_tree(output_tree, "saaq bundle", FULL_TREE_DIRS, |root, slug| {
+        exports::write_saaq_bundle(&readiness, root, slug)
+    })
+}
+
+pub fn run_pilot_plan(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, Some("pilot-plan"))?;
+    let plan = build_grok1_pilot_selection_plan(&inv)?;
+    print_pilot_plan_console_summary(&plan);
+    write_json_and_markdown(
+        &plan,
+        json_out,
+        md_out,
+        "JSON pilot selection plan",
+        "Markdown pilot selection plan",
+        report::write_pilot_selection_plan_json,
+        report::write_pilot_selection_plan_markdown,
+        report::render_pilot_selection_plan_markdown,
+    )?;
+    write_output_tree(
+        output_tree,
+        "pilot-plan bundle",
+        PLANNING_TREE_DIRS,
+        |root, slug| exports::write_pilot_plan_bundle(&plan, root, slug),
+    )
+}
+
+pub fn run_route_preservation(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, Some("route-preservation"))?;
+    let report_doc = build_grok1_route_preservation_report(&inv)?;
+    print_route_preservation_console_summary(&report_doc);
+    write_json_and_markdown(
+        &report_doc,
+        json_out,
+        md_out,
+        "JSON route-preservation report",
+        "Markdown route-preservation report",
+        report::write_route_preservation_report_json,
+        report::write_route_preservation_markdown,
+        report::render_route_preservation_markdown,
+    )?;
+    write_output_tree(
+        output_tree,
+        "route-preservation bundle",
+        PLANNING_TREE_DIRS,
+        |root, slug| exports::write_route_preservation_bundle(&report_doc, root, slug),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_quant_plan(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    sample_values: usize,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    conversion_manifest_out: Option<&Path>,
+    conversion_manifest_md_out: Option<&Path>,
+    output_tree: &OutputTreeArgs,
+) -> Result<()> {
+    let inv = run_inventory_command(scan, family, Some("quant-plan"))?;
+    let atlas = build_expert_atlas(&inv);
+    let routing = build_routing_report(&inv);
+    let stats = build_stats_report(&inv, &stats_config(sample_values))?;
+    let readiness = build_saaq_readiness_report(&inv, &stats);
+    let (conversion_manifest, quant_plan) =
+        build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness)?;
+
+    print_quant_plan_console_summary(&quant_plan, &conversion_manifest);
+    write_optional_file(conversion_manifest_out, "conversion manifest", |p| {
+        report::write_conversion_manifest_json(&conversion_manifest, p)
+    })?;
+    write_optional_file(
+        conversion_manifest_md_out,
+        "conversion manifest Markdown",
+        |p| report::write_conversion_manifest_markdown(&conversion_manifest, p),
+    )?;
+    write_json_and_markdown(
+        &quant_plan,
+        json_out,
+        md_out,
+        "JSON quant plan",
+        "Markdown quant plan",
+        report::write_quant_plan_json,
+        report::write_quant_plan_markdown,
+        report::render_quant_plan_markdown,
+    )?;
+    write_output_tree(
+        output_tree,
+        "quant-plan bundle",
+        FULL_TREE_DIRS,
+        |root, slug| {
+            exports::write_quant_plan_bundle(&conversion_manifest, &quant_plan, root, slug)
+        },
+    )
+}
+
+pub(crate) fn validate_complete_inventory_scope(
+    command: &str,
+    prefix: &str,
+    limit: Option<usize>,
+) -> Result<()> {
+    if prefix != "tensor" {
+        bail!(
+            "{command} requires a complete Grok-1 inventory; `--prefix {}` is not supported",
+            prefix
+        );
+    }
+    if let Some(limit) = limit {
+        bail!("{command} requires a complete Grok-1 inventory; `--limit {limit}` is not supported");
+    }
+    Ok(())
+}
+
+fn run_inventory_command(
+    scan: &CheckpointScanArgs,
+    family: &str,
+    complete_command: Option<&str>,
+) -> Result<ModelInventory> {
+    if let Some(command) = complete_command {
+        validate_complete_inventory_scope(command, &scan.prefix, scan.limit)?;
+    }
+    let cfg = InventoryConfig {
+        prefix: scan.prefix.clone(),
+        limit: scan.limit,
+        model_family: family.to_string(),
+    };
+    build_inventory(&scan.path, &cfg)
+}
+
+fn stats_config(sample_values: usize) -> StatsConfig {
+    StatsConfig {
+        max_sample_values: sample_values,
+        ..Default::default()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_json_and_markdown<T>(
+    doc: &T,
+    json_out: Option<&Path>,
+    md_out: Option<&Path>,
+    json_label: &str,
+    md_label: &str,
+    write_json: fn(&T, &Path) -> Result<()>,
+    write_md: fn(&T, &Path) -> Result<()>,
+    render_md: fn(&T) -> String,
+) -> Result<()> {
+    write_optional_file(json_out, json_label, |p| write_json(doc, p))?;
+    if let Some(path) = md_out {
+        write_md(doc, path)?;
+        eprintln!("wrote {md_label} -> {}", path.display());
+    } else {
+        println!();
+        println!("{}", render_md(doc));
+    }
+    Ok(())
+}
+
+fn write_optional_file(
+    path: Option<&Path>,
+    label: &str,
+    write: impl FnOnce(&Path) -> Result<()>,
+) -> Result<()> {
+    if let Some(path) = path {
+        write(path)?;
+        eprintln!("wrote {label} -> {}", path.display());
+    }
+    Ok(())
+}
+
+fn write_output_tree(
+    output_tree: &OutputTreeArgs,
+    label: &str,
+    dirs: &str,
+    write: impl FnOnce(&Path, Option<&str>) -> Result<OutputBundle>,
+) -> Result<()> {
+    if let Some(root) = output_tree.output_root.as_deref() {
+        let bundle = write(root, output_tree.checkpoint_slug.as_deref())?;
+        eprintln!(
+            "wrote {label} -> {}/{dirs}/{}/...",
+            root.display(),
+            bundle.checkpoint_slug
+        );
+    }
+    Ok(())
+}
+
+fn print_quant_plan_console_summary(
+    quant_plan: &QuantPlan,
+    conversion_manifest: &xai_dissect::schema::ConversionManifest,
+) {
+    eprintln!(
+        "checkpoint: {}  baseline: {}  tensors: {}",
+        quant_plan.checkpoint_path.display(),
+        quant_plan.baseline,
+        conversion_manifest.tensors.len(),
+    );
+    eprintln!(
+        "keep_fp32: {}  pilot_quantize: {}  defer: {}",
+        quant_plan.keep_fp32.len(),
+        quant_plan.pilot_quantize.len(),
+        quant_plan.defer.len(),
+    );
+    if !conversion_manifest.warnings.is_empty() {
+        eprintln!(
+            "warn: conversion manifest emitted {} warning categories",
+            conversion_manifest.warnings.len()
+        );
+    }
+}
+
+fn print_pilot_plan_console_summary(plan: &PilotSelectionPlan) {
+    eprintln!(
+        "checkpoint: {}  baseline: {}  selected_blocks: {}  modes: {}",
+        plan.checkpoint_path.display(),
+        plan.baseline,
+        plan.selected_blocks.len(),
+        plan.modes.len(),
+    );
+}
+
+fn print_route_preservation_console_summary(report_doc: &RoutePreservationReport) {
+    eprintln!(
+        "model_family: {}  baseline: {}  router_metrics: {}  block_metrics: {}",
+        report_doc.model_family,
+        report_doc.baseline,
+        report_doc.router_metrics.len(),
+        report_doc.block_metrics.len(),
+    );
+}
+
+fn print_console_summary(inv: &ModelInventory) {
+    eprintln!(
+        "checkpoint: {}  shards: {}  tensors: {}",
+        inv.checkpoint_path.display(),
+        inv.shard_count,
+        inv.totals.tensors,
+    );
+    let hp = &inv.inferred;
+    eprintln!(
+        "inferred:  vocab={:?}  d_model={:?}  n_experts={:?}  d_ff={:?}  n_blocks={:?}",
+        hp.vocab_size, hp.d_model, hp.n_experts, hp.d_ff, hp.n_blocks,
+    );
+
+    let has_embedding = inv
+        .tensors
+        .iter()
+        .any(|t: &TensorInfo| matches!(t.kind, TensorKind::TokenEmbedding));
+    if !has_embedding {
+        eprintln!("warn: no TokenEmbedding tensor classified; hyperparameters may be off");
+    }
+    let unknown = inv
+        .tensors
+        .iter()
+        .filter(|t| matches!(t.kind, TensorKind::Unknown { .. }))
+        .count();
+    if unknown > 0 {
+        eprintln!("warn: {unknown} tensors classified as Unknown");
+    }
+}
+
+fn print_expert_console_summary(atlas: &ExpertAtlas) {
+    eprintln!(
+        "checkpoint: {}  blocks: {}  expected_experts_per_block: {:?}",
+        atlas.checkpoint_path.display(),
+        atlas.relevant_block_count,
+        atlas.expected_experts_per_block,
+    );
+    eprintln!(
+        "naming_checks: {}  anomalies: {}",
+        atlas
+            .naming_checks
+            .iter()
+            .filter(|check| check.passed)
+            .count(),
+        atlas.anomalies.len(),
+    );
+    if !atlas.anomalies.is_empty() {
+        eprintln!(
+            "warn: expert atlas contains {} anomalies",
+            atlas.anomalies.len()
+        );
+    }
+}
+
+fn print_routing_console_summary(report_doc: &RoutingReport) {
+    eprintln!(
+        "checkpoint: {}  routing_blocks: {}  candidates: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.relevant_block_count,
+        report_doc.candidate_tensors.len(),
+    );
+    eprintln!(
+        "expected_experts_per_router: {:?}  critical_blocks: {}  anomalies: {}",
+        report_doc.expected_experts_per_router,
+        report_doc.likely_routing_critical_blocks.len(),
+        report_doc.anomalies.len(),
+    );
+    if !report_doc.anomalies.is_empty() {
+        eprintln!(
+            "warn: routing report contains {} anomalies",
+            report_doc.anomalies.len()
+        );
+    }
+}
+
+fn print_stats_console_summary(report_doc: &StatsProfileReport) {
+    eprintln!(
+        "checkpoint: {}  tensors: {}  layers: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.tensors.len(),
+        report_doc.layers.len(),
+    );
+    eprintln!(
+        "sample_values_per_tensor: {}  mean_rms: {:.6}  mean_variance: {:.6}",
+        report_doc.sampling.max_sample_values,
+        report_doc.norm_summary.mean_rms,
+        report_doc.variance_summary.mean_variance,
+    );
+}
+
+fn print_saaq_console_summary(report_doc: &SaaqReadinessReport) {
+    eprintln!(
+        "checkpoint: {}  candidate_targets: {}  routing_critical: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.candidate_targets.len(),
+        report_doc.routing_critical_tensors.len(),
+    );
+    if let Some(top) = report_doc.candidate_targets.first() {
+        eprintln!(
+            "top_candidate: {}  readiness: {:.3}  risk: {:.3}",
+            top.structural_name, top.readiness_score, top.risk_score,
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,11 +19,16 @@ use xai_dissect::planning::{
 };
 use xai_dissect::report;
 use xai_dissect::routing::build_routing_report;
-use xai_dissect::schema::{
-    ExpertAtlas, ModelInventory, PilotSelectionPlan, QuantPlan, RoutePreservationReport,
-    RoutingReport, SaaqReadinessReport, StatsProfileReport, TensorInfo, TensorKind,
-};
+use xai_dissect::schema::ModelInventory;
 use xai_dissect::stats::{StatsConfig, build_saaq_readiness_report, build_stats_report};
+
+mod summary;
+
+use summary::{
+    print_console_summary, print_expert_console_summary, print_pilot_plan_console_summary,
+    print_quant_plan_console_summary, print_route_preservation_console_summary,
+    print_routing_console_summary, print_saaq_console_summary, print_stats_console_summary,
+};
 
 const FULL_TREE_DIRS: &str = "{reports,exports,manifests}";
 const PLANNING_TREE_DIRS: &str = "{reports,manifests}";
@@ -407,153 +412,4 @@ fn write_output_tree(
         );
     }
     Ok(())
-}
-
-fn print_quant_plan_console_summary(
-    quant_plan: &QuantPlan,
-    conversion_manifest: &xai_dissect::schema::ConversionManifest,
-) {
-    eprintln!(
-        "checkpoint: {}  baseline: {}  tensors: {}",
-        quant_plan.checkpoint_path.display(),
-        quant_plan.baseline,
-        conversion_manifest.tensors.len(),
-    );
-    eprintln!(
-        "keep_fp32: {}  pilot_quantize: {}  defer: {}",
-        quant_plan.keep_fp32.len(),
-        quant_plan.pilot_quantize.len(),
-        quant_plan.defer.len(),
-    );
-    if !conversion_manifest.warnings.is_empty() {
-        eprintln!(
-            "warn: conversion manifest emitted {} warning categories",
-            conversion_manifest.warnings.len()
-        );
-    }
-}
-
-fn print_pilot_plan_console_summary(plan: &PilotSelectionPlan) {
-    eprintln!(
-        "checkpoint: {}  baseline: {}  selected_blocks: {}  modes: {}",
-        plan.checkpoint_path.display(),
-        plan.baseline,
-        plan.selected_blocks.len(),
-        plan.modes.len(),
-    );
-}
-
-fn print_route_preservation_console_summary(report_doc: &RoutePreservationReport) {
-    eprintln!(
-        "model_family: {}  baseline: {}  router_metrics: {}  block_metrics: {}",
-        report_doc.model_family,
-        report_doc.baseline,
-        report_doc.router_metrics.len(),
-        report_doc.block_metrics.len(),
-    );
-}
-
-fn print_console_summary(inv: &ModelInventory) {
-    eprintln!(
-        "checkpoint: {}  shards: {}  tensors: {}",
-        inv.checkpoint_path.display(),
-        inv.shard_count,
-        inv.totals.tensors,
-    );
-    let hp = &inv.inferred;
-    eprintln!(
-        "inferred:  vocab={:?}  d_model={:?}  n_experts={:?}  d_ff={:?}  n_blocks={:?}",
-        hp.vocab_size, hp.d_model, hp.n_experts, hp.d_ff, hp.n_blocks,
-    );
-
-    let has_embedding = inv
-        .tensors
-        .iter()
-        .any(|t: &TensorInfo| matches!(t.kind, TensorKind::TokenEmbedding));
-    if !has_embedding {
-        eprintln!("warn: no TokenEmbedding tensor classified; hyperparameters may be off");
-    }
-    let unknown = inv
-        .tensors
-        .iter()
-        .filter(|t| matches!(t.kind, TensorKind::Unknown { .. }))
-        .count();
-    if unknown > 0 {
-        eprintln!("warn: {unknown} tensors classified as Unknown");
-    }
-}
-
-fn print_expert_console_summary(atlas: &ExpertAtlas) {
-    eprintln!(
-        "checkpoint: {}  blocks: {}  expected_experts_per_block: {:?}",
-        atlas.checkpoint_path.display(),
-        atlas.relevant_block_count,
-        atlas.expected_experts_per_block,
-    );
-    eprintln!(
-        "naming_checks: {}  anomalies: {}",
-        atlas
-            .naming_checks
-            .iter()
-            .filter(|check| check.passed)
-            .count(),
-        atlas.anomalies.len(),
-    );
-    if !atlas.anomalies.is_empty() {
-        eprintln!(
-            "warn: expert atlas contains {} anomalies",
-            atlas.anomalies.len()
-        );
-    }
-}
-
-fn print_routing_console_summary(report_doc: &RoutingReport) {
-    eprintln!(
-        "checkpoint: {}  routing_blocks: {}  candidates: {}",
-        report_doc.checkpoint_path.display(),
-        report_doc.relevant_block_count,
-        report_doc.candidate_tensors.len(),
-    );
-    eprintln!(
-        "expected_experts_per_router: {:?}  critical_blocks: {}  anomalies: {}",
-        report_doc.expected_experts_per_router,
-        report_doc.likely_routing_critical_blocks.len(),
-        report_doc.anomalies.len(),
-    );
-    if !report_doc.anomalies.is_empty() {
-        eprintln!(
-            "warn: routing report contains {} anomalies",
-            report_doc.anomalies.len()
-        );
-    }
-}
-
-fn print_stats_console_summary(report_doc: &StatsProfileReport) {
-    eprintln!(
-        "checkpoint: {}  tensors: {}  layers: {}",
-        report_doc.checkpoint_path.display(),
-        report_doc.tensors.len(),
-        report_doc.layers.len(),
-    );
-    eprintln!(
-        "sample_values_per_tensor: {}  mean_rms: {:.6}  mean_variance: {:.6}",
-        report_doc.sampling.max_sample_values,
-        report_doc.norm_summary.mean_rms,
-        report_doc.variance_summary.mean_variance,
-    );
-}
-
-fn print_saaq_console_summary(report_doc: &SaaqReadinessReport) {
-    eprintln!(
-        "checkpoint: {}  candidate_targets: {}  routing_critical: {}",
-        report_doc.checkpoint_path.display(),
-        report_doc.candidate_targets.len(),
-        report_doc.routing_critical_tensors.len(),
-    );
-    if let Some(top) = report_doc.candidate_targets.first() {
-        eprintln!(
-            "top_candidate: {}  readiness: {:.3}  risk: {:.3}",
-            top.structural_name, top.readiness_score, top.risk_score,
-        );
-    }
 }

--- a/src/cli/summary.rs
+++ b/src/cli/summary.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Console summaries printed after each subcommand.
+//!
+//! Split out of `cli` so the command-dispatch module stays focused on the
+//! resolve -> inventory -> analyze -> write loop. Text is unchanged.
+
+use xai_dissect::schema::{
+    ExpertAtlas, ModelInventory, PilotSelectionPlan, QuantPlan, RoutePreservationReport,
+    RoutingReport, SaaqReadinessReport, StatsProfileReport, TensorInfo, TensorKind,
+};
+
+pub(super) fn print_quant_plan_console_summary(
+    quant_plan: &QuantPlan,
+    conversion_manifest: &xai_dissect::schema::ConversionManifest,
+) {
+    eprintln!(
+        "checkpoint: {}  baseline: {}  tensors: {}",
+        quant_plan.checkpoint_path.display(),
+        quant_plan.baseline,
+        conversion_manifest.tensors.len(),
+    );
+    eprintln!(
+        "keep_fp32: {}  pilot_quantize: {}  defer: {}",
+        quant_plan.keep_fp32.len(),
+        quant_plan.pilot_quantize.len(),
+        quant_plan.defer.len(),
+    );
+    if !conversion_manifest.warnings.is_empty() {
+        eprintln!(
+            "warn: conversion manifest emitted {} warning categories",
+            conversion_manifest.warnings.len()
+        );
+    }
+}
+
+pub(super) fn print_pilot_plan_console_summary(plan: &PilotSelectionPlan) {
+    eprintln!(
+        "checkpoint: {}  baseline: {}  selected_blocks: {}  modes: {}",
+        plan.checkpoint_path.display(),
+        plan.baseline,
+        plan.selected_blocks.len(),
+        plan.modes.len(),
+    );
+}
+
+pub(super) fn print_route_preservation_console_summary(report_doc: &RoutePreservationReport) {
+    eprintln!(
+        "model_family: {}  baseline: {}  router_metrics: {}  block_metrics: {}",
+        report_doc.model_family,
+        report_doc.baseline,
+        report_doc.router_metrics.len(),
+        report_doc.block_metrics.len(),
+    );
+}
+
+pub(super) fn print_console_summary(inv: &ModelInventory) {
+    eprintln!(
+        "checkpoint: {}  shards: {}  tensors: {}",
+        inv.checkpoint_path.display(),
+        inv.shard_count,
+        inv.totals.tensors,
+    );
+    let hp = &inv.inferred;
+    eprintln!(
+        "inferred:  vocab={:?}  d_model={:?}  n_experts={:?}  d_ff={:?}  n_blocks={:?}",
+        hp.vocab_size, hp.d_model, hp.n_experts, hp.d_ff, hp.n_blocks,
+    );
+
+    let has_embedding = inv
+        .tensors
+        .iter()
+        .any(|t: &TensorInfo| matches!(t.kind, TensorKind::TokenEmbedding));
+    if !has_embedding {
+        eprintln!("warn: no TokenEmbedding tensor classified; hyperparameters may be off");
+    }
+    let unknown = inv
+        .tensors
+        .iter()
+        .filter(|t| matches!(t.kind, TensorKind::Unknown { .. }))
+        .count();
+    if unknown > 0 {
+        eprintln!("warn: {unknown} tensors classified as Unknown");
+    }
+}
+
+pub(super) fn print_expert_console_summary(atlas: &ExpertAtlas) {
+    eprintln!(
+        "checkpoint: {}  blocks: {}  expected_experts_per_block: {:?}",
+        atlas.checkpoint_path.display(),
+        atlas.relevant_block_count,
+        atlas.expected_experts_per_block,
+    );
+    eprintln!(
+        "naming_checks: {}  anomalies: {}",
+        atlas
+            .naming_checks
+            .iter()
+            .filter(|check| check.passed)
+            .count(),
+        atlas.anomalies.len(),
+    );
+    if !atlas.anomalies.is_empty() {
+        eprintln!(
+            "warn: expert atlas contains {} anomalies",
+            atlas.anomalies.len()
+        );
+    }
+}
+
+pub(super) fn print_routing_console_summary(report_doc: &RoutingReport) {
+    eprintln!(
+        "checkpoint: {}  routing_blocks: {}  candidates: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.relevant_block_count,
+        report_doc.candidate_tensors.len(),
+    );
+    eprintln!(
+        "expected_experts_per_router: {:?}  critical_blocks: {}  anomalies: {}",
+        report_doc.expected_experts_per_router,
+        report_doc.likely_routing_critical_blocks.len(),
+        report_doc.anomalies.len(),
+    );
+    if !report_doc.anomalies.is_empty() {
+        eprintln!(
+            "warn: routing report contains {} anomalies",
+            report_doc.anomalies.len()
+        );
+    }
+}
+
+pub(super) fn print_stats_console_summary(report_doc: &StatsProfileReport) {
+    eprintln!(
+        "checkpoint: {}  tensors: {}  layers: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.tensors.len(),
+        report_doc.layers.len(),
+    );
+    eprintln!(
+        "sample_values_per_tensor: {}  mean_rms: {:.6}  mean_variance: {:.6}",
+        report_doc.sampling.max_sample_values,
+        report_doc.norm_summary.mean_rms,
+        report_doc.variance_summary.mean_variance,
+    );
+}
+
+pub(super) fn print_saaq_console_summary(report_doc: &SaaqReadinessReport) {
+    eprintln!(
+        "checkpoint: {}  candidate_targets: {}  routing_critical: {}",
+        report_doc.checkpoint_path.display(),
+        report_doc.candidate_targets.len(),
+        report_doc.routing_critical_tensors.len(),
+    );
+    if let Some(top) = report_doc.candidate_targets.first() {
+        eprintln!(
+            "top_candidate: {}  readiness: {:.3}  risk: {:.3}",
+            top.structural_name, top.readiness_score, top.risk_score,
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,26 +30,14 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use comfy_table::{Cell, ContentArrangement, Table, presets::UTF8_FULL};
 
+mod cli;
 mod observability;
 
-use xai_dissect::experts::build_expert_atlas;
-use xai_dissect::exports;
-use xai_dissect::inventory::{InventoryConfig, build_inventory};
+use cli::{CheckpointScanArgs, ModelFamilyArg, OutputTreeArgs, PlanningFamilyArg, SampleValuesArg};
 use xai_dissect::parser;
-use xai_dissect::planning::{
-    build_grok1_pilot_selection_plan, build_grok1_planning_artifacts,
-    build_grok1_route_preservation_report,
-};
-use xai_dissect::report;
-use xai_dissect::routing::build_routing_report;
-use xai_dissect::schema::{
-    ExpertAtlas, ModelInventory, PilotSelectionPlan, RoutePreservationReport, RoutingReport,
-    SaaqReadinessReport, StatsProfileReport, TensorInfo,
-};
-use xai_dissect::stats::{StatsConfig, build_saaq_readiness_report, build_stats_report};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -60,18 +48,6 @@ use xai_dissect::stats::{StatsConfig, build_saaq_readiness_report, build_stats_r
 struct Cli {
     #[command(subcommand)]
     command: Command,
-}
-
-#[derive(Args, Debug, Clone, Default)]
-struct OutputTreeArgs {
-    /// If set, also write artifacts into
-    /// `<root>/{reports,exports,manifests}/<checkpoint-slug>/...`.
-    #[arg(long)]
-    output_root: Option<PathBuf>,
-    /// Optional override for the checkpoint slug used under the unified
-    /// output tree. If unset, the slug is inferred from the checkpoint path.
-    #[arg(long, requires = "output_root")]
-    checkpoint_slug: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -91,18 +67,10 @@ enum Command {
     /// Build a full inventory of a checkpoint directory: parse, classify,
     /// group by block, and optionally export JSON and Markdown.
     Inventory {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header. Only `grok-1`
-        /// is officially supported today.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: ModelFamilyArg,
         /// If set, write the full inventory as pretty JSON to this path.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -117,18 +85,10 @@ enum Command {
     /// expert-stacked tensors, map blocks to expert counts, and optionally
     /// export JSON and Markdown.
     Experts {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header. Only `grok-1`
-        /// is officially supported today.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: ModelFamilyArg,
         /// If set, write the full expert atlas as pretty JSON to this path.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -143,18 +103,10 @@ enum Command {
     /// identify likely router tensors, summarize their geometry, and
     /// optionally export JSON and Markdown.
     RoutingReport {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header. Only `grok-1`
-        /// is officially supported today.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: ModelFamilyArg,
         /// If set, write the full routing report as pretty JSON to this path.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -167,21 +119,12 @@ enum Command {
     },
     /// Profile tensor payload statistics for offline analysis.
     Stats {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header. Only `grok-1`
-        /// is officially supported today.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
-        /// Maximum sampled values per tensor.
-        #[arg(long, default_value_t = 65_536)]
-        sample_values: usize,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: ModelFamilyArg,
+        #[command(flatten)]
+        sample: SampleValuesArg,
         /// If set, write the stats profile as pretty JSON to this path.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -194,21 +137,12 @@ enum Command {
     },
     /// Rank likely SAAQ experiment targets without applying SAAQ itself.
     SaaqReadiness {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header. Only `grok-1`
-        /// is officially supported today.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
-        /// Maximum sampled values per tensor.
-        #[arg(long, default_value_t = 65_536)]
-        sample_values: usize,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: ModelFamilyArg,
+        #[command(flatten)]
+        sample: SampleValuesArg,
         /// If set, write the SAAQ-readiness report as pretty JSON.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -224,17 +158,10 @@ enum Command {
     },
     /// Emit a planning-side Grok-1 pilot selection plan.
     PilotPlan {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: PlanningFamilyArg,
         /// If set, write the pilot-selection plan JSON to this path.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -246,17 +173,10 @@ enum Command {
     },
     /// Emit a planning-side Grok-1 route-preservation gate report.
     RoutePreservation {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: PlanningFamilyArg,
         /// If set, write the route-preservation report JSON to this path.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -268,18 +188,10 @@ enum Command {
     },
     /// Emit deterministic Grok-1 conversion and quant-planning artifacts.
     QuantPlan {
-        /// Checkpoint directory (e.g. `/path/to/grok-1/ckpt-0`).
-        path: PathBuf,
-        /// Filename prefix filter.
-        #[arg(long, default_value = "tensor")]
-        prefix: String,
-        /// Only process the first N shards (sorted by filename).
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Model family tag written into the export header. Only `grok-1`
-        /// is officially supported today.
-        #[arg(long, default_value = "grok-1")]
-        family: String,
+        #[command(flatten)]
+        scan: CheckpointScanArgs,
+        #[command(flatten)]
+        family: ModelFamilyArg,
         /// Maximum sampled values per tensor when computing readiness.
         #[arg(long, default_value_t = 65_536)]
         sample_values: usize,
@@ -332,71 +244,48 @@ impl Command {
                 family: None,
                 sample_values: None,
             },
-            Command::Inventory {
-                limit,
-                prefix,
-                family,
-                ..
-            }
-            | Command::Experts {
-                limit,
-                prefix,
-                family,
-                ..
-            }
-            | Command::RoutingReport {
-                limit,
-                prefix,
-                family,
-                ..
-            } => CommandFields {
-                limit: *limit,
-                prefix: Some(prefix.clone()),
-                family: Some(family.clone()),
+            Command::Inventory { scan, family, .. }
+            | Command::Experts { scan, family, .. }
+            | Command::RoutingReport { scan, family, .. } => CommandFields {
+                limit: scan.limit,
+                prefix: Some(scan.prefix.clone()),
+                family: Some(family.family.clone()),
                 sample_values: None,
             },
             Command::Stats {
-                limit,
-                prefix,
+                scan,
                 family,
-                sample_values,
+                sample,
                 ..
             }
             | Command::SaaqReadiness {
-                limit,
-                prefix,
+                scan,
                 family,
-                sample_values,
-                ..
-            }
-            | Command::QuantPlan {
-                limit,
-                prefix,
-                family,
-                sample_values,
+                sample,
                 ..
             } => CommandFields {
-                limit: *limit,
-                prefix: Some(prefix.clone()),
-                family: Some(family.clone()),
-                sample_values: Some(*sample_values),
+                limit: scan.limit,
+                prefix: Some(scan.prefix.clone()),
+                family: Some(family.family.clone()),
+                sample_values: Some(sample.sample_values),
             },
-            Command::PilotPlan {
-                limit,
-                prefix,
+            Command::PilotPlan { scan, family, .. }
+            | Command::RoutePreservation { scan, family, .. } => CommandFields {
+                limit: scan.limit,
+                prefix: Some(scan.prefix.clone()),
+                family: Some(family.family.clone()),
+                sample_values: None,
+            },
+            Command::QuantPlan {
+                scan,
                 family,
-                ..
-            }
-            | Command::RoutePreservation {
-                limit,
-                prefix,
-                family,
+                sample_values,
                 ..
             } => CommandFields {
-                limit: *limit,
-                prefix: Some(prefix.clone()),
-                family: Some(family.clone()),
-                sample_values: None,
+                limit: scan.limit,
+                prefix: Some(scan.prefix.clone()),
+                family: Some(family.family.clone()),
+                sample_values: Some(*sample_values),
             },
         }
     }
@@ -438,134 +327,104 @@ fn main() -> Result<()> {
             prefix,
         } => run_dissect(&path, limit, &prefix),
         Command::Inventory {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
             json,
             md,
             output_tree,
-        } => run_inventory(
-            &path,
-            &prefix,
-            limit,
-            &family,
+        } => cli::run_inventory(
+            &scan,
+            &family.family,
             json.as_deref(),
             md.as_deref(),
             &output_tree,
         ),
         Command::Experts {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
             json,
             md,
             output_tree,
-        } => run_experts(
-            &path,
-            &prefix,
-            limit,
-            &family,
+        } => cli::run_experts(
+            &scan,
+            &family.family,
             json.as_deref(),
             md.as_deref(),
             &output_tree,
         ),
         Command::RoutingReport {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
             json,
             md,
             output_tree,
-        } => run_routing_report(
-            &path,
-            &prefix,
-            limit,
-            &family,
+        } => cli::run_routing_report(
+            &scan,
+            &family.family,
             json.as_deref(),
             md.as_deref(),
             &output_tree,
         ),
         Command::Stats {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
-            sample_values,
+            sample,
             json,
             md,
             output_tree,
-        } => run_stats(
-            &path,
-            &prefix,
-            limit,
-            &family,
-            sample_values,
+        } => cli::run_stats(
+            &scan,
+            &family.family,
+            sample.sample_values,
             json.as_deref(),
             md.as_deref(),
             &output_tree,
         ),
         Command::SaaqReadiness {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
-            sample_values,
+            sample,
             json,
             md,
             manifest,
             output_tree,
-        } => run_saaq_readiness(
-            &path,
-            &prefix,
-            limit,
-            &family,
-            sample_values,
+        } => cli::run_saaq_readiness(
+            &scan,
+            &family.family,
+            sample.sample_values,
             json.as_deref(),
             md.as_deref(),
             manifest.as_deref(),
             &output_tree,
         ),
         Command::PilotPlan {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
             json,
             md,
             output_tree,
-        } => run_pilot_plan(
-            &path,
-            &prefix,
-            limit,
-            &family,
+        } => cli::run_pilot_plan(
+            &scan,
+            &family.family,
             json.as_deref(),
             md.as_deref(),
             &output_tree,
         ),
         Command::RoutePreservation {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
             json,
             md,
             output_tree,
-        } => run_route_preservation(
-            &path,
-            &prefix,
-            limit,
-            &family,
+        } => cli::run_route_preservation(
+            &scan,
+            &family.family,
             json.as_deref(),
             md.as_deref(),
             &output_tree,
         ),
         Command::QuantPlan {
-            path,
-            prefix,
-            limit,
+            scan,
             family,
             sample_values,
             json,
@@ -573,11 +432,9 @@ fn main() -> Result<()> {
             conversion_manifest,
             conversion_manifest_md,
             output_tree,
-        } => run_quant_plan(
-            &path,
-            &prefix,
-            limit,
-            &family,
+        } => cli::run_quant_plan(
+            &scan,
+            &family.family,
             sample_values,
             json.as_deref(),
             md.as_deref(),
@@ -669,574 +526,9 @@ fn run_dissect(path: &std::path::Path, limit: Option<usize>, prefix: &str) -> Re
     Ok(())
 }
 
-// --- `inventory` -----------------------------------------------------------
-
-fn run_inventory(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-
-    // Always print a compact console summary.
-    print_console_summary(&inv);
-
-    if let Some(p) = json_out {
-        report::write_json(&inv, p)?;
-        eprintln!("wrote JSON inventory -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_markdown(&inv, p)?;
-        eprintln!("wrote Markdown report -> {}", p.display());
-    } else {
-        // If no Markdown file was requested, print the Markdown report to
-        // stdout so `cargo run -- inventory <path>` is useful on its own.
-        println!();
-        println!("{}", report::render_markdown(&inv));
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle =
-            exports::write_inventory_bundle(&inv, root, output_tree.checkpoint_slug.as_deref())?;
-        print_output_bundle("inventory bundle", root, &bundle);
-    }
-
-    Ok(())
-}
-
-// --- `experts` -------------------------------------------------------------
-
-fn run_experts(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let atlas = build_expert_atlas(&inv);
-
-    print_expert_console_summary(&atlas);
-
-    if let Some(p) = json_out {
-        report::write_expert_json(&atlas, p)?;
-        eprintln!("wrote JSON expert atlas -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_expert_markdown(&atlas, p)?;
-        eprintln!("wrote Markdown expert atlas -> {}", p.display());
-    } else {
-        println!();
-        println!("{}", report::render_expert_markdown(&atlas));
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle =
-            exports::write_expert_bundle(&atlas, root, output_tree.checkpoint_slug.as_deref())?;
-        print_output_bundle("expert bundle", root, &bundle);
-    }
-
-    Ok(())
-}
-
-// --- `routing-report` -----------------------------------------------------
-
-fn run_routing_report(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let report_doc = build_routing_report(&inv);
-
-    print_routing_console_summary(&report_doc);
-
-    if let Some(p) = json_out {
-        report::write_routing_json(&report_doc, p)?;
-        eprintln!("wrote JSON routing report -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_routing_markdown(&report_doc, p)?;
-        eprintln!("wrote Markdown routing report -> {}", p.display());
-    } else {
-        println!();
-        println!("{}", report::render_routing_markdown(&report_doc));
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle = exports::write_routing_bundle(
-            &report_doc,
-            root,
-            output_tree.checkpoint_slug.as_deref(),
-        )?;
-        print_output_bundle("routing bundle", root, &bundle);
-    }
-
-    Ok(())
-}
-
-// --- `stats` --------------------------------------------------------------
-
-#[allow(clippy::too_many_arguments)]
-fn run_stats(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    sample_values: usize,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let stats_cfg = StatsConfig {
-        max_sample_values: sample_values,
-        ..Default::default()
-    };
-    let report_doc = build_stats_report(&inv, &stats_cfg)?;
-
-    print_stats_console_summary(&report_doc);
-
-    if let Some(p) = json_out {
-        report::write_stats_json(&report_doc, p)?;
-        eprintln!("wrote JSON stats report -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_stats_markdown(&report_doc, p)?;
-        eprintln!("wrote Markdown stats report -> {}", p.display());
-    } else {
-        println!();
-        println!("{}", report::render_stats_markdown(&report_doc));
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle =
-            exports::write_stats_bundle(&report_doc, root, output_tree.checkpoint_slug.as_deref())?;
-        print_output_bundle("stats bundle", root, &bundle);
-    }
-
-    Ok(())
-}
-
-// --- `saaq-readiness` -----------------------------------------------------
-
-#[allow(clippy::too_many_arguments)]
-fn run_saaq_readiness(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    sample_values: usize,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    manifest_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let stats_cfg = StatsConfig {
-        max_sample_values: sample_values,
-        ..Default::default()
-    };
-    let stats = build_stats_report(&inv, &stats_cfg)?;
-    let readiness = build_saaq_readiness_report(&inv, &stats);
-
-    print_saaq_console_summary(&readiness);
-
-    if let Some(p) = json_out {
-        report::write_saaq_readiness_json(&readiness, p)?;
-        eprintln!("wrote JSON SAAQ-readiness report -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_saaq_readiness_markdown(&readiness, p)?;
-        eprintln!("wrote Markdown SAAQ-readiness report -> {}", p.display());
-    } else {
-        println!();
-        println!("{}", report::render_saaq_readiness_markdown(&readiness));
-    }
-    if let Some(p) = manifest_out {
-        report::write_candidate_manifest_json(&readiness.manifest, p)?;
-        eprintln!("wrote candidate manifest -> {}", p.display());
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle =
-            exports::write_saaq_bundle(&readiness, root, output_tree.checkpoint_slug.as_deref())?;
-        print_output_bundle("saaq bundle", root, &bundle);
-    }
-
-    Ok(())
-}
-
-// --- `pilot-plan` ---------------------------------------------------------
-
-fn run_pilot_plan(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    validate_complete_inventory_scope("pilot-plan", prefix, limit)?;
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let plan = build_grok1_pilot_selection_plan(&inv)?;
-    print_pilot_plan_console_summary(&plan);
-    if let Some(p) = json_out {
-        report::write_pilot_selection_plan_json(&plan, p)?;
-        eprintln!("wrote JSON pilot selection plan -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_pilot_selection_plan_markdown(&plan, p)?;
-        eprintln!("wrote Markdown pilot selection plan -> {}", p.display());
-    } else {
-        println!();
-        println!("{}", report::render_pilot_selection_plan_markdown(&plan));
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle =
-            exports::write_pilot_plan_bundle(&plan, root, output_tree.checkpoint_slug.as_deref())?;
-        eprintln!(
-            "wrote pilot-plan bundle -> {}/{{reports,manifests}}/{}/...",
-            root.display(),
-            bundle.checkpoint_slug
-        );
-    }
-    Ok(())
-}
-
-// --- `route-preservation` --------------------------------------------------
-
-fn run_route_preservation(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    validate_complete_inventory_scope("route-preservation", prefix, limit)?;
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let report_doc = build_grok1_route_preservation_report(&inv)?;
-    print_route_preservation_console_summary(&report_doc);
-    if let Some(p) = json_out {
-        report::write_route_preservation_report_json(&report_doc, p)?;
-        eprintln!("wrote JSON route-preservation report -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_route_preservation_markdown(&report_doc, p)?;
-        eprintln!(
-            "wrote Markdown route-preservation report -> {}",
-            p.display()
-        );
-    } else {
-        println!();
-        println!(
-            "{}",
-            report::render_route_preservation_markdown(&report_doc)
-        );
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle = exports::write_route_preservation_bundle(
-            &report_doc,
-            root,
-            output_tree.checkpoint_slug.as_deref(),
-        )?;
-        eprintln!(
-            "wrote route-preservation bundle -> {}/{{reports,manifests}}/{}/...",
-            root.display(),
-            bundle.checkpoint_slug
-        );
-    }
-    Ok(())
-}
-
-// --- `quant-plan` ---------------------------------------------------------
-
-#[allow(clippy::too_many_arguments)]
-fn run_quant_plan(
-    path: &std::path::Path,
-    prefix: &str,
-    limit: Option<usize>,
-    family: &str,
-    sample_values: usize,
-    json_out: Option<&std::path::Path>,
-    md_out: Option<&std::path::Path>,
-    conversion_manifest_out: Option<&std::path::Path>,
-    conversion_manifest_md_out: Option<&std::path::Path>,
-    output_tree: &OutputTreeArgs,
-) -> Result<()> {
-    validate_complete_inventory_scope("quant-plan", prefix, limit)?;
-    let cfg = InventoryConfig {
-        prefix: prefix.to_string(),
-        limit,
-        model_family: family.to_string(),
-    };
-    let inv = build_inventory(path, &cfg)?;
-    let atlas = build_expert_atlas(&inv);
-    let routing = build_routing_report(&inv);
-    let stats_cfg = StatsConfig {
-        max_sample_values: sample_values,
-        ..Default::default()
-    };
-    let stats = build_stats_report(&inv, &stats_cfg)?;
-    let readiness = build_saaq_readiness_report(&inv, &stats);
-    let (conversion_manifest, quant_plan) =
-        build_grok1_planning_artifacts(&inv, &atlas, &routing, &readiness)?;
-
-    print_quant_plan_console_summary(&quant_plan, &conversion_manifest);
-
-    if let Some(p) = conversion_manifest_out {
-        report::write_conversion_manifest_json(&conversion_manifest, p)?;
-        eprintln!("wrote conversion manifest -> {}", p.display());
-    }
-    if let Some(p) = conversion_manifest_md_out {
-        report::write_conversion_manifest_markdown(&conversion_manifest, p)?;
-        eprintln!("wrote conversion manifest Markdown -> {}", p.display());
-    }
-    if let Some(p) = json_out {
-        report::write_quant_plan_json(&quant_plan, p)?;
-        eprintln!("wrote JSON quant plan -> {}", p.display());
-    }
-    if let Some(p) = md_out {
-        report::write_quant_plan_markdown(&quant_plan, p)?;
-        eprintln!("wrote Markdown quant plan -> {}", p.display());
-    } else {
-        println!();
-        println!("{}", report::render_quant_plan_markdown(&quant_plan));
-    }
-    if let Some(root) = output_tree.output_root.as_deref() {
-        let bundle = exports::write_quant_plan_bundle(
-            &conversion_manifest,
-            &quant_plan,
-            root,
-            output_tree.checkpoint_slug.as_deref(),
-        )?;
-        print_output_bundle("quant-plan bundle", root, &bundle);
-    }
-
-    Ok(())
-}
-
-fn validate_complete_inventory_scope(
-    command: &str,
-    prefix: &str,
-    limit: Option<usize>,
-) -> Result<()> {
-    if prefix != "tensor" {
-        bail!(
-            "{command} requires a complete Grok-1 inventory; `--prefix {}` is not supported",
-            prefix
-        );
-    }
-    if let Some(limit) = limit {
-        bail!("{command} requires a complete Grok-1 inventory; `--limit {limit}` is not supported");
-    }
-    Ok(())
-}
-
-fn print_quant_plan_console_summary(
-    quant_plan: &xai_dissect::schema::QuantPlan,
-    conversion_manifest: &xai_dissect::schema::ConversionManifest,
-) {
-    eprintln!(
-        "checkpoint: {}  baseline: {}  tensors: {}",
-        quant_plan.checkpoint_path.display(),
-        quant_plan.baseline,
-        conversion_manifest.tensors.len(),
-    );
-    eprintln!(
-        "keep_fp32: {}  pilot_quantize: {}  defer: {}",
-        quant_plan.keep_fp32.len(),
-        quant_plan.pilot_quantize.len(),
-        quant_plan.defer.len(),
-    );
-    if !conversion_manifest.warnings.is_empty() {
-        eprintln!(
-            "warn: conversion manifest emitted {} warning categories",
-            conversion_manifest.warnings.len()
-        );
-    }
-}
-
-fn print_pilot_plan_console_summary(plan: &PilotSelectionPlan) {
-    eprintln!(
-        "checkpoint: {}  baseline: {}  selected_blocks: {}  modes: {}",
-        plan.checkpoint_path.display(),
-        plan.baseline,
-        plan.selected_blocks.len(),
-        plan.modes.len(),
-    );
-}
-
-fn print_route_preservation_console_summary(report_doc: &RoutePreservationReport) {
-    eprintln!(
-        "model_family: {}  baseline: {}  router_metrics: {}  block_metrics: {}",
-        report_doc.model_family,
-        report_doc.baseline,
-        report_doc.router_metrics.len(),
-        report_doc.block_metrics.len(),
-    );
-}
-
-fn print_output_bundle(label: &str, root: &std::path::Path, bundle: &exports::OutputBundle) {
-    eprintln!(
-        "wrote {label} -> {}/{{reports,exports,manifests}}/{}/...",
-        root.display(),
-        bundle.checkpoint_slug
-    );
-}
-
-fn print_console_summary(inv: &ModelInventory) {
-    eprintln!(
-        "checkpoint: {}  shards: {}  tensors: {}",
-        inv.checkpoint_path.display(),
-        inv.shard_count,
-        inv.totals.tensors,
-    );
-    let hp = &inv.inferred;
-    eprintln!(
-        "inferred:  vocab={:?}  d_model={:?}  n_experts={:?}  d_ff={:?}  n_blocks={:?}",
-        hp.vocab_size, hp.d_model, hp.n_experts, hp.d_ff, hp.n_blocks,
-    );
-
-    // Warn if the embedding tensor is missing or there are Unknown records.
-    let has_embedding = inv
-        .tensors
-        .iter()
-        .any(|t: &TensorInfo| matches!(t.kind, xai_dissect::schema::TensorKind::TokenEmbedding));
-    if !has_embedding {
-        eprintln!("warn: no TokenEmbedding tensor classified; hyperparameters may be off");
-    }
-    let unknown = inv
-        .tensors
-        .iter()
-        .filter(|t| matches!(t.kind, xai_dissect::schema::TensorKind::Unknown { .. }))
-        .count();
-    if unknown > 0 {
-        eprintln!("warn: {} tensors classified as Unknown", unknown);
-    }
-}
-
-fn print_expert_console_summary(atlas: &ExpertAtlas) {
-    eprintln!(
-        "checkpoint: {}  blocks: {}  expected_experts_per_block: {:?}",
-        atlas.checkpoint_path.display(),
-        atlas.relevant_block_count,
-        atlas.expected_experts_per_block,
-    );
-    eprintln!(
-        "naming_checks: {}  anomalies: {}",
-        atlas
-            .naming_checks
-            .iter()
-            .filter(|check| check.passed)
-            .count(),
-        atlas.anomalies.len(),
-    );
-    if !atlas.anomalies.is_empty() {
-        eprintln!(
-            "warn: expert atlas contains {} anomalies",
-            atlas.anomalies.len()
-        );
-    }
-}
-
-fn print_routing_console_summary(report_doc: &RoutingReport) {
-    eprintln!(
-        "checkpoint: {}  routing_blocks: {}  candidates: {}",
-        report_doc.checkpoint_path.display(),
-        report_doc.relevant_block_count,
-        report_doc.candidate_tensors.len(),
-    );
-    eprintln!(
-        "expected_experts_per_router: {:?}  critical_blocks: {}  anomalies: {}",
-        report_doc.expected_experts_per_router,
-        report_doc.likely_routing_critical_blocks.len(),
-        report_doc.anomalies.len(),
-    );
-    if !report_doc.anomalies.is_empty() {
-        eprintln!(
-            "warn: routing report contains {} anomalies",
-            report_doc.anomalies.len()
-        );
-    }
-}
-
-fn print_stats_console_summary(report_doc: &StatsProfileReport) {
-    eprintln!(
-        "checkpoint: {}  tensors: {}  layers: {}",
-        report_doc.checkpoint_path.display(),
-        report_doc.tensors.len(),
-        report_doc.layers.len(),
-    );
-    eprintln!(
-        "sample_values_per_tensor: {}  mean_rms: {:.6}  mean_variance: {:.6}",
-        report_doc.sampling.max_sample_values,
-        report_doc.norm_summary.mean_rms,
-        report_doc.variance_summary.mean_variance,
-    );
-}
-
-fn print_saaq_console_summary(report_doc: &SaaqReadinessReport) {
-    eprintln!(
-        "checkpoint: {}  candidate_targets: {}  routing_critical: {}",
-        report_doc.checkpoint_path.display(),
-        report_doc.candidate_targets.len(),
-        report_doc.routing_critical_tensors.len(),
-    );
-    if let Some(top) = report_doc.candidate_targets.first() {
-        eprintln!(
-            "top_candidate: {}  readiness: {:.3}  risk: {:.3}",
-            top.structural_name, top.readiness_score, top.risk_score,
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::validate_complete_inventory_scope;
+    use crate::cli::validate_complete_inventory_scope;
 
     #[test]
     fn quant_plan_rejects_non_default_prefix() {


### PR DESCRIPTION
## **User description**
## Summary

`src/main.rs` had ~1250 LOC in which every inventory-backed subcommand
repeated the same shape: resolve paths → load/build inventory → run analyzer →
write json/md/output-tree.

This extracts that loop into `src/cli.rs` as shared helpers (`OutputTreeArgs`
and the per-command run functions), leaving `main.rs` as clap wiring plus
dispatch.

| | before | after |
|---|---|---|
| `src/main.rs` | 1253 LOC | 545 LOC |
| `src/cli.rs` | — | 559 LOC |

Net **−708 LOC in `main.rs`**, against the −200 target in #45.

## Behavior

No intended behavior change. Specifically unchanged:

- clap flag names and help text
- artifact output paths, including the `{reports,exports,manifests}` output-tree layout
- checkpoint-slug inference

## Verification

```
cargo fmt --check                                          # clean
cargo clippy --all-targets --all-features -- -D warnings   # clean
cargo test --locked                                        # 84 passed, 0 failed
```

`tests/cli_help.rs` is the guard on the acceptance criterion "CLI help text and
behavior unchanged" — it asserts the top-level command list and the
output-tree options on each analysis subcommand, and it passes unmodified.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9Nt19YWAsZA7CHoH8abMW

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Extracts the repeated resolve → inventory → analyze → write loop from `src/main.rs` into shared CLI helpers without changing CLI behavior, meeting the −200 LOC target in #45.

- Shared run functions and clap args live in `src/cli/mod.rs`; console summaries moved to `src/cli/summary.rs` so no module exceeds 500 lines per Codacy.
- `main.rs` drops from 1253 to 545 LOC; flag names, help text, `{reports,exports,manifests}` output-tree paths, and checkpoint-slug inference are unchanged, and `tests/cli_help.rs` still passes.
- Review focus is per-command output parity and that `validate_complete_inventory_scope` still guards planning commands.
- No migration; existing CLI invocations keep working.

<sup>Written for commit 232aec51b333d9229945e75b342fafabb4bd13fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/xai-dissect/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Centralize CLI command handling while preserving existing command behavior

### What Changed
- Inventory, expert, routing, statistics, readiness, and planning commands now use shared handling for checkpoint processing and artifact generation
- Existing command options, help text, report formats, output paths, and unified output-tree bundles remain unchanged
- Planning commands continue to reject filtered or partial inventories with clear errors
- Console summaries and output messages remain available for each analysis command

### Impact
`✅ Consistent reports across CLI analysis commands`
`✅ Unchanged command usage and output locations`
`✅ Clear errors for incomplete planning inputs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
